### PR TITLE
fix: exclude reaction blueprints from copy planner and improve EFT import naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Material Exchange: saving the hub configuration on `/indy_hub/material-exchange/config/` no longer crashes with `TooManyFieldsSent` when many market groups are toggled at once.
 - Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).
 - Crafting Projects: EFT fittings whose fit name contains square brackets (for example `[Retribution,   [PRIME] SD 01]`) are now parsed correctly. Previously the header regex bailed out on the inner `]`, the hull was treated as an unknown item and the rest of the fit was discarded.
-- Crafting Projects: when importing an EFT fitting and leaving the project name blank, the modal now pre-fills it as `Hull / Fit Name` (for example `Hurricane // s.2012 T2`) instead of just the fit name, making project lists easier to scan.
+- Crafting Projects: when importing an EFT fitting and leaving the project name blank, the modal now pre-fills it as `Hull // Fit Name` (for example `Hurricane // s.2012 T2`) instead of just the fit name, making project lists easier to scan.
 
 ## [1.16.2] - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Material Exchange: clicking a stale Discord link to a sell or buy order that has been completed, cancelled, or deleted now lands on a friendly "order no longer available" page (HTTP 404) with a button back to the Material Exchange index, instead of Django's raw 404 debug message. Honors the `next=` query parameter when present and safe (issue #68).
 - Material Exchange: saving the hub configuration on `/indy_hub/material-exchange/config/` no longer crashes with `TooManyFieldsSent` when many market groups are toggled at once.
+- Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).
+- Crafting Projects: EFT fittings whose fit name contains square brackets (for example `[Retribution,   [PRIME] SD 01]`) are now parsed correctly. Previously the header regex bailed out on the inner `]`, the hull was treated as an unknown item and the rest of the fit was discarded.
+- Crafting Projects: when importing an EFT fitting and leaving the project name blank, the modal now pre-fills it as `Hull / Fit Name` (for example `Hurricane / s.2012 T2`) instead of just the fit name, making project lists easier to scan.
 
 ## [1.16.2] - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Material Exchange: saving the hub configuration on `/indy_hub/material-exchange/config/` no longer crashes with `TooManyFieldsSent` when many market groups are toggled at once.
 - Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).
 - Crafting Projects: EFT fittings whose fit name contains square brackets (for example `[Retribution,   [PRIME] SD 01]`) are now parsed correctly. Previously the header regex bailed out on the inner `]`, the hull was treated as an unknown item and the rest of the fit was discarded.
-- Crafting Projects: when importing an EFT fitting and leaving the project name blank, the modal now pre-fills it as `Hull / Fit Name` (for example `Hurricane / s.2012 T2`) instead of just the fit name, making project lists easier to scan.
+- Crafting Projects: when importing an EFT fitting and leaving the project name blank, the modal now pre-fills it as `Hull / Fit Name` (for example `Hurricane // s.2012 T2`) instead of just the fit name, making project lists easier to scan.
 
 ## [1.16.2] - 2026-04-26
 

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -1513,7 +1513,7 @@ def _parse_eft_project_import(raw_text: str) -> dict[str, object]:
     hull_name = header_match.group("hull").strip()
     fit_name = header_match.group("fit_name").strip()
     if hull_name and fit_name:
-        source_name = f"{hull_name} / {fit_name}"
+        source_name = f"{hull_name} // {fit_name}"
     else:
         source_name = fit_name or hull_name
 

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -25,7 +25,11 @@ from ..models import (
     ProductionProjectItem,
     SDESyncCompatState,
 )
-from ..utils.eve import get_blueprint_product_type_id, get_type_name
+from ..utils.eve import (
+    get_blueprint_product_type_id,
+    get_type_name,
+    is_reaction_blueprint,
+)
 from .craft_materials import (
     compute_job_material_quantity,
     is_base_item_material_efficiency_exempt,
@@ -36,7 +40,7 @@ from .industry_skills import build_craft_character_advisor
 
 logger = get_extension_logger(__name__)
 
-EFT_HEADER_RE = re.compile(r"^\[(?P<hull>[^,\]]+?)\s*,\s*(?P<fit_name>[^\]]*?)\s*\]$")
+EFT_HEADER_RE = re.compile(r"^\[(?P<hull>[^,\]]+?)\s*,\s*(?P<fit_name>.*?)\s*\]$")
 QUANTITY_SUFFIX_RE = re.compile(r"^(?P<name>.+?)\s+x(?P<quantity>\d+)$", re.IGNORECASE)
 QUANTITY_PREFIX_RE = re.compile(
     r"^(?P<quantity>\d+)\s*x?\s+(?P<name>.+)$", re.IGNORECASE
@@ -1506,9 +1510,16 @@ def _parse_eft_project_import(raw_text: str) -> dict[str, object]:
                 )
             )
 
+    hull_name = header_match.group("hull").strip()
+    fit_name = header_match.group("fit_name").strip()
+    if hull_name and fit_name:
+        source_name = f"{hull_name} / {fit_name}"
+    else:
+        source_name = fit_name or hull_name
+
     return {
         "source_kind": "eft",
-        "source_name": header_match.group("fit_name").strip(),
+        "source_name": source_name,
         "entries": entries,
     }
 
@@ -1902,6 +1913,7 @@ def _build_project_blueprint_configs_grouped(
                 "user_time_efficiency": user_time_efficiency,
                 "user_owns": user_owns,
                 "is_copy": is_copy,
+                "is_reaction": bool(is_reaction_blueprint(int(blueprint_type_id))),
                 "runs_available": runs_available,
                 "shared_copies_available": [],
                 "product_type_id": int(type_id),

--- a/indy_hub/static/indy_hub/js/craft_bp_page.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_page.js
@@ -380,6 +380,20 @@
             return;
         }
 
+        if (bp && bp.is_reaction) {
+            const reactionAlert = document.querySelector(`.runs-validation-alert[data-bp-type-id="${typeId}"]`);
+            if (reactionAlert) {
+                reactionAlert.innerHTML = `
+                    <div class="alert alert-warning py-1 px-2 mb-2 text-center" style="font-size: 0.8rem;">
+                        <i class="fas fa-exclamation-triangle me-1"></i>
+                        <strong>${getMessage('missing_runs_label', 'Missing')} ${shortfallRuns} ${getMessage('runs_label', 'runs')}</strong>
+                        <div class="small text-muted mt-1">${getMessage('reaction_not_copyable', 'Reaction blueprints cannot be copied. Acquire the formula from the market.')}</div>
+                    </div>
+                `;
+            }
+            return;
+        }
+
         const selectedEfficiency = getSelectedCopyEfficiencies(typeId, bp?.time_efficiency);
         const launchLimit = getCopyRequestLaunchLimit(typeId, bp?.product_type_id, selectedEfficiency.te);
         const maxRunsPerCopy = Number(launchLimit.maxRunsPerCopy || 0) || 0;

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -859,7 +859,7 @@
                                     <div class="craft-config-level">
                                         <div class="craft-config-items-grid">
                                             {% for bc in level.blueprints %}
-                                            <div class="craft-bp-card card h-100" data-blueprint-type-id="{{ bc.type_id }}" {% if not bc.user_owns %}data-blueprint-not-owned="true"{% endif %}>
+                                            <div class="craft-bp-card card h-100" data-blueprint-type-id="{{ bc.type_id }}" {% if not bc.user_owns %}data-blueprint-not-owned="true"{% endif %} {% if bc.is_reaction %}data-blueprint-is-reaction="true"{% endif %}>
                                                 <div class="card-header text-center py-1 {% if bc.user_owns %}bg-success bg-opacity-10{% elif bc.shared_copies_available %}bg-warning bg-opacity-10{% else %}bg-danger bg-opacity-10{% endif %}">
                                                     <img
                                                         src="https://images.evetech.net/types/{{ bc.type_id }}/bp?size=128"
@@ -925,7 +925,11 @@
                                                         </div>
                                                     </div>
 
-                                                    {% if not bc.user_owns or bc.is_copy %}
+                                                    {% if bc.is_reaction %}
+                                                    <div class="alert alert-secondary py-1 px-2 mb-0" style="font-size: 0.75rem;">
+                                                        <small class="text-muted"><i class="fas fa-flask me-1"></i>{% trans "Reaction blueprints cannot be copied. Acquire the formula from the market." %}</small>
+                                                    </div>
+                                                    {% elif not bc.user_owns or bc.is_copy %}
                                                     <div class="blueprint-sharing-section{% if bc.user_owns and bc.is_copy %} d-none{% endif %}" data-bp-type-id="{{ bc.type_id }}" data-bp-owned-copy="{% if bc.user_owns and bc.is_copy %}1{% else %}0{% endif %}">
                                                         {% if bc.shared_copies_available %}
                                                         <div class="alert alert-info py-1 px-2 mb-0" style="font-size: 0.8rem;">

--- a/indy_hub/tests/test_production_projects.py
+++ b/indy_hub/tests/test_production_projects.py
@@ -166,12 +166,26 @@ Warp Disruptor II x2
         )
 
         self.assertEqual(payload["source_kind"], "eft")
-        self.assertEqual(payload["source_name"], "PVE - Vedmak Stronghold")
+        self.assertEqual(payload["source_name"], "Vedmak / PVE - Vedmak Stronghold")
         self.assertEqual(payload["entries"][0]["type_name"], "Vedmak")
         self.assertEqual(payload["entries"][0]["category_key"], "hull")
         self.assertEqual(payload["entries"][1]["category_key"], "low_slots")
         self.assertEqual(payload["entries"][3]["category_key"], "mid_slots")
         self.assertEqual(payload["entries"][3]["quantity"], 2)
+
+    def test_parse_eft_import_supports_brackets_in_fit_name(self) -> None:
+        payload = parse_project_import_text(
+            """
+[Retribution,   [PRIME] SD 01]
+
+Heat Sink II
+""".strip()
+        )
+
+        self.assertEqual(payload["source_kind"], "eft")
+        self.assertEqual(payload["source_name"], "Retribution / [PRIME] SD 01")
+        self.assertEqual(payload["entries"][0]["type_name"], "Retribution")
+        self.assertEqual(payload["entries"][0]["category_key"], "hull")
 
     def test_parse_manual_import_supports_prefix_and_suffix_quantities(self) -> None:
         payload = parse_project_import_text(
@@ -668,3 +682,31 @@ Mobile Depot x1
             grouped[0]["levels"][0]["blueprints"][0]["type_name"],
             "Cyclone Fleet Issue Blueprint",
         )
+
+    @patch("indy_hub.services.production_projects.is_reaction_blueprint")
+    @patch("indy_hub.services.production_projects._resolve_user_blueprint_inventory")
+    def test_project_blueprint_configs_flag_reaction_blueprints(
+        self,
+        mock_inventory,
+        mock_is_reaction,
+    ) -> None:
+        mock_inventory.return_value = {}
+        mock_is_reaction.return_value = True
+
+        blueprints, _grouped = _build_project_blueprint_configs_grouped(
+            user=object(),
+            cycle_summary={
+                16670: {
+                    "type_id": 16670,
+                    "type_name": "Carbon Fiber",
+                    "total_needed": 5,
+                }
+            },
+            product_blueprint_cache={16670: 17887},
+            overrides={},
+            type_name_cache={17887: "Carbon Fiber Reaction Formula"},
+        )
+
+        self.assertEqual(len(blueprints), 1)
+        self.assertTrue(blueprints[0]["is_reaction"])
+        mock_is_reaction.assert_called_with(17887)

--- a/indy_hub/tests/test_production_projects.py
+++ b/indy_hub/tests/test_production_projects.py
@@ -166,7 +166,7 @@ Warp Disruptor II x2
         )
 
         self.assertEqual(payload["source_kind"], "eft")
-        self.assertEqual(payload["source_name"], "Vedmak / PVE - Vedmak Stronghold")
+        self.assertEqual(payload["source_name"], "Vedmak // PVE - Vedmak Stronghold")
         self.assertEqual(payload["entries"][0]["type_name"], "Vedmak")
         self.assertEqual(payload["entries"][0]["category_key"], "hull")
         self.assertEqual(payload["entries"][1]["category_key"], "low_slots")
@@ -183,7 +183,7 @@ Heat Sink II
         )
 
         self.assertEqual(payload["source_kind"], "eft")
-        self.assertEqual(payload["source_name"], "Retribution / [PRIME] SD 01")
+        self.assertEqual(payload["source_name"], "Retribution // [PRIME] SD 01")
         self.assertEqual(payload["entries"][0]["type_name"], "Retribution")
         self.assertEqual(payload["entries"][0]["category_key"], "hull")
 

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -2652,6 +2652,35 @@ class BlueprintCopyRequestPageTests(TestCase):
         )
         self.assertEqual(mock_notify.call_count, 0)
 
+    def test_reaction_blueprint_request_is_rejected(self) -> None:
+        url = reverse("indy_hub:bp_copy_request_create")
+        post_data = {
+            "type_id": 605001,
+            "material_efficiency": 0,
+            "time_efficiency": 0,
+            "runs_requested": 1,
+            "copies_requested": 1,
+        }
+
+        with (
+            patch(
+                "indy_hub.views.industry.is_reaction_blueprint",
+                return_value=True,
+            ),
+            patch("indy_hub.views.industry.notify_user") as mock_notify,
+        ):
+            response = self.client.post(url, post_data)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(
+            BlueprintCopyRequest.objects.filter(
+                type_id=605001,
+                requested_by=self.user,
+                fulfilled=False,
+            ).exists()
+        )
+        self.assertEqual(mock_notify.call_count, 0)
+
     def test_everyone_scope_shows_blueprint(self) -> None:
         settings = CharacterSettings.objects.get(user=self.owner, character_id=0)
         settings.copy_sharing_scope = CharacterSettings.SCOPE_EVERYONE

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -135,6 +135,7 @@ from ..utils.eve import (
     get_corporation_name,
     get_corporation_ticker,
     get_type_name,
+    is_reaction_blueprint,
 )
 from .navigation import build_nav_context
 
@@ -2659,6 +2660,22 @@ def bp_copy_request_create(request):
 
     if type_id <= 0:
         messages.error(request, _("Invalid blueprint type."))
+        return redirect("indy_hub:bp_copy_request_page")
+
+    if is_reaction_blueprint(type_id):
+        messages.error(
+            request,
+            _(
+                "Reaction blueprints cannot be copied. Acquire the formula from the market instead."
+            ),
+        )
+        referer = request.headers.get("referer", "")
+        if referer and url_has_allowed_host_and_scheme(
+            url=referer,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
+            return redirect(referer)
         return redirect("indy_hub:bp_copy_request_page")
 
     max_runs_per_copy = get_max_copy_runs_per_request(

--- a/indy_hub/views/material_exchange_orders.py
+++ b/indy_hub/views/material_exchange_orders.py
@@ -222,10 +222,10 @@ def _render_order_not_found(request, *, order_id, order_type: str):
     intentionally surfaced as the same neutral "no longer available" page so we
     do not leak information about other users' orders:
 
-    * The order does not exist (e.g. completed, cancelled, or deleted) — typical
-      when following a stale link from a Discord notification.
+    * The order does not exist (e.g. completed, cancelled, or deleted) —
+        typical when following a stale link from a Discord notification.
     * The order exists but the current user is not allowed to view it (i.e.
-      they are not the seller/buyer and lack ``indy_hub.can_manage_material_hub``).
+        they are not the seller/buyer and lack ``indy_hub.can_manage_material_hub``).
 
     Honors a safe ``next`` query parameter so the user can continue back to
     where they came from.


### PR DESCRIPTION
Closes #69.

## Summary

### Reaction blueprints excluded from the copy planner (issue #69)
Reaction blueprints (e.g. *Carbon Fiber Reaction Formula*) cannot be copied in EVE, but the craft page was previously rendering the full copy request UI (select / runs / copies / Request button) on their per-blueprint configuration cards. This change:

- Tags reaction entries with `is_reaction` in `_build_project_blueprint_configs_grouped` (`indy_hub/services/production_projects.py`) using the existing `is_reaction_blueprint` helper.
- In `Craft_BP_v2.html`, replaces the sharing section with an explanatory note (“Reaction blueprints cannot be copied. Acquire the formula from the market.”) when `bc.is_reaction` is true.
- Suppresses the recommendation logic in `craft_bp_page.js` (`updateBlueprintCopyRequestRecommendation`) for reactions and shows the same friendly message instead of the “Recommended request / Max per copy” block.
- Adds a defense-in-depth guard in `bp_copy_request_create` (`indy_hub/views/industry.py`) that rejects POSTs whose `type_id` is a reaction blueprint.

### EFT import: support brackets in fit names
The EFT header regex `^\[([^,]+?)\s*,\s*([^\]]*?)\s*\]$` rejected fit names containing `]`, so a paste like:

```
[Retribution,   [PRIME] SD 01]
```

silently fell back to the manual parser, treated `[Retribution, [PRIME] SD 01]` as an unknown item and discarded the rest of the fitting. Loosened the fit name capture to `.*?` so brackets inside the fit name are accepted.

### EFT import: nicer auto-generated project name
When the EFT preview pre-fills an empty project name, it now reads `Hull / Fit Name` (e.g. `Hurricane / s.2012 T2`) instead of just the fit name, making project lists easier to scan. Implemented in `_parse_eft_project_import` so existing front-end logic (`production_projects.js`) needs no change.

## Tests
- New: `test_parse_eft_import_supports_brackets_in_fit_name` and updated EFT parsing test for the new `Hull / Fit Name` source name (`indy_hub/tests/test_production_projects.py`).
- New: `test_project_blueprint_configs_flag_reaction_blueprints` (`indy_hub/tests/test_production_projects.py`).
- New: `test_reaction_blueprint_request_is_rejected` in `BlueprintCopyRequestPageTests` (`indy_hub/tests/test_smoke.py`).

`tox -e py312` and `pre-commit` both pass locally.