### PR TITLE
Fix #68: friendly 404 page for missing Material Exchange orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ## [Unreleased]
 
+### Fixed
+
+- Material Exchange: clicking a stale Discord link to a sell or buy order that has been completed, cancelled, or deleted now lands on a friendly "order no longer available" page (HTTP 404) with a button back to the Material Exchange index, instead of Django's raw 404 debug page (`No MaterialExchangeSellOrder matches the given query.`). Honors the `next=` query parameter when present and safe (issue #68).
+
 ## [1.17.0] - 2026-04-26
 
 ### Added

--- a/indy_hub/templates/indy_hub/material_exchange/order_not_found.html
+++ b/indy_hub/templates/indy_hub/material_exchange/order_not_found.html
@@ -1,0 +1,60 @@
+{% extends "indy_hub/base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block page_title %}{% trans "Order Not Found" %}{% endblock page_title %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
+{% endblock extra_css %}
+
+{% block content %}
+<main class="bg-body p-4">
+    <div class="container-fluid my-0 bg-body">
+        <div class="page-header mb-4">
+            <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                <div>
+                    <h2 class="h3 mb-1">
+                        <i class="fas fa-store me-2"></i>
+                        {% trans "Material Exchange" %}
+                    </h2>
+                </div>
+                <div class="d-flex gap-2">
+                    <a href="{% url 'indy_hub:material_exchange_index' %}" class="btn btn-outline-light">
+                        <i class="fas fa-arrow-left me-1"></i>{% trans "Back to Material Exchange" %}
+                    </a>
+                </div>
+            </div>
+            <i class="fas fa-store header-bg"></i>
+        </div>
+
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body text-center py-5">
+                        <i class="fas fa-receipt fa-4x text-muted mb-4"></i>
+                        <h3 class="h4">{% trans "This order is no longer available" %}</h3>
+                        <p class="text-muted mb-4">
+                            {% if order_type == "buy" %}
+                            {% blocktrans with order_id=order_id %}The buy order #{{ order_id }} could not be found. It may have been completed, cancelled, or deleted.{% endblocktrans %}
+                            {% else %}
+                            {% blocktrans with order_id=order_id %}The sell order #{{ order_id }} could not be found. It may have been completed, cancelled, or deleted.{% endblocktrans %}
+                            {% endif %}
+                        </p>
+                        <div class="d-flex justify-content-center gap-2 flex-wrap">
+                            {% if next_url %}
+                            <a href="{{ next_url }}" class="btn btn-primary">
+                                <i class="fas fa-arrow-right me-2"></i>{% trans "Continue" %}
+                            </a>
+                            {% endif %}
+                            <a href="{% url 'indy_hub:material_exchange_index' %}" class="btn btn-outline-secondary">
+                                <i class="fas fa-store me-2"></i>{% trans "Material Exchange" %}
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock content %}

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -719,6 +719,34 @@ class MaterialExchangeContractCheckTests(TestCase):
             response, reverse("indy_hub:buy_order_check_contract", args=[order.id])
         )
 
+    def test_sell_order_detail_missing_renders_friendly_404(self) -> None:
+        response = self.client.get(
+            reverse("indy_hub:sell_order_detail", args=[99999999])
+            + "?next=/indy_hub/material-exchange/"
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertContains(
+            response,
+            "no longer available",
+            status_code=404,
+        )
+        self.assertContains(
+            response,
+            "/indy_hub/material-exchange/",
+            status_code=404,
+        )
+
+    def test_buy_order_detail_missing_renders_friendly_404(self) -> None:
+        response = self.client.get(
+            reverse("indy_hub:buy_order_detail", args=[99999999])
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertContains(
+            response,
+            "no longer available",
+            status_code=404,
+        )
+
 
 class BlueprintModelClassificationTests(TestCase):
     def setUp(self) -> None:

--- a/indy_hub/views/material_exchange_orders.py
+++ b/indy_hub/views/material_exchange_orders.py
@@ -10,6 +10,7 @@ from django.core.paginator import Paginator
 from django.db.models import Count, Q
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
@@ -214,6 +215,36 @@ def my_orders(request):
     return render(request, "indy_hub/material_exchange/my_orders.html", context)
 
 
+def _render_order_not_found(request, *, order_id, order_type: str):
+    """Render a friendly 404 page when a Material Exchange order is missing.
+
+    Used when users follow a stale link (e.g. from a Discord notification) to a
+    sell/buy order that has been completed, cancelled, or deleted. Honors a
+    safe ``next`` query parameter so the user can continue back to where they
+    came from.
+    """
+    next_url = request.GET.get("next") or ""
+    if next_url and not url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        next_url = ""
+
+    context = {
+        "order_id": order_id,
+        "order_type": order_type,
+        "next_url": next_url,
+    }
+    context.update(build_nav_context(request.user, active_tab="material_hub"))
+    return render(
+        request,
+        "indy_hub/material_exchange/order_not_found.html",
+        context,
+        status=404,
+    )
+
+
 @indy_hub_permission_required("can_access_indy_hub")
 @login_required
 def sell_order_detail(request, order_id):
@@ -238,7 +269,7 @@ def sell_order_detail(request, order_id):
             order_id,
             request.user.id,
         )
-        raise
+        return _render_order_not_found(request, order_id=order_id, order_type="sell")
 
     logger.debug(
         "Sell order detail accessed (order_id=%s, user_id=%s)",
@@ -297,7 +328,7 @@ def buy_order_detail(request, order_id):
             order_id,
             request.user.id,
         )
-        raise
+        return _render_order_not_found(request, order_id=order_id, order_type="buy")
 
     logger.debug(
         "Buy order detail accessed (order_id=%s, user_id=%s)",


### PR DESCRIPTION
Closes #68.

## Problem
When a user clicks a Discord notification link pointing to a Material Exchange sell or buy order that has been completed, cancelled, or deleted, Django returns the raw 404 debug page (`No MaterialExchangeSellOrder matches the given query.`) instead of a friendly page.

## Fix
- New template `indy_hub/material_exchange/order_not_found.html` — branded "order no longer available" page with localized sell/buy message.
- `material_exchange_orders.sell_order_detail` and `buy_order_detail` now catch `Http404` and render the new template with `status=404` instead of re-raising.
- Honors a safe `next=` query parameter (validated with `url_has_allowed_host_and_scheme`) and shows a "Continue" button + a "Material Exchange" fallback button.

## Tests
Two new tests in `MaterialExchangeContractCheckTests` covering both sell and buy missing orders. Full class: 7/7 OK.

```
Ran 7 tests in 3.397s
OK
```

## Files
- `indy_hub/templates/indy_hub/material_exchange/order_not_found.html` (new)
- `indy_hub/views/material_exchange_orders.py`
- `indy_hub/tests/test_smoke.py`
- `CHANGELOG.md`