### PR TITLE
chore: post-merge fixes for Material Exchange and SDE sync docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Material Exchange (Config): market-group source now uses direct `eve_sde.ItemType -> ItemGroup` mapping with category allowlist filtering and explicit forced group includes for required groups.
 - Material Exchange (Config): page layout was streamlined (header summary integration, vertical Available/Selected dual-list flow, consistent BUY/SELL color semantics, and normalized header action button sizing).
 - Material Exchange (Sell): multi-character selector was redesigned into a compact selected-character card with integrated dropdown and portrait context.
+- Material Exchange (Sell): multi-character selector rendering was hardened so switch controls remain available even when active-tab metadata is temporarily missing.
 - Material Exchange (Buy/Sell): item rows now use theme-adaptive Bootstrap text colors for better readability in light/dark themes.
+- Material Exchange (Config): market-group search index generation now scopes `ItemType` queries to relevant `group_id` values to reduce cache-miss rebuild cost.
 
 ### Fixed
 
@@ -46,6 +48,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Material Exchange (Config): saving large market-group selections no longer triggers `TooManyFieldsSent` by posting selected IDs as compact CSV payloads.
 - Material Exchange (Buy/Sell): item image resolution now supports blueprint endpoints (`bp`/`bpc`) to avoid invalid icon URL failures on blueprint types.
 - Material Exchange (Config): search/index coverage now correctly includes configured group contexts such as moon-material related entries when available.
+- Material Exchange (Sell): large order forms no longer exceed Django field limits; zero-quantity `qty_*` inputs are excluded from submit payloads to prevent `TooManyFieldsSent`.
+- Material Exchange (Buy/Sell): pressing Enter in search inputs no longer triggers unintended order-form submission.
+- Material Exchange (Sell): fixed a client-side script regression in quantity shortcut handling that could break page interactions.
 
 ### Internal
 
@@ -54,6 +59,56 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Utility refactor: extracted menu badge count computation into dedicated helper (`indy_hub/utils/menu_badge.py`) and reused it across API/task paths.
 - Test coverage: expanded `test_material_exchange_contracts.py` for in-game override scenarios and mismatch detail propagation.
 - Legacy migration note: historical reference to `eveuniverse` remains in `0021_blueprint_table_and_bp_type.py` as a guarded fallback (`LookupError`) for old migration compatibility.
+- Material Exchange (Config): documented ItemCategory/ItemGroup allowlist constants with maintenance guidance for future filtering updates.
+
+### Update
+
+To apply this release safely, use the sequence matching your deployment type.
+
+#### Bare Metal
+
+1. Install SDE backend dependency:
+
+- `pip install git+https://github.com/Solar-Helix-Independent-Transport/django-eveonline-sde.git`
+
+2. Update Indy Hub:
+
+- `pip install --upgrade indy-hub`
+
+3. Apply database migrations:
+
+- `python manage.py migrate`
+
+4. Refresh static assets:
+
+- `python manage.py collectstatic --noinput`
+
+5. Restart the Alliance Auth server/services.
+1. Populate new Indy Hub compatibility tables:
+
+- `python manage.py sync_sde_compat`
+
+#### Docker
+
+1. Install/upgrade dependencies in the application container:
+
+- `docker compose exec allianceauth_gunicorn bash -c "pip install git+https://github.com/Solar-Helix-Independent-Transport/django-eveonline-sde.git && pip install --upgrade indy-hub"`
+
+2. Apply database migrations:
+
+- `docker compose exec allianceauth_gunicorn auth migrate`
+
+3. Refresh static assets:
+
+- `docker compose exec allianceauth_gunicorn auth collectstatic --noinput`
+
+4. Restart Alliance Auth containers:
+
+- `docker compose build && docker compose down && docker compose up -d`
+
+5. Populate new Indy Hub compatibility tables:
+
+- `docker compose exec allianceauth_gunicorn auth sync_sde_compat`
 
 ## [1.14.5] - 2026-02-22
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,15 @@ INSTALLED_APPS = [
     "eve_sde",
     "indy_hub",
 ]
-
-INDY_HUB_SDE_FOLDER = "eve-sde"
 ```
+
+Optional override (only if your extracted SDE folder is not the eve_sde default):
+
+```python
+INDY_HUB_SDE_FOLDER = "/path/to/your/sde-folder"
+```
+
+If omitted, Indy Hub automatically reuses the default folder used by `eve_sde`.
 
 Run migrations and collect static files:
 
@@ -80,10 +86,9 @@ python manage.py migrate
 python manage.py collectstatic --noinput
 ```
 
-Load SDE data and Indy Hub compatibility data:
+Load Indy Hub compatibility data (after completing `eve_sde` data loading as documented in the `django-eveonline-sde` module):
 
 ```text
-python manage.py esde_load_sde
 python manage.py sync_sde_compat
 ```
 
@@ -108,9 +113,15 @@ INSTALLED_APPS = [
     "eve_sde",
     "indy_hub",
 ]
-
-INDY_HUB_SDE_FOLDER = "eve-sde"
 ```
+
+Optional override (only if your extracted SDE folder is not the eve_sde default):
+
+```python
+INDY_HUB_SDE_FOLDER = "/path/to/your/sde-folder"
+```
+
+If omitted, Indy Hub automatically reuses the default folder used by `eve_sde`.
 
 Add to your `conf/requirements.txt` (Always use current versions)
 
@@ -136,11 +147,10 @@ docker compose down
 docker compose up -d
 ```
 
-Load SDE data and Indy Hub compatibility data:
+Load Indy Hub compatibility data (after completing `eve_sde` data loading as documented in the `django-eveonline-sde` module):
 
 ```text
 docker compose exec allianceauth_gunicorn bash
-auth esde_load_sde
 auth sync_sde_compat
 exit
 ```

--- a/indy_hub/management/commands/indy_sde.py
+++ b/indy_hub/management/commands/indy_sde.py
@@ -1,3 +1,6 @@
+# Standard Library
+import os
+
 # Django
 from django.core.management import BaseCommand, call_command
 
@@ -47,12 +50,20 @@ class Command(BaseCommand):
             # Alliance Auth (External Libs)
             from eve_sde.sde_tasks import SDE_FOLDER, download_extract_sde
 
-            self.stdout.write(
-                self.style.NOTICE("[2/3] Downloading latest SDE JSONL files...")
-            )
-            download_extract_sde()
-            sde_folder = SDE_FOLDER
-            downloaded_sde = True
+            if os.path.isdir(SDE_FOLDER):
+                sde_folder = SDE_FOLDER
+                self.stdout.write(
+                    self.style.NOTICE(
+                        f"[2/3] Reusing existing eve_sde folder: {sde_folder}"
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.NOTICE("[2/3] Downloading latest SDE JSONL files...")
+                )
+                download_extract_sde()
+                sde_folder = SDE_FOLDER
+                downloaded_sde = True
         else:
             self.stdout.write(
                 self.style.NOTICE(f"[2/3] Using provided SDE folder: {sde_folder}")

--- a/indy_hub/management/commands/sync_sde_compat.py
+++ b/indy_hub/management/commands/sync_sde_compat.py
@@ -30,7 +30,16 @@ class Command(BaseCommand):
 
         sde_folder = (options.get("sde_folder") or "").strip()
         if not sde_folder:
-            sde_folder = getattr(settings, "INDY_HUB_SDE_FOLDER", "eve-sde")
+            sde_folder = getattr(settings, "INDY_HUB_SDE_FOLDER", "").strip()
+
+        if not sde_folder:
+            try:
+                # Alliance Auth (External Libs)
+                from eve_sde.sde_tasks import SDE_FOLDER
+
+                sde_folder = SDE_FOLDER
+            except Exception:
+                sde_folder = "eve-sde"
 
         if not os.path.isdir(sde_folder):
             raise CommandError(f"SDE folder not found: {sde_folder}")

--- a/indy_hub/tasks/sde_sync.py
+++ b/indy_hub/tasks/sde_sync.py
@@ -21,8 +21,17 @@ logger = get_extension_logger(__name__)
 
 @shared_task(bind=True, base=QueueOnce)
 def sync_sde_compatibility_data(self):
-    sde_folder = getattr(settings, "INDY_HUB_SDE_FOLDER", "eve-sde")
+    sde_folder = getattr(settings, "INDY_HUB_SDE_FOLDER", "").strip()
     downloaded_folder = False
+
+    if not sde_folder:
+        try:
+            # Alliance Auth (External Libs)
+            from eve_sde.sde_tasks import SDE_FOLDER
+
+            sde_folder = SDE_FOLDER
+        except Exception:
+            sde_folder = "eve-sde"
 
     if not os.path.isdir(sde_folder):
         try:


### PR DESCRIPTION
## Description

This PR includes follow-up commits after the previous merge to stabilize Material Exchange UX and align SDE sync behavior/documentation.

### Summary of changes
- Reuses `eve_sde` default SDE folder automatically when available (to avoid unnecessary re-downloads).
- Improves `sync_sde_compat` / `indy_sde` flow to prefer existing SDE data before downloading.
- Updates README installation guidance:
  - clarifies `INDY_HUB_SDE_FOLDER` is optional,
  - removes redundant `esde_load_sde` step from Indy Hub install flow,
  - keeps `sync_sde_compat` as Indy Hub compatibility population step.
- Hardens sell form submission behavior for large item lists and input validation edge cases.

### Motivation / context
After merging the previous PR, additional commits were needed to:
- reduce duplicated SDE downloads,
- prevent confusion in install instructions,
- finalize UX/validation adjustments discovered during post-merge testing.

### Dependencies required
- `django-eveonline-sde` (already required by project)
- `indy-hub`

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
