### PR TITLE
Fix #78: keep Indy Hub dropdown labels visible on mobile

### DIFF
--- a/indy_hub/templates/indy_hub/base.html
+++ b/indy_hub/templates/indy_hub/base.html
@@ -89,7 +89,7 @@
             <div class="nav-item dropdown">
                 <a class="nav-link {{ blueprints_nav_class }} dropdown-toggle" href="#" id="blueprintsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                     <i class="fa-solid fa-copy me-2"></i>
-                    <span class="d-none d-lg-inline">{{ blueprints_tab_title }}</span>
+                    <span class="nav-link-label">{{ blueprints_tab_title }}</span>
                 </a>
                 <ul class="dropdown-menu" aria-labelledby="blueprintsDropdown">
                     <li><a class="dropdown-item" href="{% url 'indy_hub:personnal_bp_list' %}">
@@ -112,7 +112,7 @@
             <div class="nav-item dropdown">
                 <a class="nav-link {{ blueprint_sharing_nav_class }} dropdown-toggle" href="#" id="blueprintSharingDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                     <i class="fa-solid fa-share-nodes me-2"></i>
-                    <span class="d-none d-lg-inline">{{ blueprint_sharing_tab_title }}</span>
+                    <span class="nav-link-label">{{ blueprint_sharing_tab_title }}</span>
                     {% if blueprint_sharing_nav_badge_count %}
                         <span class="badge rounded-pill indy-hub-nav-badge bg-warning-subtle text-warning ms-1" data-nav-badge="blueprint-sharing">{{ blueprint_sharing_nav_badge_count }}</span>
                     {% endif %}
@@ -147,7 +147,7 @@
             <div class="nav-item dropdown">
                 <a class="nav-link {{ industry_nav_class }} dropdown-toggle" href="#" id="industryDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                     <i class="fa-solid fa-industry me-2"></i>
-                    <span class="d-none d-lg-inline">{{ industry_tab_title }}</span>
+                    <span class="nav-link-label">{{ industry_tab_title }}</span>
                 </a>
                 <ul class="dropdown-menu" aria-labelledby="industryDropdown">
                     <li><a class="dropdown-item" href="{% url 'indy_hub:personnal_job_list' %}">


### PR DESCRIPTION
The Blueprints, Blueprint Sharing and Industry top-level menu items hid their text label with 'd-none d-lg-inline', so on viewports narrower than 992px (mobile, including the AllianceAuth mobile view that triggers around 1200px) only the icon remained — making the dropdowns blank. Replaced with 'nav-link-label' to match the other nav-collapse-button entries which already display fine on mobile.

## Description

Please include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for this
change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
