### PR TITLE
Fix craft blueprint ME/TE and stock refresh UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,18 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Crafting Projects / Stock allocations: the Stock tab's *Use* inputs now accept large quantities reliably. Numeric input attributes use raw integers instead of display-formatted values with thousands separators, and allocation changes are batched into a deferred commit after editing; dependent Stock, Needed, Financial and session-state refreshes are then split into separate tasks instead of running inside each keystroke, Enter key event, or animation frame (issue #83).
 
+- Crafting Projects / Blueprint planning: project workspaces now default to the best owned blueprint ME/TE when no saved override exists, so Plan, material requirements, timing and financial calculations no longer fall back to 0/0 for researched blueprints. Legacy single-blueprint projects whose selected item only stores a `blueprint_type_id` also register that final blueprint in the *Blueprints* tab, ensuring final products such as Chimera show their blueprint card alongside every intermediate blueprint used by the project. ME/TE edits made in the *Blueprints* tab now refresh the Plan view immediately when switching tabs, without requiring Save Table plus a full reload (issue #85).
+
+- Crafting Projects / Financial planner: the Margin quick-stat now warns when Buy tab rows have no effective price, while ignoring zero per-output sale inputs when *Total sale price* revenue mode is active because those row prices are intentionally bypassed.
+
+- Crafting Projects: reduced browser console performance warnings on project pages by deferring heavier startup tab initialisation out of the immediate `DOMContentLoaded` handlers and removing the forced-layout read used to restart the missing-price alert animation.
+
+- Crafting Projects / Stock: the Stock tab now lists only required items that have cached character stock available, with a notice explaining that zero-stock lines are hidden.
+
+- Crafting Projects / Stock: opening a saved project now schedules the same Celery character-asset refresh used by Material Hub sell pages when cached data is older than one hour; projects opened within that window reuse the cached snapshot without another ESI assets call.
+
+- Crafting Projects / Stock: when the background character-asset refresh finishes after the project page has already loaded, the Stock tab now shows a reload prompt so users know the cached stock snapshot changed.
+
 - Crafting Projects / Financial planner: the *Buy* tab now supports two revenue modes for projects with one or several final outputs (typical of fits or multi-item production projects). The default *Per-unit sale prices (× qty)* keeps the existing behaviour, summing each row's unit price × quantity. The new *Total sale price (whole project)* mode lets the user enter a single lump-sum revenue for the whole project; per-unit price inputs are visually disabled and the surplus credit is suppressed (the user-declared total is authoritative). Per-row revenue cells distribute the lump sum proportionally to quantity for readability. The selected mode and the override amount are persisted in `workspace_state` and survive reload (issue #71).
 
 ## [1.16.2] - 2026-04-26

--- a/indy_hub/services/asset_cache.py
+++ b/indy_hub/services/asset_cache.py
@@ -1523,12 +1523,16 @@ def get_user_assets_cached(
 
 
 def build_user_asset_inventory_snapshot(
-    user, *, allow_refresh: bool = True, include_blueprints: bool = False
+    user,
+    *,
+    allow_refresh: bool = True,
+    include_blueprints: bool = False,
+    max_age_minutes: int | None = None,
 ) -> dict[str, Any]:
     """Return a craft-friendly summary of cached user assets grouped by item and character."""
 
     assets, assets_scope_missing = get_user_assets_cached(
-        user, allow_refresh=allow_refresh
+        user, allow_refresh=allow_refresh, max_age_minutes=max_age_minutes
     )
     character_names = {
         int(character_id): str(character_name or character_id)

--- a/indy_hub/services/material_exchange_assets.py
+++ b/indy_hub/services/material_exchange_assets.py
@@ -1,0 +1,159 @@
+"""Shared helpers for Material Exchange user asset refresh progress."""
+
+# Django
+from django.core.cache import cache
+from django.utils import timezone
+
+# Alliance Auth
+from allianceauth.services.hooks import get_extension_logger
+
+logger = get_extension_logger(__name__)
+
+SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS = 10 * 60
+SELL_ASSETS_REFRESH_STALE_PROGRESS_SECONDS = 180
+
+
+def material_exchange_sell_assets_progress_key(user_id: int) -> str:
+    return f"indy_hub:material_exchange:sell_assets_refresh:{int(user_id)}"
+
+
+def _default_sell_assets_refresh_state() -> dict:
+    return {
+        "running": False,
+        "finished": False,
+        "error": None,
+        "total": 0,
+        "done": 0,
+        "failed": 0,
+    }
+
+
+def _retry_after_minutes(cooldown_until) -> int:
+    try:
+        retry_seconds = max(0, int(float(cooldown_until) - timezone.now().timestamp()))
+    except (TypeError, ValueError):
+        from ..tasks.material_exchange import ESI_DOWN_COOLDOWN_SECONDS
+
+        retry_seconds = int(ESI_DOWN_COOLDOWN_SECONDS)
+    return int((retry_seconds + 59) // 60)
+
+
+def _mark_stale_progress_if_needed(state: dict, *, progress_key: str) -> dict:
+    if not state.get("running"):
+        return state
+
+    try:
+        started_at = float(state.get("started_at") or 0)
+        last_progress_at = float(state.get("last_progress_at") or started_at or 0)
+        elapsed = timezone.now().timestamp() - last_progress_at
+    except (TypeError, ValueError):
+        elapsed = 0
+    if not state.get("started_at") and not state.get("last_progress_at"):
+        elapsed = 999999
+    if elapsed <= SELL_ASSETS_REFRESH_STALE_PROGRESS_SECONDS:
+        return state
+
+    state.update({"running": False, "finished": True, "error": "timeout"})
+    cache.set(progress_key, state, SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS)
+    return state
+
+
+def get_sell_assets_refresh_progress(user_id: int) -> dict:
+    progress_key = material_exchange_sell_assets_progress_key(int(user_id))
+    state = cache.get(progress_key) or _default_sell_assets_refresh_state()
+    return _mark_stale_progress_if_needed(state, progress_key=progress_key)
+
+
+def ensure_sell_assets_refresh_started(user, *, log_context: str = "asset") -> dict:
+    """Start an async user asset refresh when needed and return progress state."""
+
+    from ..tasks.material_exchange import (
+        me_sell_assets_esi_cooldown_key,
+        refresh_material_exchange_sell_user_assets,
+    )
+
+    user_id = int(user.id)
+    progress_key = material_exchange_sell_assets_progress_key(user_id)
+    state = cache.get(progress_key) or {}
+
+    cooldown_until = cache.get(me_sell_assets_esi_cooldown_key(user_id))
+    if cooldown_until:
+        state = {
+            "running": False,
+            "finished": True,
+            "error": "esi_down",
+            "retry_after_minutes": _retry_after_minutes(cooldown_until),
+        }
+        cache.set(progress_key, state, SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS)
+        return state
+
+    state = _mark_stale_progress_if_needed(state, progress_key=progress_key)
+    if state.get("running"):
+        return state
+
+    try:
+        # Alliance Auth
+        from allianceauth.authentication.models import CharacterOwnership
+        from esi.models import Token
+
+        total = int(
+            CharacterOwnership.objects.filter(user=user)
+            .values_list("character__character_id", flat=True)
+            .distinct()
+            .count()
+        )
+        has_assets_token = (
+            Token.objects.filter(user=user)
+            .require_scopes(["esi-assets.read_assets.v1"])
+            .require_valid()
+            .exists()
+        )
+    except Exception:
+        total = 0
+        has_assets_token = False
+
+    if total > 0 and not has_assets_token:
+        state = {
+            "running": False,
+            "finished": True,
+            "error": "missing_assets_scope",
+            "total": total,
+            "done": 0,
+            "failed": 0,
+        }
+        cache.set(progress_key, state, SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS)
+        return state
+
+    started_at = timezone.now().timestamp()
+    state = {
+        "running": True,
+        "finished": False,
+        "error": None,
+        "total": total,
+        "done": 0,
+        "failed": 0,
+        "started_at": started_at,
+        "last_progress_at": started_at,
+    }
+    cache.set(progress_key, state, SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS)
+
+    try:
+        task_result = refresh_material_exchange_sell_user_assets.delay(user_id)
+        logger.info(
+            "Started %s refresh task for user %s (task_id=%s)",
+            log_context,
+            user_id,
+            task_result.id,
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to start %s refresh task for user %s: %s",
+            log_context,
+            user_id,
+            exc,
+            exc_info=True,
+        )
+        state.update({"running": False, "finished": True, "error": "task_start_failed"})
+        cache.set(progress_key, state, SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS)
+
+    return state

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -913,6 +913,7 @@ def build_project_workspace_payload(
         _extract_workspace_me_te_overrides(workspace_state),
         me_te_overrides,
     )
+    owned_blueprint_inventory_map: dict[int, dict[str, object]] = {}
     owned_blueprint_efficiency_cache: dict[int, dict[str, int]] = {}
 
     def get_owned_blueprint_efficiency(blueprint_type_id: int) -> dict[str, int]:
@@ -922,10 +923,7 @@ def build_project_workspace_payload(
         if numeric_blueprint_type_id in owned_blueprint_efficiency_cache:
             return owned_blueprint_efficiency_cache[numeric_blueprint_type_id]
 
-        user_entry = _resolve_user_blueprint_inventory(
-            user=project.user,
-            blueprint_type_ids=[numeric_blueprint_type_id],
-        ).get(numeric_blueprint_type_id, {})
+        user_entry = owned_blueprint_inventory_map.get(numeric_blueprint_type_id, {})
         owned_entry = user_entry.get("original") or user_entry.get("best_copy") or {}
         owned_blueprint_efficiency_cache[numeric_blueprint_type_id] = (
             {
@@ -1011,6 +1009,7 @@ def build_project_workspace_payload(
 
     blueprint_product_cache: dict[int, dict[str, object] | None] = {}
     blueprint_recipe_cache: dict[tuple[int, int], dict[str, object]] = {}
+    blueprint_material_rows_cache: dict[int, list[tuple[int, str, int]]] = {}
     product_blueprint_cache: dict[int, int | None] = {}
     type_meta_cache: dict[int, tuple[int | None, int | None]] = {}
     type_name_cache_started_at = perf_counter()
@@ -1202,6 +1201,110 @@ def build_project_workspace_payload(
         }
         return blueprint_recipe_cache[cache_key]
 
+    def get_blueprint_material_rows(
+        blueprint_type_id: int,
+    ) -> list[tuple[int, str, int]]:
+        numeric_blueprint_type_id = int(blueprint_type_id or 0)
+        if numeric_blueprint_type_id <= 0:
+            return []
+        if numeric_blueprint_type_id in blueprint_material_rows_cache:
+            return blueprint_material_rows_cache[numeric_blueprint_type_id]
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT m.material_eve_type_id, COALESCE(t.name_en, t.name), m.quantity
+                FROM indy_hub_sdeindustryactivitymaterial m
+                JOIN eve_sde_itemtype t ON t.id = m.material_eve_type_id
+                                WHERE m.eve_type_id = %s
+                                    AND m.activity_id IN (1, 11)
+                                    AND COALESCE(t.published, 0) = 1
+                """,
+                [numeric_blueprint_type_id],
+            )
+            rows = [
+                (
+                    int(material_type_id),
+                    str(material_name or ""),
+                    int(base_quantity or 0),
+                )
+                for material_type_id, material_name, base_quantity in cursor.fetchall()
+            ]
+
+        blueprint_material_rows_cache[numeric_blueprint_type_id] = rows
+        return rows
+
+    def collect_project_blueprint_type_ids() -> set[int]:
+        blueprint_type_ids: set[int] = set()
+
+        def collect_output_blueprints(
+            *,
+            type_id: int | None,
+            blueprint_type_id: int | None,
+            seen: set[int] | None = None,
+        ) -> None:
+            numeric_type_id = int(type_id or 0) if type_id else None
+            numeric_blueprint_type_id = (
+                int(blueprint_type_id or 0) if blueprint_type_id else 0
+            )
+            if numeric_blueprint_type_id > 0 and not get_blueprint_product_row(
+                numeric_blueprint_type_id
+            ):
+                normalized_blueprint_type_id = get_blueprint_for_product(
+                    numeric_type_id or numeric_blueprint_type_id
+                )
+                if normalized_blueprint_type_id:
+                    numeric_blueprint_type_id = int(normalized_blueprint_type_id)
+            if numeric_blueprint_type_id <= 0:
+                return
+
+            current_seen = set(seen or set())
+            if numeric_blueprint_type_id in current_seen:
+                return
+            current_seen.add(numeric_blueprint_type_id)
+            blueprint_type_ids.add(numeric_blueprint_type_id)
+
+            product_row = get_blueprint_product_row(numeric_blueprint_type_id) or {}
+            resolved_product_type_id = int(
+                numeric_type_id or product_row.get("product_type_id") or 0
+            )
+            _remember_project_blueprint_for_product(
+                product_blueprint_cache,
+                resolved_product_type_id,
+                numeric_blueprint_type_id,
+            )
+
+            for (
+                material_type_id,
+                _material_name,
+                _base_quantity,
+            ) in get_blueprint_material_rows(numeric_blueprint_type_id):
+                child_blueprint_type_id = get_blueprint_for_product(material_type_id)
+                collect_output_blueprints(
+                    type_id=material_type_id,
+                    blueprint_type_id=child_blueprint_type_id,
+                    seen=current_seen,
+                )
+
+        for item in selected_items:
+            collect_output_blueprints(
+                type_id=item.type_id,
+                blueprint_type_id=item.blueprint_type_id,
+            )
+
+        return blueprint_type_ids
+
+    blueprint_inventory_started_at = perf_counter()
+    owned_blueprint_inventory_map = _resolve_user_blueprint_inventory(
+        user=project.user,
+        blueprint_type_ids=collect_project_blueprint_type_ids(),
+    )
+    record_timing_step(
+        "blueprint-inventory",
+        "Resolve owned blueprint inventory",
+        blueprint_inventory_started_at,
+    )
+
     def build_project_output_node(
         *,
         type_id: int | None,
@@ -1288,20 +1391,7 @@ def build_project_workspace_payload(
         )
 
         children: list[dict[str, object]] = []
-        with connection.cursor() as cursor:
-            cursor.execute(
-                """
-                SELECT m.material_eve_type_id, COALESCE(t.name_en, t.name), m.quantity
-                FROM indy_hub_sdeindustryactivitymaterial m
-                JOIN eve_sde_itemtype t ON t.id = m.material_eve_type_id
-                                WHERE m.eve_type_id = %s
-                                    AND m.activity_id IN (1, 11)
-                                    AND COALESCE(t.published, 0) = 1
-                """,
-                [numeric_blueprint_type_id],
-            )
-            material_rows = list(cursor.fetchall())
-
+        material_rows = get_blueprint_material_rows(numeric_blueprint_type_id)
         for material_type_id, material_name, base_quantity in material_rows:
             material_type_id = int(material_type_id)
             apply_material_efficiency = material_efficiency_applies(
@@ -1485,6 +1575,7 @@ def build_project_workspace_payload(
             overrides=overrides,
             type_name_cache=type_name_cache,
             market_group_map=market_group_map,
+            user_bp_map=owned_blueprint_inventory_map,
         )
     )
     record_timing_step(
@@ -2076,12 +2167,14 @@ def _build_project_blueprint_configs_grouped(
     overrides: dict[int, dict[str, int]],
     type_name_cache: dict[int, str],
     market_group_map: dict[int, dict[str, object]] | None = None,
+    user_bp_map: dict[int, dict[str, object]] | None = None,
 ) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
     market_group_map = market_group_map or {}
-    user_bp_map = _resolve_user_blueprint_inventory(
-        user=user,
-        blueprint_type_ids=product_blueprint_cache.values(),
-    )
+    if user_bp_map is None:
+        user_bp_map = _resolve_user_blueprint_inventory(
+            user=user,
+            blueprint_type_ids=product_blueprint_cache.values(),
+        )
     blueprints = []
     for type_id, entry in sorted(
         cycle_summary.items(),

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -136,6 +136,68 @@ def _payload_uses_unpublished_blueprints(payload: dict[str, object] | None) -> b
         return cursor.fetchone() is not None
 
 
+def _collect_payload_blueprint_type_ids(payload: dict[str, object] | None) -> set[int]:
+    blueprint_type_ids: set[int] = set()
+    if not isinstance(payload, dict):
+        return blueprint_type_ids
+
+    def collect(nodes: object) -> None:
+        for node in nodes if isinstance(nodes, list) else []:
+            if not isinstance(node, dict):
+                continue
+            blueprint_type_id = int(node.get("blueprint_type_id") or 0)
+            if blueprint_type_id > 0:
+                blueprint_type_ids.add(blueprint_type_id)
+            collect(node.get("sub_materials"))
+
+    collect(payload.get("materials_tree"))
+    for key in ("bp_type_id", "type_id"):
+        try:
+            blueprint_type_id = int(payload.get(key) or 0)
+        except (TypeError, ValueError):
+            blueprint_type_id = 0
+        if blueprint_type_id > 0:
+            blueprint_type_ids.add(blueprint_type_id)
+    return blueprint_type_ids
+
+
+def _cached_payload_includes_blueprint_configs(
+    cached_payload: dict[str, object] | None,
+    workspace_state: dict[str, object] | None,
+) -> bool:
+    if not isinstance(cached_payload, dict):
+        return False
+
+    used_blueprint_type_ids = _collect_payload_blueprint_type_ids(cached_payload)
+    if isinstance(workspace_state, dict):
+        try:
+            workspace_blueprint_type_id = int(
+                workspace_state.get("blueprint_type_id") or 0
+            )
+        except (TypeError, ValueError):
+            workspace_blueprint_type_id = 0
+        if workspace_blueprint_type_id > 0:
+            used_blueprint_type_ids.add(workspace_blueprint_type_id)
+    if not used_blueprint_type_ids:
+        return True
+
+    page = cached_payload.get("page")
+    if not isinstance(page, dict):
+        return True
+    blueprint_configs = page.get("blueprint_configs")
+    configured_blueprint_type_ids: set[int] = set()
+    for config in blueprint_configs if isinstance(blueprint_configs, list) else []:
+        if not isinstance(config, dict):
+            continue
+        try:
+            blueprint_type_id = int(config.get("type_id") or 0)
+        except (TypeError, ValueError):
+            continue
+        if blueprint_type_id > 0:
+            configured_blueprint_type_ids.add(blueprint_type_id)
+    return used_blueprint_type_ids.issubset(configured_blueprint_type_ids)
+
+
 def cached_project_workspace_payload_matches_state(
     cached_payload: dict[str, object] | None,
     workspace_state: dict[str, object] | None,
@@ -145,6 +207,12 @@ def cached_project_workspace_payload_matches_state(
 
     normalized_workspace_state = strip_project_workspace_cache(workspace_state)
     if normalized_workspace_state.get("pendingWorkspaceRefresh"):
+        return False
+
+    if not _cached_payload_includes_blueprint_configs(
+        cached_payload,
+        normalized_workspace_state,
+    ):
         return False
 
     try:
@@ -484,6 +552,94 @@ def parse_project_me_te_overrides(query_params) -> dict[int, dict[str, int]]:
     return overrides
 
 
+def _clamp_blueprint_me(value) -> int:
+    try:
+        return max(0, min(int(value or 0), 10))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _clamp_blueprint_te(value) -> int:
+    try:
+        return max(0, min(int(value or 0), 20))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _extract_workspace_me_te_overrides(
+    workspace_state: dict[str, object] | None,
+) -> dict[int, dict[str, int]]:
+    """Extract saved per-blueprint ME/TE choices from project workspace state."""
+
+    state = workspace_state if isinstance(workspace_state, dict) else {}
+    overrides: dict[int, dict[str, int]] = {}
+    me_te_config = state.get("meTeConfig")
+    if isinstance(me_te_config, dict):
+        blueprint_configs = me_te_config.get("blueprintConfigs")
+        if isinstance(blueprint_configs, dict):
+            for raw_type_id, raw_config in blueprint_configs.items():
+                try:
+                    blueprint_type_id = int(raw_type_id)
+                except (TypeError, ValueError):
+                    continue
+                if blueprint_type_id <= 0 or not isinstance(raw_config, dict):
+                    continue
+                entry: dict[str, int] = {}
+                if "me" in raw_config:
+                    entry["me"] = _clamp_blueprint_me(raw_config.get("me"))
+                if "te" in raw_config:
+                    entry["te"] = _clamp_blueprint_te(raw_config.get("te"))
+                if entry:
+                    overrides[blueprint_type_id] = entry
+        return overrides
+
+    for raw_config in state.get("blueprint_efficiencies") or []:
+        if not isinstance(raw_config, dict):
+            continue
+        try:
+            blueprint_type_id = int(raw_config.get("blueprint_type_id") or 0)
+        except (TypeError, ValueError):
+            continue
+        if blueprint_type_id <= 0:
+            continue
+        me = _clamp_blueprint_me(raw_config.get("material_efficiency"))
+        te = _clamp_blueprint_te(raw_config.get("time_efficiency"))
+        if me or te:
+            overrides[blueprint_type_id] = {"me": me, "te": te}
+    return overrides
+
+
+def _merge_me_te_overrides(
+    *sources: dict[int, dict[str, int]] | None,
+) -> dict[int, dict[str, int]]:
+    merged: dict[int, dict[str, int]] = {}
+    for source in sources:
+        for raw_type_id, raw_config in (source or {}).items():
+            try:
+                blueprint_type_id = int(raw_type_id)
+            except (TypeError, ValueError):
+                continue
+            if blueprint_type_id <= 0 or not isinstance(raw_config, dict):
+                continue
+            entry = merged.setdefault(blueprint_type_id, {})
+            if "me" in raw_config:
+                entry["me"] = _clamp_blueprint_me(raw_config.get("me"))
+            if "te" in raw_config:
+                entry["te"] = _clamp_blueprint_te(raw_config.get("te"))
+    return merged
+
+
+def _remember_project_blueprint_for_product(
+    product_blueprint_cache: dict[int, int | None],
+    product_type_id: int | None,
+    blueprint_type_id: int | None,
+) -> None:
+    numeric_product_type_id = int(product_type_id or 0)
+    numeric_blueprint_type_id = int(blueprint_type_id or 0)
+    if numeric_product_type_id > 0 and numeric_blueprint_type_id > 0:
+        product_blueprint_cache[numeric_product_type_id] = numeric_blueprint_type_id
+
+
 def create_project_from_entries(
     *,
     user,
@@ -742,7 +898,6 @@ def build_project_workspace_payload(
             "steps": workspace_timing_steps,
         }
 
-    overrides = me_te_overrides or {}
     selected_items_started_at = perf_counter()
     selected_items = list(
         project.items.filter(is_selected=True)
@@ -754,6 +909,53 @@ def build_project_workspace_payload(
     )
 
     workspace_state = strip_project_workspace_cache(project.workspace_state)
+    overrides = _merge_me_te_overrides(
+        _extract_workspace_me_te_overrides(workspace_state),
+        me_te_overrides,
+    )
+    owned_blueprint_efficiency_cache: dict[int, dict[str, int]] = {}
+
+    def get_owned_blueprint_efficiency(blueprint_type_id: int) -> dict[str, int]:
+        numeric_blueprint_type_id = int(blueprint_type_id or 0)
+        if numeric_blueprint_type_id <= 0:
+            return {}
+        if numeric_blueprint_type_id in owned_blueprint_efficiency_cache:
+            return owned_blueprint_efficiency_cache[numeric_blueprint_type_id]
+
+        user_entry = _resolve_user_blueprint_inventory(
+            user=project.user,
+            blueprint_type_ids=[numeric_blueprint_type_id],
+        ).get(numeric_blueprint_type_id, {})
+        owned_entry = user_entry.get("original") or user_entry.get("best_copy") or {}
+        owned_blueprint_efficiency_cache[numeric_blueprint_type_id] = (
+            {
+                "me": _clamp_blueprint_me(owned_entry.get("me")),
+                "te": _clamp_blueprint_te(owned_entry.get("te")),
+            }
+            if owned_entry
+            else {}
+        )
+        return owned_blueprint_efficiency_cache[numeric_blueprint_type_id]
+
+    def get_effective_blueprint_efficiency(blueprint_type_id: int) -> dict[str, int]:
+        numeric_blueprint_type_id = int(blueprint_type_id or 0)
+        if numeric_blueprint_type_id <= 0:
+            return {"me": 0, "te": 0}
+        override = overrides.get(numeric_blueprint_type_id) or {}
+        owned_efficiency = get_owned_blueprint_efficiency(numeric_blueprint_type_id)
+        return {
+            "me": (
+                _clamp_blueprint_me(override.get("me"))
+                if "me" in override
+                else _clamp_blueprint_me(owned_efficiency.get("me"))
+            ),
+            "te": (
+                _clamp_blueprint_te(override.get("te"))
+                if "te" in override
+                else _clamp_blueprint_te(owned_efficiency.get("te"))
+            ),
+        }
+
     saved_runs = max(1, int(workspace_state.get("runs") or 1))
     if runs_override is not None:
         try:
@@ -1060,13 +1262,25 @@ def build_project_workspace_payload(
 
         current_seen.add(numeric_blueprint_type_id)
         product_row = get_blueprint_product_row(numeric_blueprint_type_id) or {}
+        resolved_product_type_id = int(
+            numeric_type_id or product_row.get("product_type_id") or 0
+        )
+        resolved_product_type_name = str(
+            product_row.get("product_type_name") or type_name or ""
+        )
+        _remember_project_blueprint_for_product(
+            product_blueprint_cache,
+            resolved_product_type_id,
+            numeric_blueprint_type_id,
+        )
         produced_per_cycle = max(1, int(product_row.get("produced_per_cycle") or 1))
         cycles = max(1, ceil(numeric_quantity / produced_per_cycle))
         total_produced = cycles * produced_per_cycle
         surplus = max(0, total_produced - numeric_quantity)
-        blueprint_me = int(
-            (overrides.get(numeric_blueprint_type_id) or {}).get("me") or 0
+        blueprint_efficiency = get_effective_blueprint_efficiency(
+            numeric_blueprint_type_id
         )
+        blueprint_me = int(blueprint_efficiency.get("me") or 0)
 
         recipe_map.setdefault(
             int(numeric_type_id or product_row.get("product_type_id") or 0),
@@ -1118,8 +1332,10 @@ def build_project_workspace_payload(
             children.append(child_node)
 
         return {
-            "type_id": numeric_type_id or int(product_row.get("product_type_id") or 0),
-            "type_name": type_name or str(product_row.get("product_type_name") or ""),
+            "type_id": resolved_product_type_id,
+            "type_name": (
+                resolved_product_type_name if not numeric_type_id else type_name
+            ),
             "quantity": numeric_quantity,
             "cycles": cycles,
             "produced_per_cycle": produced_per_cycle,
@@ -1326,17 +1542,9 @@ def build_project_workspace_payload(
             int(root_item.quantity_requested or root_node.get("quantity") or 0),
         )
 
-        me_te_config = workspace_state.get("meTeConfig")
-        if not isinstance(me_te_config, dict):
-            me_te_config = {}
-        blueprint_configs_state = me_te_config.get("blueprintConfigs")
-        if not isinstance(blueprint_configs_state, dict):
-            blueprint_configs_state = {}
-        root_me_te = blueprint_configs_state.get(str(root_blueprint_type_id))
-        if not isinstance(root_me_te, dict):
-            root_me_te = {}
-        main_me = int(root_me_te.get("me") or me_te_config.get("mainME") or 0)
-        main_te = int(root_me_te.get("te") or me_te_config.get("mainTE") or 0)
+        root_efficiency = get_effective_blueprint_efficiency(root_blueprint_type_id)
+        main_me = int(root_efficiency.get("me") or 0)
+        main_te = int(root_efficiency.get("te") or 0)
 
         root_children = (
             root_node.get("sub_materials")

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -566,6 +566,29 @@ def _clamp_blueprint_te(value) -> int:
         return 0
 
 
+def _select_best_owned_blueprint_entry(
+    user_entry: dict[str, object],
+) -> tuple[dict[str, object] | None, bool]:
+    candidates: list[tuple[dict[str, object], bool]] = []
+    original = user_entry.get("original")
+    if isinstance(original, dict) and original:
+        candidates.append((original, False))
+    best_copy = user_entry.get("best_copy")
+    if isinstance(best_copy, dict) and best_copy:
+        candidates.append((best_copy, True))
+    if not candidates:
+        return None, False
+
+    return max(
+        candidates,
+        key=lambda candidate: (
+            _clamp_blueprint_me(candidate[0].get("me")),
+            _clamp_blueprint_te(candidate[0].get("te")),
+            0 if candidate[1] else 1,
+        ),
+    )
+
+
 def _extract_workspace_me_te_overrides(
     workspace_state: dict[str, object] | None,
 ) -> dict[int, dict[str, int]]:
@@ -924,7 +947,7 @@ def build_project_workspace_payload(
             return owned_blueprint_efficiency_cache[numeric_blueprint_type_id]
 
         user_entry = owned_blueprint_inventory_map.get(numeric_blueprint_type_id, {})
-        owned_entry = user_entry.get("original") or user_entry.get("best_copy") or {}
+        owned_entry, _is_copy = _select_best_owned_blueprint_entry(user_entry)
         owned_blueprint_efficiency_cache[numeric_blueprint_type_id] = (
             {
                 "me": _clamp_blueprint_me(owned_entry.get("me")),
@@ -2186,18 +2209,19 @@ def _build_project_blueprint_configs_grouped(
         is_reaction = bool(is_reaction_blueprint(int(blueprint_type_id)))
         override = overrides.get(int(blueprint_type_id), {})
         user_entry = user_bp_map.get(int(blueprint_type_id), {})
-        original = user_entry.get("original") or None
-        best_copy = user_entry.get("best_copy") or None
-        user_owns = bool(original or best_copy)
-        is_copy = bool(best_copy) and not bool(original)
+        selected_owned_entry, selected_is_copy = _select_best_owned_blueprint_entry(
+            user_entry
+        )
+        user_owns = bool(selected_owned_entry)
+        is_copy = bool(selected_is_copy)
         runs_available = (
             int(user_entry.get("copy_runs_total") or 0) if is_copy else None
         )
         user_material_efficiency = (
-            int((original or best_copy or {}).get("me") or 0) if user_owns else None
+            int(selected_owned_entry.get("me") or 0) if selected_owned_entry else None
         )
         user_time_efficiency = (
-            int((original or best_copy or {}).get("te") or 0) if user_owns else None
+            int(selected_owned_entry.get("te") or 0) if selected_owned_entry else None
         )
         # Reaction "blueprints" (Reaction Formulas) cannot have non-zero ME/TE
         # and cannot be copied: force ME/TE to 0 (template hides the inputs)

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -2223,6 +2223,44 @@ html[data-theme="darkly"] .craft-header-icon {
     word-break: break-word;
 }
 
+.craft-zero-price-alert {
+    display: inline-flex;
+    align-items: center;
+    margin-top: 0.15rem;
+    padding: 0.1rem 0.35rem;
+    border-radius: 999px;
+    background: rgba(var(--bs-warning-rgb), 0.12);
+    line-height: 1.2;
+}
+
+.craft-zero-price-alert--pulse {
+    animation: craftZeroPriceAlertPulse 2s ease-out;
+}
+
+@keyframes craftZeroPriceAlertPulse {
+    0%, 100% {
+        background: rgba(var(--bs-warning-rgb), 0.12);
+        box-shadow: 0 0 0 rgba(var(--bs-warning-rgb), 0);
+        transform: scale(1);
+    }
+    12%, 42% {
+        background: rgba(var(--bs-warning-rgb), 0.32);
+        box-shadow: 0 0 0 0.25rem rgba(var(--bs-warning-rgb), 0.18);
+        transform: scale(1.04);
+    }
+    26%, 58% {
+        background: rgba(var(--bs-warning-rgb), 0.2);
+        box-shadow: 0 0 0 0.08rem rgba(var(--bs-warning-rgb), 0.08);
+        transform: scale(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .craft-zero-price-alert--pulse {
+        animation: none;
+    }
+}
+
 /* ========== PROGRESS INDICATORS ========== */
 .craft-progress-section {
     background: var(--bs-body-bg);

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -5554,11 +5554,10 @@ function getZeroPricedFinancialRows(revenueMode) {
     return Array.from(document.querySelectorAll('#financialItemsBody tr[data-type-id]'))
         .filter((row) => {
             const isFinalOutput = row.getAttribute('data-final-output') === 'true';
-            if (isFinalOutput && revenueMode === REVENUE_MODE_TOTAL) {
+            if (isFinalOutput) {
                 return false;
             }
-            const priceKind = isFinalOutput ? 'sale' : 'buy';
-            return getFinancialRowEffectiveUnitPrice(row, priceKind) <= 0;
+            return getFinancialRowEffectiveUnitPrice(row, 'buy') <= 0;
         })
         .map(getFinancialRowLabel);
 }

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -6365,12 +6365,11 @@ function renderCraftStockManagement() {
     }
 
     const rows = getCraftSourceRequirementRows();
-    const rowsWithStock = rows
-        .map((item) => ({
-            item,
-            stockSummary: getCraftStockAllocationSummary(item.typeId, item.quantity),
-        }))
-        .filter(({ stockSummary }) => stockSummary.availableQty > 0);
+    const summarizedRows = rows.map((item) => ({
+        item,
+        stockSummary: getCraftStockAllocationSummary(item.typeId, item.quantity),
+    }));
+    const rowsWithStock = summarizedRows.filter(({ stockSummary }) => stockSummary.availableQty > 0);
     const hiddenZeroStockCount = Math.max(0, rows.length - rowsWithStock.length);
     const api = window.SimulationAPI;
     let totalRequiredQty = 0;
@@ -6378,17 +6377,21 @@ function renderCraftStockManagement() {
     let totalRemainingQty = 0;
     let totalStockValue = 0;
 
+    summarizedRows.forEach(({ item, stockSummary }) => {
+        const unitInfo = api && typeof api.getPrice === 'function' ? api.getPrice(item.typeId, 'buy') : { value: 0 };
+        const unitPrice = unitInfo && typeof unitInfo.value === 'number' ? unitInfo.value : 0;
+        totalRequiredQty += stockSummary.requiredQty;
+        totalAllocatedQty += stockSummary.allocatedQty;
+        totalRemainingQty += stockSummary.remainingQty;
+        totalStockValue += unitPrice * stockSummary.allocatedQty;
+    });
+
     const renderedRows = rowsWithStock.map(({ item, stockSummary }) => {
         const maxAllocatable = Math.min(stockSummary.requiredQty, stockSummary.availableQty);
         const unitInfo = api && typeof api.getPrice === 'function' ? api.getPrice(item.typeId, 'buy') : { value: 0 };
         const unitPrice = unitInfo && typeof unitInfo.value === 'number' ? unitInfo.value : 0;
         const stockValue = unitPrice * stockSummary.allocatedQty;
         const remainingValue = unitPrice * stockSummary.remainingQty;
-
-        totalRequiredQty += stockSummary.requiredQty;
-        totalAllocatedQty += stockSummary.allocatedQty;
-        totalRemainingQty += stockSummary.remainingQty;
-        totalStockValue += stockValue;
 
         const characterMarkup = stockSummary.characters.length > 0
             ? stockSummary.characters.map((entry) => `

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -1778,6 +1778,12 @@ function setCraftStockRefreshNotice(state = {}) {
         return;
     }
 
+    if (state.error === 'stock_status_unavailable') {
+        notice.classList.add('alert-warning');
+        notice.textContent = state.message || __('Unable to refresh stock status. Stock uses the latest cached asset snapshot.');
+        return;
+    }
+
     if (state.error && state.error !== 'no_assets_fetched') {
         notice.classList.add('alert-danger');
         notice.textContent = __('Character asset refresh did not complete. Stock uses the latest cached asset snapshot.');
@@ -1825,6 +1831,11 @@ function scheduleCraftStockRefreshStatusPolling() {
                 window.craftBPFlags.stockRefreshPollingStarted = false;
             })
             .catch(() => {
+                setCraftStockRefreshNotice({
+                    running: false,
+                    error: 'stock_status_unavailable',
+                    message: __('Unable to refresh stock status. Please try again.'),
+                });
                 window.craftBPFlags.stockRefreshPollingStarted = false;
             });
     };

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -633,6 +633,28 @@ function buildCraftRecalculationUrl(options = {}) {
     return cleanUrl;
 }
 
+function resolveRecalculationTabForMainTab(mainTabName) {
+    const normalizedTabName = String(mainTabName || '').trim();
+    if (normalizedTabName === 'plan') {
+        const hiddenActiveTab = document.querySelector('#bpTabs .nav-link.active');
+        const hiddenTarget = hiddenActiveTab ? String(hiddenActiveTab.getAttribute('data-bs-target') || '').trim() : '';
+        return hiddenTarget ? hiddenTarget.replace('#tab-', '') : 'materials';
+    }
+    if (normalizedTabName === 'buy') {
+        return 'financial';
+    }
+    if (normalizedTabName === 'build') {
+        return 'cycles';
+    }
+    if (normalizedTabName === 'structure' || normalizedTabName === 'configure') {
+        return 'config';
+    }
+    if (normalizedTabName === 'stock') {
+        return 'stock';
+    }
+    return normalizedTabName || getCurrentActiveBlueprintTab() || 'materials';
+}
+
 function getCurrentActiveBlueprintTab() {
     const activeMainTab = document.querySelector('#craftMainTabs .nav-link.active');
     const mainTabName = activeMainTab ? String(activeMainTab.getAttribute('data-tab-name') || '').trim() : '';
@@ -910,6 +932,7 @@ function hydratePlanPane() {
     planPane.dataset.planHydrated = 'true';
 
     renderPlanTreeFromPayload();
+    updatePlanMETEIndicators();
 
     const notice = document.getElementById('planPaneLazyNotice');
     if (notice) {
@@ -943,9 +966,23 @@ function replaceTreeMarkup(nextTreeNode) {
     }
 
     renderPlanTreeFromPayload();
+    updatePlanMETEIndicators();
 
     initializeBuyCraftSwitches();
     refreshTreeSummaryIcons();
+}
+
+function updatePlanMETEIndicators(config = null) {
+    const normalized = normalizeMETEConfig(config || buildDefaultMETEConfig());
+    const meEl = document.getElementById('craftPlanMEValue');
+    const teEl = document.getElementById('craftPlanTEValue');
+
+    if (meEl) {
+        meEl.textContent = String(normalized.mainME || 0);
+    }
+    if (teEl) {
+        teEl.textContent = String(normalized.mainTE || 0);
+    }
 }
 
 function updateFinalProductRowFromPayload(payload) {
@@ -954,6 +991,7 @@ function updateFinalProductRowFromPayload(payload) {
         return;
     }
 
+    updatePlanMETEIndicators();
     const outputs = getFinalOutputEntries(payload);
     if (outputs.length === 0) {
         return;
@@ -1465,6 +1503,7 @@ async function recalculateBlueprintWorkspace(options = {}) {
     try {
         const snapshot = await fetchCraftPageSnapshot(url);
         syncBlueprintPayloadNode(snapshot.payload);
+        updatePlanMETEIndicators();
 
         if (window.SimulationAPI && typeof window.SimulationAPI.replacePayload === 'function') {
             window.SimulationAPI.replacePayload(window.BLUEPRINT_DATA, {
@@ -1499,6 +1538,7 @@ async function recalculateBlueprintWorkspace(options = {}) {
         // visible production tree from the final in-memory payload so root quantities
         // stay aligned with the rest of the workspace.
         renderPlanTreeFromPayload();
+        updatePlanMETEIndicators();
         initializeBuyCraftSwitches();
         refreshTreeSummaryIcons();
 
@@ -1679,6 +1719,116 @@ function getCraftCharacterStockSnapshot() {
     return snapshot && typeof snapshot === 'object'
         ? snapshot
         : { totals_by_type: {}, characters: [], scope_missing: false, synced_at: '' };
+}
+
+function getCraftStockRefreshState() {
+    const state = window.BLUEPRINT_DATA?.character_stock_refresh;
+    return state && typeof state === 'object' ? state : {};
+}
+
+function setCraftStockRefreshNotice(state = {}) {
+    const notice = document.getElementById('stockRefreshStatusNotice');
+    if (!notice) {
+        return;
+    }
+
+    notice.classList.remove('alert-info', 'alert-warning', 'alert-danger', 'd-none');
+    notice.innerHTML = '';
+
+    const appendReloadButton = () => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-sm btn-dark ms-2 py-0 fw-semibold';
+        button.textContent = __('Reload');
+        button.addEventListener('click', () => window.location.reload());
+        notice.appendChild(button);
+    };
+
+    if (state.changed) {
+        notice.classList.add('alert-warning');
+        notice.appendChild(document.createTextNode(__('Character assets were refreshed after this project loaded. Reload the page to show the updated Stock tab.')));
+        appendReloadButton();
+        return;
+    }
+
+    if (state.running) {
+        const total = Math.max(0, Math.floor(Number(state.total || 0)));
+        const done = Math.max(0, Math.floor(Number(state.done || 0)));
+        const progressText = total > 0 ? ` (${formatInteger(done)}/${formatInteger(total)})` : '';
+        notice.classList.add('alert-info');
+        notice.textContent = `${__('Refreshing character assets in the background. Stock may change when it finishes.')}${progressText}`;
+        return;
+    }
+
+    if (state.error === 'missing_assets_scope') {
+        notice.classList.add('alert-warning');
+        notice.textContent = __('Character assets scope is missing. Stock data may be incomplete until assets access is granted.');
+        return;
+    }
+
+    if (state.error === 'esi_down') {
+        notice.classList.add('alert-warning');
+        notice.textContent = __('ESI is temporarily unavailable. Stock uses the latest cached asset snapshot.');
+        return;
+    }
+
+    if (state.error === 'no_assets_fetched') {
+        notice.classList.add('alert-warning');
+        notice.textContent = __('Character asset refresh finished, but no assets were returned. Stock uses the latest cached snapshot.');
+        return;
+    }
+
+    if (state.error && state.error !== 'no_assets_fetched') {
+        notice.classList.add('alert-danger');
+        notice.textContent = __('Character asset refresh did not complete. Stock uses the latest cached asset snapshot.');
+        return;
+    }
+
+    if (state.finished) {
+        notice.classList.add('alert-info');
+        notice.textContent = __('Character asset refresh finished. The Stock tab is already using the latest cached snapshot available at page load.');
+        return;
+    }
+
+    notice.classList.add('d-none', 'alert-info');
+}
+
+function scheduleCraftStockRefreshStatusPolling() {
+    window.craftBPFlags = window.craftBPFlags || {};
+    if (window.craftBPFlags.stockRefreshPollingStarted) {
+        return;
+    }
+
+    const url = String(window.BLUEPRINT_DATA?.urls?.craft_stock_refresh_status || '').trim();
+    const initialSyncedAt = String(getCraftCharacterStockSnapshot().synced_at || '').trim();
+    const initialState = getCraftStockRefreshState();
+    setCraftStockRefreshNotice(initialState);
+    if (!url || (!initialState.running && !initialState.error)) {
+        return;
+    }
+
+    window.craftBPFlags.stockRefreshPollingStarted = true;
+    const poll = () => {
+        const statusUrl = new URL(url, window.location.origin);
+        statusUrl.searchParams.set('since', initialSyncedAt);
+        fetch(statusUrl.toString(), {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            credentials: 'same-origin',
+        })
+            .then((response) => (response.ok ? response.json() : Promise.reject(response)))
+            .then((state) => {
+                setCraftStockRefreshNotice(state);
+                if (state.running) {
+                    window.setTimeout(poll, 3000);
+                    return;
+                }
+                window.craftBPFlags.stockRefreshPollingStarted = false;
+            })
+            .catch(() => {
+                window.craftBPFlags.stockRefreshPollingStarted = false;
+            });
+    };
+    window.setTimeout(poll, 3000);
 }
 
 function getCraftStockAllocations() {
@@ -2552,31 +2702,58 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    // Capture the initial dashboard Materials ordering before any UI updates replace the markup.
-    try {
-        getDashboardMaterialsOrdering();
-    } catch (e) {
-        // ignore
-    }
+    const scheduleStartupPhase = (callback) => {
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(() => window.setTimeout(callback, 0));
+            return;
+        }
+        window.setTimeout(callback, 0);
+    };
+    const startupPhases = [
+        () => {
+            // Capture the initial dashboard Materials ordering before any UI updates replace the markup.
+            try {
+                getDashboardMaterialsOrdering();
+            } catch (e) {
+                // ignore
+            }
+            initializeBlueprintIcons();
+            initializeCollapseHandlers();
+        },
+        () => {
+            initializeBuyCraftSwitches();
+            initializeDecisionStrategyTab();
+        },
+        () => {
+            initializeCraftPageSessionPersistence();
+            if (!restoreCraftPageSessionState()) {
+                restoreBuyCraftStateFromURL();
+            }
+            initializeStructureMotherSystemControls();
+        },
+        () => {
+            if (window.CraftBPLoading && typeof window.CraftBPLoading.stepBootstrap === 'function') {
+                window.CraftBPLoading.stepBootstrap('loading-interface', {
+                    detail: __('Opening the main workspace view.'),
+                    message: __('Loading workspace...'),
+                });
+            }
+            hydrateVisibleCraftStartupTab();
+        },
+        () => {
+            persistCraftPageSessionState();
+            syncCraftBrowserUrl();
+        },
+    ];
+    const runStartupPhase = (index) => {
+        if (index >= startupPhases.length) {
+            return;
+        }
+        startupPhases[index]();
+        scheduleStartupPhase(() => runStartupPhase(index + 1));
+    };
 
-    initializeBlueprintIcons();
-    initializeCollapseHandlers();
-    initializeBuyCraftSwitches();
-    initializeDecisionStrategyTab();
-    initializeCraftPageSessionPersistence();
-    if (!restoreCraftPageSessionState()) {
-        restoreBuyCraftStateFromURL();
-    }
-    initializeStructureMotherSystemControls();
-    if (window.CraftBPLoading && typeof window.CraftBPLoading.stepBootstrap === 'function') {
-        window.CraftBPLoading.stepBootstrap('loading-interface', {
-            detail: __('Opening the main workspace view.'),
-            message: __('Loading workspace...'),
-        });
-    }
-    hydrateVisibleCraftStartupTab();
-    persistCraftPageSessionState();
-    syncCraftBrowserUrl();
+    scheduleStartupPhase(() => runStartupPhase(0));
     // Financial calculations will be initialized via CraftBP.init()
 });
 
@@ -4100,6 +4277,8 @@ function initializeMETEHandlers() {
 
     function saveMETEToLocalStorage() {
         const config = getCurrentMETEConfig();
+        window.craftBPFlags = window.craftBPFlags || {};
+        window.craftBPFlags.pendingMETEConfig = config;
         try {
             withCraftPageSessionStorage((storage) => {
                 storage.setItem(storageKey, JSON.stringify(config));
@@ -4146,8 +4325,9 @@ function initializeMETEHandlers() {
             const sourceTab = String(window.craftBPFlags?.pendingWorkspaceSourceTab || '').trim();
 
             if (targetTab && targetTab !== sourceTab && window.craftBPFlags?.hasPendingWorkspaceRefresh) {
-                window.craftBPFlags.pendingWorkspaceTargetTab = getCurrentActiveBlueprintTab();
-                window.craftBPFlags.switchingToTab = getCurrentActiveBlueprintTab();
+                const recalculationTab = resolveRecalculationTabForMainTab(targetTab);
+                window.craftBPFlags.pendingWorkspaceTargetTab = recalculationTab;
+                window.craftBPFlags.switchingToTab = recalculationTab;
                 craftBPDebugLog('Applying pending workspace changes...');
                 applyPendingMETEChanges();
             }
@@ -5345,6 +5525,85 @@ function initializeRevenueModeControls() {
     applyRevenueModeToInputs();
 }
 
+function getFinancialRowLabel(row) {
+    return String(row?.querySelector('.craft-planner-item-name')?.textContent || '').trim()
+        || String(row?.getAttribute('data-type-id') || '').trim()
+        || __('Unknown item');
+}
+
+function getFinancialRowEffectiveUnitPrice(row, priceKind) {
+    const typeId = Number(row?.getAttribute('data-type-id') || 0) || 0;
+    const overrideSelector = priceKind === 'sale' ? '.sale-price-unit' : '.real-price';
+    const overrideValue = Number.parseFloat(row?.querySelector(overrideSelector)?.value) || 0;
+    if (overrideValue > 0) {
+        return overrideValue;
+    }
+
+    if (window.SimulationAPI && typeof window.SimulationAPI.getPrice === 'function' && typeId) {
+        const info = window.SimulationAPI.getPrice(typeId, priceKind === 'sale' ? 'sale' : 'buy');
+        const apiValue = info && typeof info.value === 'number' ? info.value : 0;
+        if (apiValue > 0) {
+            return apiValue;
+        }
+    }
+
+    return Number.parseFloat(row?.querySelector('.fuzzwork-price')?.value) || 0;
+}
+
+function getZeroPricedFinancialRows(revenueMode) {
+    return Array.from(document.querySelectorAll('#financialItemsBody tr[data-type-id]'))
+        .filter((row) => {
+            const isFinalOutput = row.getAttribute('data-final-output') === 'true';
+            if (isFinalOutput && revenueMode === REVENUE_MODE_TOTAL) {
+                return false;
+            }
+            const priceKind = isFinalOutput ? 'sale' : 'buy';
+            return getFinancialRowEffectiveUnitPrice(row, priceKind) <= 0;
+        })
+        .map(getFinancialRowLabel);
+}
+
+function triggerZeroPriceAlertAnimation(alertEl) {
+    if (!alertEl || (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches)) {
+        return;
+    }
+    alertEl.classList.remove('craft-zero-price-alert--pulse');
+    const scheduleAnimation = typeof window.requestAnimationFrame === 'function'
+        ? window.requestAnimationFrame.bind(window)
+        : (callback) => window.setTimeout(callback, 0);
+    scheduleAnimation(() => {
+        if (!alertEl.classList.contains('d-none')) {
+            alertEl.classList.add('craft-zero-price-alert--pulse');
+        }
+    });
+}
+
+function updateQuickMarginZeroPriceAlert(zeroPricedRows) {
+    const alertEl = document.getElementById('quickMarginZeroPriceAlert');
+    if (!alertEl) {
+        return;
+    }
+
+    const names = Array.isArray(zeroPricedRows) ? zeroPricedRows.filter(Boolean) : [];
+    if (names.length === 0) {
+        alertEl.textContent = '';
+        alertEl.classList.add('d-none');
+        alertEl.removeAttribute('title');
+        return;
+    }
+
+    const nextText = names.length === 1
+        ? __('1 Buy line has no price')
+        : `${formatInteger(names.length)} ${__('Buy lines have no price')}`;
+    const shouldAnimate = alertEl.classList.contains('d-none') || alertEl.textContent !== nextText;
+    alertEl.textContent = nextText;
+    alertEl.setAttribute('title', names.slice(0, 8).join(', '));
+    alertEl.classList.remove('d-none');
+    if (shouldAnimate) {
+        triggerZeroPriceAlertAnimation(alertEl);
+    }
+}
+
 /**
  * Recalculate financial totals
  */
@@ -5441,6 +5700,7 @@ function recalcFinancials() {
     // and the KPI block stay coherent.
     const revenueMode = getRevenueMode();
     const revenueTotalOverride = getRevenueTotalOverride();
+    const zeroPricedRows = getZeroPricedFinancialRows(revenueMode);
     if (revenueMode === REVENUE_MODE_TOTAL) {
         revTotal = revenueTotalOverride;
         const finalOutputRows = Array.from(document.querySelectorAll('#financialItemsBody tr[data-final-output="true"]'));
@@ -5689,6 +5949,7 @@ function recalcFinancials() {
     if (quickMarginEl) {
         quickMarginEl.textContent = `${marginText}%`;
     }
+    updateQuickMarginZeroPriceAlert(zeroPricedRows);
 
     applyFinancialPlannerFilters();
 
@@ -6104,14 +6365,20 @@ function renderCraftStockManagement() {
     }
 
     const rows = getCraftSourceRequirementRows();
+    const rowsWithStock = rows
+        .map((item) => ({
+            item,
+            stockSummary: getCraftStockAllocationSummary(item.typeId, item.quantity),
+        }))
+        .filter(({ stockSummary }) => stockSummary.availableQty > 0);
+    const hiddenZeroStockCount = Math.max(0, rows.length - rowsWithStock.length);
     const api = window.SimulationAPI;
     let totalRequiredQty = 0;
     let totalAllocatedQty = 0;
     let totalRemainingQty = 0;
     let totalStockValue = 0;
 
-    const renderedRows = rows.map((item) => {
-        const stockSummary = getCraftStockAllocationSummary(item.typeId, item.quantity);
+    const renderedRows = rowsWithStock.map(({ item, stockSummary }) => {
         const maxAllocatable = Math.min(stockSummary.requiredQty, stockSummary.availableQty);
         const unitInfo = api && typeof api.getPrice === 'function' ? api.getPrice(item.typeId, 'buy') : { value: 0 };
         const unitPrice = unitInfo && typeof unitInfo.value === 'number' ? unitInfo.value : 0;
@@ -6159,7 +6426,7 @@ function renderCraftStockManagement() {
         ? renderedRows.join('')
         : `
             <tr>
-                <td colspan="7" class="text-center text-muted py-4">${escapeHtml(__('No sourceable items require stock management right now.'))}</td>
+                <td colspan="7" class="text-center text-muted py-4">${escapeHtml(__('No required items have cached stock available right now.'))}</td>
             </tr>
         `;
 
@@ -6170,11 +6437,19 @@ function renderCraftStockManagement() {
         }
     };
 
-    setText('stockSummaryLineCount', formatInteger(rows.length));
+    setText('stockSummaryLineCount', formatInteger(rowsWithStock.length));
     setText('stockSummaryRequiredQty', formatInteger(totalRequiredQty));
     setText('stockSummaryAllocatedQty', formatInteger(totalAllocatedQty));
     setText('stockSummaryRemainingQty', formatInteger(totalRemainingQty));
     setText('stockSummaryValue', formatPrice(totalStockValue));
+
+    const availableOnlyNotice = document.getElementById('stockAvailableOnlyNotice');
+    if (availableOnlyNotice) {
+        const hiddenText = hiddenZeroStockCount > 0
+            ? ` ${formatInteger(hiddenZeroStockCount)} ${hiddenZeroStockCount === 1 ? __('line with 0 stock is hidden.') : __('lines with 0 stock are hidden.')}`
+            : '';
+        availableOnlyNotice.textContent = `${__('Only required items with cached stock available are shown.')}${hiddenText}`;
+    }
 
     const syncEl = document.getElementById('stockSummaryUpdated');
     if (syncEl) {
@@ -6188,6 +6463,7 @@ function renderCraftStockManagement() {
         scopeMissingEl.classList.toggle('d-none', !getCraftCharacterStockSnapshot().scope_missing);
     }
 
+    scheduleCraftStockRefreshStatusPolling();
     initializeStockManagementInteractions();
 }
 

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -5552,14 +5552,19 @@ function getFinancialRowEffectiveUnitPrice(row, priceKind) {
 
 function getZeroPricedFinancialRows(revenueMode) {
     return Array.from(document.querySelectorAll('#financialItemsBody tr[data-type-id]'))
-        .filter((row) => {
-            const isFinalOutput = row.getAttribute('data-final-output') === 'true';
-            if (isFinalOutput) {
-                return false;
+        .reduce((groups, row) => {
+            const label = getFinancialRowLabel(row);
+            if (row.getAttribute('data-final-output') === 'true') {
+                if (revenueMode !== REVENUE_MODE_TOTAL && getFinancialRowEffectiveUnitPrice(row, 'sale') <= 0) {
+                    groups.revenue.push(label);
+                }
+                return groups;
             }
-            return getFinancialRowEffectiveUnitPrice(row, 'buy') <= 0;
-        })
-        .map(getFinancialRowLabel);
+            if (getFinancialRowEffectiveUnitPrice(row, 'buy') <= 0) {
+                groups.buy.push(label);
+            }
+            return groups;
+        }, { buy: [], revenue: [] });
 }
 
 function triggerZeroPriceAlertAnimation(alertEl) {
@@ -5583,20 +5588,36 @@ function updateQuickMarginZeroPriceAlert(zeroPricedRows) {
         return;
     }
 
-    const names = Array.isArray(zeroPricedRows) ? zeroPricedRows.filter(Boolean) : [];
-    if (names.length === 0) {
+    const buyNames = Array.isArray(zeroPricedRows)
+        ? zeroPricedRows.filter(Boolean)
+        : (zeroPricedRows?.buy || []).filter(Boolean);
+    const revenueNames = Array.isArray(zeroPricedRows?.revenue)
+        ? zeroPricedRows.revenue.filter(Boolean)
+        : [];
+    const missingCount = buyNames.length + revenueNames.length;
+    if (missingCount === 0) {
         alertEl.textContent = '';
         alertEl.classList.add('d-none');
         alertEl.removeAttribute('title');
         return;
     }
 
-    const nextText = names.length === 1
-        ? __('1 Buy line has no price')
-        : `${formatInteger(names.length)} ${__('Buy lines have no price')}`;
+    const parts = [];
+    if (buyNames.length > 0) {
+        parts.push(buyNames.length === 1
+            ? __('1 Buy line has no price')
+            : `${formatInteger(buyNames.length)} ${__('Buy lines have no price')}`);
+    }
+    if (revenueNames.length > 0) {
+        parts.push(revenueNames.length === 1
+            ? __('1 Revenue target has no sale price')
+            : `${formatInteger(revenueNames.length)} ${__('Revenue targets have no sale price')}`);
+    }
+
+    const nextText = parts.join(' · ');
     const shouldAnimate = alertEl.classList.contains('d-none') || alertEl.textContent !== nextText;
     alertEl.textContent = nextText;
-    alertEl.setAttribute('title', names.slice(0, 8).join(', '));
+    alertEl.setAttribute('title', buyNames.concat(revenueNames).slice(0, 8).join(', '));
     alertEl.classList.remove('d-none');
     if (shouldAnimate) {
         triggerZeroPriceAlertAnimation(alertEl);
@@ -6248,7 +6269,7 @@ function updateMaterialsTabFromState() {
         window.updateCraftQuickStats();
     }
 
-    if (planPaneHydrated && typeof recalcFinancials === 'function') {
+    if (typeof recalcFinancials === 'function') {
         recalcFinancials();
     }
 }

--- a/indy_hub/static/indy_hub/js/craft_bp_active_tab.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_active_tab.js
@@ -78,10 +78,17 @@ window.CraftBPTabs = {
 
         // Silently preload the Tree tab to initialize switches, but keep the
         // workspace hidden until the page bootstrap reports that it is ready.
-        try {
-            this.preloadTreeTab();
-        } catch (error) {
-            console.error('[IndyHub] Failed during initial craft workspace hydration', error);
+        const runTreePreload = () => {
+            try {
+                this.preloadTreeTab();
+            } catch (error) {
+                console.error('[IndyHub] Failed during initial craft workspace hydration', error);
+            }
+        };
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(() => window.setTimeout(runTreePreload, 0));
+        } else {
+            window.setTimeout(runTreePreload, 0);
         }
 
     },
@@ -301,5 +308,9 @@ document.addEventListener('DOMContentLoaded', function() {
             setTimeout(checkAndInit, 100);
         }
     };
-    checkAndInit();
+    if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(checkAndInit);
+        return;
+    }
+    window.setTimeout(checkAndInit, 0);
 });

--- a/indy_hub/static/indy_hub/js/craft_bp_inline.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_inline.js
@@ -22,15 +22,31 @@
 
     function buildMeTeConfigFromLegacyEfficiencies(efficiencies) {
         const blueprintConfigs = {};
+        const pageBlueprintConfigs = Array.isArray(blueprintData.page?.blueprint_configs)
+            ? blueprintData.page.blueprint_configs
+            : [];
+
+        pageBlueprintConfigs.forEach((entry) => {
+            const blueprintTypeId = Number(entry?.type_id || 0) || 0;
+            if (!(blueprintTypeId > 0)) {
+                return;
+            }
+            blueprintConfigs[String(blueprintTypeId)] = {
+                me: Math.max(0, Math.min(Number(entry?.material_efficiency || 0) || 0, 10)),
+                te: Math.max(0, Math.min(Number(entry?.time_efficiency || 0) || 0, 20)),
+            };
+        });
+
         (Array.isArray(efficiencies) ? efficiencies : []).forEach((entry) => {
             const blueprintTypeId = Number(entry?.blueprint_type_id || entry?.blueprintTypeId || 0) || 0;
             if (!(blueprintTypeId > 0)) {
                 return;
             }
-            blueprintConfigs[String(blueprintTypeId)] = {
-                me: Math.max(0, Math.min(Number(entry?.material_efficiency || entry?.materialEfficiency || 0) || 0, 10)),
-                te: Math.max(0, Math.min(Number(entry?.time_efficiency || entry?.timeEfficiency || 0) || 0, 20)),
-            };
+            const me = Math.max(0, Math.min(Number(entry?.material_efficiency || entry?.materialEfficiency || 0) || 0, 10));
+            const te = Math.max(0, Math.min(Number(entry?.time_efficiency || entry?.timeEfficiency || 0) || 0, 20));
+            if (me || te || !blueprintConfigs[String(blueprintTypeId)]) {
+                blueprintConfigs[String(blueprintTypeId)] = { me, te };
+            }
         });
 
         const mainBlueprintTypeId = Number((blueprintData.bp_type_id || blueprintData.type_id || 0)) || 0;

--- a/indy_hub/tasks/material_exchange.py
+++ b/indy_hub/tasks/material_exchange.py
@@ -57,6 +57,10 @@ from indy_hub.services.esi_client import (
     get_retry_after_seconds,
     shared_client,
 )
+from indy_hub.services.material_exchange_assets import (
+    SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS,
+    material_exchange_sell_assets_progress_key,
+)
 from indy_hub.utils.analytics import emit_analytics_event
 from indy_hub.utils.eve import get_type_name
 
@@ -132,7 +136,7 @@ def _set_esi_cooldown(cache_key: str, *, cooldown_seconds: int) -> float:
 
 
 def _me_sell_assets_progress_key(user_id: int) -> str:
-    return f"indy_hub:material_exchange:sell_assets_refresh:{int(user_id)}"
+    return material_exchange_sell_assets_progress_key(int(user_id))
 
 
 @shared_task(
@@ -291,7 +295,7 @@ def refresh_material_exchange_sell_user_assets(user_id: int) -> None:
     logger.info("Starting asset refresh task for user %s", user_id)
 
     progress_key = _me_sell_assets_progress_key(int(user_id))
-    ttl_seconds = 10 * 60
+    ttl_seconds = SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS
     cached_state = cache.get(progress_key) or {}
     started_at = cached_state.get("started_at") or timezone.now().timestamp()
 

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260426-tabs-responsive">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260505-zero-price-alert">
 {% endblock extra_css %}
 
 {% block content %}
@@ -193,6 +193,7 @@
                         <div class="craft-stat-content">
                             <div class="craft-stat-label">{% trans "Margin" %}</div>
                             <div class="craft-stat-value" id="quickMargin">-</div>
+                            <div class="small text-warning fw-semibold craft-zero-price-alert d-none" id="quickMarginZeroPriceAlert"></div>
                         </div>
                     </div>
                 </div>
@@ -208,11 +209,11 @@
                     </div>
                     <div class="craft-kpi craft-kpi-sm">
                         <span class="craft-kpi-label">ME</span>
-                        <span class="craft-kpi-value">{{ me|default:0 }}</span>
+                        <span class="craft-kpi-value" id="craftPlanMEValue">{{ me|default:0 }}</span>
                     </div>
                     <div class="craft-kpi craft-kpi-sm">
                         <span class="craft-kpi-label">TE</span>
-                        <span class="craft-kpi-value">{{ te|default:0 }}</span>
+                        <span class="craft-kpi-value" id="craftPlanTEValue">{{ te|default:0 }}</span>
                     </div>
                 </div>
 
@@ -645,6 +646,12 @@
 
                     <div class="small text-muted mb-3">
                         {% trans "Last cached asset sync" %}: <span id="stockSummaryUpdated">{% trans "No asset sync yet" %}</span>
+                    </div>
+
+                    <div class="alert alert-info py-2 small mb-3 d-none" id="stockRefreshStatusNotice"></div>
+
+                    <div class="alert alert-info py-2 small mb-3" id="stockAvailableOnlyNotice">
+                        {% trans "Only required items with cached stock available are shown." %}
                     </div>
 
                     <div class="table-responsive craft-stock-table-wrap">
@@ -1129,9 +1136,9 @@
 <script src="{% static 'indy_hub/js/craft_bp_page.js' %}?v=20260426-pending-refresh-fix"></script>
 {% if not deferred_shell %}
 <script src="{% static 'indy_hub/js/craft_bp_simulation_api.js' %}?v=20260427-inclusion-mode-restore"></script>
-<script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260425-loading-replay2"></script>
+<script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260505-deferred-tab-init"></script>
 <script src="{% static 'indy_hub/js/craft_bp_financial_planner.js' %}?v=20260428-no-output-override"></script>
-<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260505-stock-input-task-split"></script>
-<script src="{% static 'indy_hub/js/craft_bp_inline.js' %}?v=20260427-revenue-mode-total"></script>
+<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260505-stock-refresh-notice"></script>
+<script src="{% static 'indy_hub/js/craft_bp_inline.js' %}?v=20260505-owned-bp-mete-defaults"></script>
 {% endif %}
 {% endblock extra_javascript %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -648,7 +648,7 @@
                         {% trans "Last cached asset sync" %}: <span id="stockSummaryUpdated">{% trans "No asset sync yet" %}</span>
                     </div>
 
-                    <div class="alert alert-info py-2 small mb-3 d-none" id="stockRefreshStatusNotice"></div>
+                    <div class="alert alert-info py-2 small mb-3 d-none" id="stockRefreshStatusNotice" role="status" aria-live="polite" aria-atomic="true"></div>
 
                     <div class="alert alert-info py-2 small mb-3" id="stockAvailableOnlyNotice">
                         {% trans "Only required items with cached stock available are shown." %}

--- a/indy_hub/tests/test_asset_cache_character_structure_names.py
+++ b/indy_hub/tests/test_asset_cache_character_structure_names.py
@@ -1,6 +1,7 @@
 """Tests for character asset refresh caching structure names."""
 
 # Standard Library
+from datetime import timedelta
 from unittest.mock import patch
 
 # Django
@@ -31,6 +32,71 @@ class _FakeTokenQuerySet(list):
 
 
 class CharacterAssetRefreshStructureNameTests(TestCase):
+    def test_user_assets_cached_skips_esi_when_cache_is_younger_than_one_hour(
+        self,
+    ) -> None:
+        user = User.objects.create_user("recent_assets_user", password="secret123")
+        CachedCharacterAsset.objects.create(
+            user=user,
+            character_id=12345,
+            location_id=60003760,
+            location_flag="Hangar",
+            type_id=34,
+            quantity=100,
+            synced_at=timezone.now() - timedelta(minutes=30),
+        )
+
+        with patch.object(asset_cache, "_refresh_character_assets") as refresh_mock:
+            assets, scope_missing = asset_cache.get_user_assets_cached(
+                user,
+                allow_refresh=True,
+                max_age_minutes=60,
+            )
+
+        refresh_mock.assert_not_called()
+        self.assertFalse(scope_missing)
+        self.assertEqual(assets[0]["type_id"], 34)
+
+    def test_user_assets_cached_refreshes_when_cache_is_older_than_one_hour(
+        self,
+    ) -> None:
+        user = User.objects.create_user("stale_assets_user", password="secret123")
+        CachedCharacterAsset.objects.create(
+            user=user,
+            character_id=12345,
+            location_id=60003760,
+            location_flag="Hangar",
+            type_id=34,
+            quantity=100,
+            synced_at=timezone.now() - timedelta(minutes=61),
+        )
+        refreshed_assets = [
+            {
+                "character_id": 12345,
+                "location_id": 60003760,
+                "location_flag": "Hangar",
+                "type_id": 35,
+                "quantity": 200,
+                "is_singleton": False,
+                "is_blueprint": False,
+            }
+        ]
+
+        with patch.object(
+            asset_cache,
+            "_refresh_character_assets",
+            return_value=(refreshed_assets, False),
+        ) as refresh_mock:
+            assets, scope_missing = asset_cache.get_user_assets_cached(
+                user,
+                allow_refresh=True,
+                max_age_minutes=60,
+            )
+
+        refresh_mock.assert_called_once_with(user)
+        self.assertFalse(scope_missing)
+        self.assertEqual(assets, refreshed_assets)
+
     def test_refresh_character_assets_triggers_structure_name_cache(self) -> None:
         user = User.objects.create_user("assets_user", password="secret123")
 

--- a/indy_hub/tests/test_legacy_simulation_unification.py
+++ b/indy_hub/tests/test_legacy_simulation_unification.py
@@ -706,9 +706,11 @@ class LegacySimulationUnificationTests(TestCase):
         self.assertEqual(progress, {"running": True})
         mock_ensure_refresh_started.assert_called_once_with(self.user)
 
-    @patch("indy_hub.views.industry.refresh_material_exchange_sell_user_assets.delay")
-    @patch("indy_hub.views.industry.Token.objects.filter")
-    @patch("indy_hub.views.industry.CharacterOwnership.objects.filter")
+    @patch(
+        "indy_hub.tasks.material_exchange.refresh_material_exchange_sell_user_assets.delay"
+    )
+    @patch("esi.models.Token.objects.filter")
+    @patch("allianceauth.authentication.models.CharacterOwnership.objects.filter")
     def test_ensure_craft_project_stock_refresh_started_enqueues_celery_task(
         self,
         mock_character_ownership_filter,

--- a/indy_hub/tests/test_legacy_simulation_unification.py
+++ b/indy_hub/tests/test_legacy_simulation_unification.py
@@ -1,5 +1,6 @@
 # Standard Library
 import json
+from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -8,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.cache import cache
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 from django.http import HttpRequest
@@ -16,7 +18,12 @@ from django.urls import reverse
 from django.utils import timezone
 
 # AA Example App
-from indy_hub.models import IndustryJob, ProductionProject, ProductionProjectItem
+from indy_hub.models import (
+    CachedCharacterAsset,
+    IndustryJob,
+    ProductionProject,
+    ProductionProjectItem,
+)
 from indy_hub.services.production_projects import (
     LEGACY_SINGLE_BLUEPRINT_PROJECT_NOTE,
     _scale_project_selected_items_for_runs,
@@ -30,13 +37,48 @@ from indy_hub.views.api import (
     save_production_project_progress,
     save_production_project_workspace,
 )
-from indy_hub.views.industry import craft_bp, craft_project
+from indy_hub.views.industry import (
+    _craft_project_stock_refresh_progress_key,
+    _ensure_craft_project_stock_refresh_started,
+    _get_craft_project_stock_refresh_progress,
+    craft_bp,
+    craft_project,
+    craft_project_stock_refresh_status,
+)
 
 
 def _unwrap_view(view):
     while hasattr(view, "__wrapped__"):
         view = view.__wrapped__
     return view
+
+
+class _FakeOwnershipCountQuerySet:
+    def __init__(self, count: int):
+        self._count = int(count)
+
+    def values_list(self, *args, **kwargs):
+        return self
+
+    def distinct(self):
+        return self
+
+    def count(self):
+        return self._count
+
+
+class _FakeTokenQuerySet:
+    def __init__(self, exists: bool):
+        self._exists = bool(exists)
+
+    def require_scopes(self, scopes):
+        return self
+
+    def require_valid(self):
+        return self
+
+    def exists(self):
+        return self._exists
 
 
 class LegacySimulationUnificationTests(TestCase):
@@ -68,6 +110,10 @@ class LegacySimulationUnificationTests(TestCase):
     @property
     def _craft_project_view(self):
         return _unwrap_view(craft_project)
+
+    @property
+    def _craft_project_stock_refresh_status_view(self):
+        return _unwrap_view(craft_project_stock_refresh_status)
 
     def _prepare_request(self, request: HttpRequest, *, user=None) -> HttpRequest:
         request.user = user or self.user
@@ -540,12 +586,16 @@ class LegacySimulationUnificationTests(TestCase):
             mock_build_project_workspace_payload.call_args.kwargs["runs_override"], 5
         )
 
+    @patch("indy_hub.views.industry.build_user_asset_inventory_snapshot")
+    @patch("indy_hub.views.industry._get_craft_project_stock_refresh_progress")
     @patch("indy_hub.views.industry.build_project_workspace_payload")
     @patch("indy_hub.views.industry.get_cached_project_workspace_payload")
     def test_craft_project_renders_runs_control_and_uses_runs_override(
         self,
         mock_get_cached_project_workspace_payload,
         mock_build_project_workspace_payload,
+        mock_get_stock_refresh_progress,
+        mock_build_user_asset_inventory_snapshot,
     ):
         project = ProductionProject.objects.create(
             user=self.user,
@@ -582,6 +632,13 @@ class LegacySimulationUnificationTests(TestCase):
             "structure_planner": {},
             "final_outputs": [{"type_id": 603, "quantity": 14}],
         }
+        mock_build_user_asset_inventory_snapshot.return_value = {
+            "scope_missing": False,
+            "synced_at": "",
+            "totals_by_type": {},
+            "characters": [],
+        }
+        mock_get_stock_refresh_progress.return_value = {"running": True}
 
         request = self._prepare_request(
             self.factory.get(
@@ -595,9 +652,145 @@ class LegacySimulationUnificationTests(TestCase):
         self.assertEqual(
             mock_build_project_workspace_payload.call_args.kwargs["runs_override"], 7
         )
+        mock_get_stock_refresh_progress.assert_called_once_with(self.user)
+        mock_build_user_asset_inventory_snapshot.assert_called_once_with(
+            self.user,
+            allow_refresh=False,
+        )
         self.assertContains(response, 'id="runsInput"', html=False)
         self.assertContains(response, 'value="7"', html=False)
         self.assertContains(response, 'id="recalcNowBtn"', html=False)
+
+    @patch("indy_hub.views.industry._ensure_craft_project_stock_refresh_started")
+    def test_craft_project_stock_refresh_progress_skips_recent_asset_cache(
+        self,
+        mock_ensure_refresh_started,
+    ):
+        cache.delete(_craft_project_stock_refresh_progress_key(int(self.user.id)))
+        CachedCharacterAsset.objects.create(
+            user=self.user,
+            character_id=12345,
+            location_id=60003760,
+            location_flag="Hangar",
+            type_id=34,
+            quantity=100,
+            synced_at=timezone.now() - timedelta(minutes=30),
+        )
+
+        progress = _get_craft_project_stock_refresh_progress(self.user)
+
+        self.assertEqual(progress, {})
+        mock_ensure_refresh_started.assert_not_called()
+
+    @patch(
+        "indy_hub.views.industry._ensure_craft_project_stock_refresh_started",
+        return_value={"running": True},
+    )
+    def test_craft_project_stock_refresh_progress_starts_stale_asset_cache(
+        self,
+        mock_ensure_refresh_started,
+    ):
+        cache.delete(_craft_project_stock_refresh_progress_key(int(self.user.id)))
+        CachedCharacterAsset.objects.create(
+            user=self.user,
+            character_id=12345,
+            location_id=60003760,
+            location_flag="Hangar",
+            type_id=34,
+            quantity=100,
+            synced_at=timezone.now() - timedelta(minutes=61),
+        )
+
+        progress = _get_craft_project_stock_refresh_progress(self.user)
+
+        self.assertEqual(progress, {"running": True})
+        mock_ensure_refresh_started.assert_called_once_with(self.user)
+
+    @patch("indy_hub.views.industry.refresh_material_exchange_sell_user_assets.delay")
+    @patch("indy_hub.views.industry.Token.objects.filter")
+    @patch("indy_hub.views.industry.CharacterOwnership.objects.filter")
+    def test_ensure_craft_project_stock_refresh_started_enqueues_celery_task(
+        self,
+        mock_character_ownership_filter,
+        mock_token_filter,
+        mock_delay,
+    ):
+        progress_key = _craft_project_stock_refresh_progress_key(int(self.user.id))
+        cache.delete(progress_key)
+        mock_character_ownership_filter.return_value = _FakeOwnershipCountQuerySet(1)
+        mock_token_filter.return_value = _FakeTokenQuerySet(True)
+        mock_delay.return_value = type("TaskResult", (), {"id": "task-123"})()
+
+        progress = _ensure_craft_project_stock_refresh_started(self.user)
+
+        self.assertTrue(progress["running"])
+        self.assertEqual(progress["total"], 1)
+        mock_delay.assert_called_once_with(int(self.user.id))
+
+    def test_craft_project_stock_refresh_status_reports_changed_assets(self):
+        progress_key = _craft_project_stock_refresh_progress_key(int(self.user.id))
+        cache.set(
+            progress_key,
+            {"running": False, "finished": True, "error": None},
+            600,
+        )
+        old_sync = timezone.now() - timedelta(minutes=70)
+        latest_sync = timezone.now()
+        CachedCharacterAsset.objects.create(
+            user=self.user,
+            character_id=12345,
+            location_id=60003760,
+            location_flag="Hangar",
+            type_id=34,
+            quantity=100,
+            synced_at=latest_sync,
+        )
+
+        request = self._prepare_request(
+            self.factory.get(
+                reverse("indy_hub:craft_project_stock_refresh_status"),
+                data={"since": old_sync.isoformat()},
+            )
+        )
+        response = self._craft_project_stock_refresh_status_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content.decode())
+        self.assertTrue(payload["changed"])
+        self.assertEqual(payload["synced_at"], latest_sync.isoformat())
+
+    def test_craft_project_stock_refresh_status_reports_changed_from_empty_snapshot(
+        self,
+    ):
+        progress_key = _craft_project_stock_refresh_progress_key(int(self.user.id))
+        cache.set(
+            progress_key,
+            {"running": False, "finished": True, "error": None},
+            600,
+        )
+        latest_sync = timezone.now()
+        CachedCharacterAsset.objects.create(
+            user=self.user,
+            character_id=12345,
+            location_id=60003760,
+            location_flag="Hangar",
+            type_id=34,
+            quantity=100,
+            synced_at=latest_sync,
+        )
+
+        request = self._prepare_request(
+            self.factory.get(
+                reverse("indy_hub:craft_project_stock_refresh_status"),
+                data={"since": ""},
+            )
+        )
+        response = self._craft_project_stock_refresh_status_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content.decode())
+        self.assertTrue(payload["changed"])
+        self.assertEqual(payload["synced_at"], latest_sync.isoformat())
 
     def test_save_production_project_progress_persists_summary_progress(self):
         project = ProductionProject.objects.create(

--- a/indy_hub/tests/test_production_projects.py
+++ b/indy_hub/tests/test_production_projects.py
@@ -310,9 +310,9 @@ class ProductionProjectImportTests(TestCase):
         )
         inventory_map = {
             1000: {
-                "original": {"me": 10, "te": 20},
-                "best_copy": None,
-                "copy_runs_total": 0,
+                "original": {"me": 0, "te": 0},
+                "best_copy": {"me": 10, "te": 20},
+                "copy_runs_total": 3,
             },
             3001: {
                 "original": {"me": 8, "te": 16},
@@ -385,6 +385,41 @@ class ProductionProjectImportTests(TestCase):
             mock_blueprint_configs.call_args.kwargs["user_bp_map"],
             inventory_map,
         )
+
+    @patch("indy_hub.services.production_projects._resolve_user_blueprint_inventory")
+    def test_project_blueprint_configs_use_best_copy_when_better_than_original(
+        self,
+        mock_inventory,
+    ) -> None:
+        mock_inventory.return_value = {
+            46165: {
+                "original": {"me": 0, "te": 0},
+                "best_copy": {"me": 8, "te": 16},
+                "copy_runs_total": 5,
+            }
+        }
+
+        blueprints, _grouped = _build_project_blueprint_configs_grouped(
+            user=object(),
+            cycle_summary={
+                78272: {
+                    "type_id": 78272,
+                    "type_name": "Cyclone Fleet Issue",
+                    "total_needed": 2,
+                }
+            },
+            product_blueprint_cache={78272: 46165},
+            overrides={},
+            type_name_cache={46165: "Cyclone Fleet Issue Blueprint"},
+        )
+
+        self.assertEqual(len(blueprints), 1)
+        self.assertEqual(blueprints[0]["material_efficiency"], 8)
+        self.assertEqual(blueprints[0]["time_efficiency"], 16)
+        self.assertEqual(blueprints[0]["user_material_efficiency"], 8)
+        self.assertEqual(blueprints[0]["user_time_efficiency"], 16)
+        self.assertTrue(blueprints[0]["is_copy"])
+        self.assertEqual(blueprints[0]["runs_available"], 5)
 
     @patch("indy_hub.services.production_projects.connection.cursor")
     def test_resolve_preferred_blueprint_for_product_prefers_published_types(

--- a/indy_hub/tests/test_production_projects.py
+++ b/indy_hub/tests/test_production_projects.py
@@ -8,7 +8,11 @@ from unittest.mock import patch
 from indy_hub.models import generate_production_project_ref
 from indy_hub.services.production_projects import (
     _build_project_blueprint_configs_grouped,
+    _cached_payload_includes_blueprint_configs,
+    _extract_workspace_me_te_overrides,
+    _merge_me_te_overrides,
     _payload_uses_unpublished_blueprints,
+    _remember_project_blueprint_for_product,
     _resolve_blueprints_for_products,
     _resolve_preferred_blueprint_for_product,
     aggregate_project_import_entries,
@@ -102,6 +106,114 @@ class ProductionProjectImportTests(TestCase):
         self.assertEqual(
             normalize_production_project_ref("ABC123DEF4"),
             "abc123def4",
+        )
+
+    def test_workspace_mete_overrides_ignore_legacy_zero_defaults(self) -> None:
+        overrides = _extract_workspace_me_te_overrides(
+            {
+                "blueprint_efficiencies": [
+                    {
+                        "blueprint_type_id": 23916,
+                        "material_efficiency": 0,
+                        "time_efficiency": 0,
+                    },
+                    {
+                        "blueprint_type_id": 23920,
+                        "material_efficiency": 10,
+                        "time_efficiency": 20,
+                    },
+                ]
+            }
+        )
+
+        self.assertNotIn(23916, overrides)
+        self.assertEqual(overrides[23920], {"me": 10, "te": 20})
+
+    def test_workspace_mete_overrides_preserve_modern_zero_choices(self) -> None:
+        overrides = _extract_workspace_me_te_overrides(
+            {"meTeConfig": {"blueprintConfigs": {"23916": {"me": 0, "te": 0}}}}
+        )
+
+        self.assertEqual(overrides[23916], {"me": 0, "te": 0})
+
+    def test_request_mete_overrides_replace_saved_workspace_choices(self) -> None:
+        merged = _merge_me_te_overrides(
+            {23916: {"me": 8, "te": 16}},
+            {23916: {"me": 10}},
+        )
+
+        self.assertEqual(merged[23916], {"me": 10, "te": 16})
+
+    def test_project_blueprint_cache_remembers_explicit_root_blueprint(self) -> None:
+        product_blueprint_cache = {}
+
+        _remember_project_blueprint_for_product(
+            product_blueprint_cache,
+            product_type_id=23915,
+            blueprint_type_id=23916,
+        )
+
+        self.assertEqual(product_blueprint_cache, {23915: 23916})
+
+    def test_cached_payload_requires_cards_for_used_blueprints(self) -> None:
+        self.assertFalse(
+            _cached_payload_includes_blueprint_configs(
+                {
+                    "materials_tree": [
+                        {
+                            "type_id": 23915,
+                            "blueprint_type_id": 23916,
+                            "sub_materials": [],
+                        }
+                    ],
+                    "page": {"blueprint_configs": []},
+                },
+                {"blueprint_type_id": 23916},
+            )
+        )
+
+    def test_cached_payload_allows_legacy_payload_without_page_configs(self) -> None:
+        self.assertTrue(
+            _cached_payload_includes_blueprint_configs(
+                {
+                    "materials_tree": [
+                        {
+                            "type_id": 23915,
+                            "blueprint_type_id": 23916,
+                            "sub_materials": [],
+                        }
+                    ]
+                },
+                {"blueprint_type_id": 23916},
+            )
+        )
+
+    def test_cached_payload_accepts_cards_for_all_used_blueprints(self) -> None:
+        self.assertTrue(
+            _cached_payload_includes_blueprint_configs(
+                {
+                    "materials_tree": [
+                        {
+                            "type_id": 23915,
+                            "blueprint_type_id": 23916,
+                            "sub_materials": [
+                                {
+                                    "type_id": 123,
+                                    "blueprint_type_id": 456,
+                                    "sub_materials": [],
+                                }
+                            ],
+                        }
+                    ],
+                    "page": {
+                        "blueprint_configs": [
+                            {"type_id": 23916},
+                            {"type_id": 456},
+                        ]
+                    },
+                },
+                {"blueprint_type_id": 23916},
+            )
         )
 
     @patch("indy_hub.services.production_projects.connection.cursor")

--- a/indy_hub/tests/test_production_projects.py
+++ b/indy_hub/tests/test_production_projects.py
@@ -1,6 +1,7 @@
 """Tests for production project import parsing and resolution."""
 
 # Standard Library
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ from indy_hub.services.production_projects import (
     _resolve_preferred_blueprint_for_product,
     aggregate_project_import_entries,
     build_project_import_preview,
+    build_project_workspace_payload,
     normalize_production_project_ref,
     parse_project_import_text,
     resolve_project_import_entries,
@@ -79,6 +81,69 @@ class _FetchoneCursorStub:
 
     def fetchone(self):
         return self._fetchone_result
+
+
+class _ProjectItemsQueryStub:
+    def __init__(self, items):
+        self._items = items
+
+    def filter(self, **kwargs):
+        return self
+
+    def exclude(self, **kwargs):
+        return self
+
+    def order_by(self, *fields):
+        return list(self._items)
+
+
+class _WorkspacePayloadCursorStub:
+    product_rows = {
+        1000: (2000, "Root Product", 1, 1, "Ships", 10),
+        3001: (3000, "Child Product", 1, 1, "Modules", 11),
+    }
+    material_rows = {
+        1000: [(3000, "Child Product", 10), (34, "Tritanium", 100)],
+        3001: [],
+    }
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=None):
+        query = " ".join(str(sql).split())
+        blueprint_type_id = int((params or [0])[0] or 0)
+        if "SELECT p.product_eve_type_id" in query:
+            row = self.product_rows.get(blueprint_type_id)
+            self._result = [row] if row else []
+            return
+        if "SELECT m.material_eve_type_id, COALESCE" in query:
+            self._result = self.material_rows.get(blueprint_type_id, [])
+            return
+        if "SELECT m.material_eve_type_id, m.quantity" in query:
+            self._result = [
+                (type_id, quantity)
+                for type_id, _name, quantity in self.material_rows.get(
+                    blueprint_type_id, []
+                )
+            ]
+            return
+        if "SELECT t.meta_group_id_raw, g.category_id" in query:
+            self._result = [(None, None)]
+            return
+        if "SELECT COALESCE(g.name, ''), g.id" in query:
+            self._result = [("", None)]
+            return
+        self._result = []
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return self._result
 
 
 class ProductionProjectImportTests(TestCase):
@@ -214,6 +279,111 @@ class ProductionProjectImportTests(TestCase):
                 },
                 {"blueprint_type_id": 23916},
             )
+        )
+
+    def test_workspace_payload_resolves_user_blueprints_once_for_project_tree(
+        self,
+    ) -> None:
+        project_item = SimpleNamespace(
+            id=1,
+            type_id=2000,
+            type_name="Root Product",
+            quantity_requested=1,
+            is_selected=True,
+            is_craftable=True,
+            inclusion_mode="produce",
+            blueprint_type_id=1000,
+            category_key="manual",
+            category_label="Manual list",
+            category_order=90,
+        )
+        project = SimpleNamespace(
+            id=1,
+            project_ref="abc123def4",
+            name="Root Project",
+            status="draft",
+            source_kind="manual",
+            workspace_state={},
+            notes="",
+            user=object(),
+            items=_ProjectItemsQueryStub([project_item]),
+        )
+        inventory_map = {
+            1000: {
+                "original": {"me": 10, "te": 20},
+                "best_copy": None,
+                "copy_runs_total": 0,
+            },
+            3001: {
+                "original": {"me": 8, "te": 16},
+                "best_copy": None,
+                "copy_runs_total": 0,
+            },
+        }
+
+        with (
+            patch(
+                "indy_hub.services.production_projects.connection.cursor",
+                side_effect=lambda: _WorkspacePayloadCursorStub(),
+            ),
+            patch(
+                "indy_hub.services.production_projects._resolve_type_names",
+                return_value={
+                    34: "Tritanium",
+                    1000: "Root Blueprint",
+                    2000: "Root Product",
+                    3000: "Child Product",
+                    3001: "Child Blueprint",
+                },
+            ),
+            patch(
+                "indy_hub.services.production_projects._resolve_preferred_blueprint_for_product",
+                side_effect=lambda type_id: {3000: 3001}.get(int(type_id)),
+            ),
+            patch(
+                "indy_hub.services.production_projects._resolve_market_groups",
+                return_value={},
+            ),
+            patch(
+                "indy_hub.services.production_projects.is_base_item_material_efficiency_exempt",
+                return_value=False,
+            ),
+            patch(
+                "indy_hub.services.production_projects.build_craft_time_map",
+                return_value={},
+            ),
+            patch(
+                "indy_hub.services.production_projects.build_craft_character_advisor",
+                return_value={"characters": [], "items": {}, "summary": {}},
+            ),
+            patch(
+                "indy_hub.services.production_projects.build_craft_structure_planner",
+                return_value={},
+            ),
+            patch(
+                "indy_hub.services.production_projects._resolve_user_blueprint_inventory",
+                return_value=inventory_map,
+            ) as mock_inventory,
+            patch(
+                "indy_hub.services.production_projects._build_project_blueprint_configs_grouped",
+                return_value=([], []),
+            ) as mock_blueprint_configs,
+        ):
+            payload = build_project_workspace_payload(project)
+
+        mock_inventory.assert_called_once()
+        self.assertSetEqual(
+            set(mock_inventory.call_args.kwargs["blueprint_type_ids"]),
+            {1000, 3001},
+        )
+        self.assertEqual(payload["me"], 10)
+        self.assertEqual(
+            payload["materials_tree"][0]["sub_materials"][0]["blueprint_type_id"],
+            3001,
+        )
+        self.assertIs(
+            mock_blueprint_configs.call_args.kwargs["user_bp_map"],
+            inventory_map,
         )
 
     @patch("indy_hub.services.production_projects.connection.cursor")

--- a/indy_hub/urls.py
+++ b/indy_hub/urls.py
@@ -39,6 +39,7 @@ from .views.industry import (
     bp_update_copy_request,
     craft_bp,
     craft_project,
+    craft_project_stock_refresh_status,
     delete_production_project,
 )
 from .views.industry import (
@@ -481,6 +482,11 @@ urlpatterns = [
         "material-exchange/api/debug-tokens/<int:corp_id>/",
         material_exchange_debug_tokens,
         name="material_exchange_debug_tokens",
+    ),
+    path(
+        "craft/project/api/stock-refresh-status/",
+        craft_project_stock_refresh_status,
+        name="craft_project_stock_refresh_status",
     ),
     path(
         "material-exchange/sell/",

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.core.paginator import Paginator
 from django.db import connection
@@ -51,6 +52,7 @@ from ..models import (
     BlueprintCopyMessage,
     BlueprintCopyOffer,
     BlueprintCopyRequest,
+    CachedCharacterAsset,
     IndustryActivityMixin,
     IndustryJob,
     IndustrySkillSnapshot,
@@ -122,6 +124,11 @@ from ..tasks.industry import (
     STRUCTURE_SCOPE,
     request_manual_refresh,
 )
+from ..tasks.material_exchange import (
+    ESI_DOWN_COOLDOWN_SECONDS,
+    me_sell_assets_esi_cooldown_key,
+    refresh_material_exchange_sell_user_assets,
+)
 from ..utils.analytics import emit_view_analytics_event
 from ..utils.discord_actions import (
     _DEFAULT_TOKEN_MAX_AGE,
@@ -166,6 +173,189 @@ else:  # pragma: no cover - eve_sde not installed
     EveType = None
 
 logger = get_extension_logger(__name__)
+CRAFT_PROJECT_STOCK_CACHE_MAX_AGE_MINUTES = 60
+CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS = 10 * 60
+CRAFT_PROJECT_STOCK_REFRESH_STALE_PROGRESS_SECONDS = 180
+
+
+def _craft_project_stock_refresh_progress_key(user_id: int) -> str:
+    return f"indy_hub:material_exchange:sell_assets_refresh:{int(user_id)}"
+
+
+def _ensure_craft_project_stock_refresh_started(user) -> dict:
+    """Start an async character asset refresh for Craft stock when needed."""
+
+    progress_key = _craft_project_stock_refresh_progress_key(int(user.id))
+    state = cache.get(progress_key) or {}
+
+    cooldown_until = cache.get(me_sell_assets_esi_cooldown_key(int(user.id)))
+    if cooldown_until:
+        try:
+            retry_seconds = max(
+                0, int(float(cooldown_until) - timezone.now().timestamp())
+            )
+        except (TypeError, ValueError):
+            retry_seconds = int(ESI_DOWN_COOLDOWN_SECONDS)
+        state = {
+            "running": False,
+            "finished": True,
+            "error": "esi_down",
+            "retry_after_minutes": int((retry_seconds + 59) // 60),
+        }
+        cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
+        return state
+
+    if state.get("running"):
+        try:
+            started_at = float(state.get("started_at") or 0)
+            last_progress_at = float(state.get("last_progress_at") or started_at or 0)
+            elapsed = timezone.now().timestamp() - last_progress_at
+        except (TypeError, ValueError):
+            elapsed = 0
+        if not state.get("started_at") and not state.get("last_progress_at"):
+            elapsed = 999999
+        if elapsed <= CRAFT_PROJECT_STOCK_REFRESH_STALE_PROGRESS_SECONDS:
+            return state
+        state.update({"running": False, "finished": True, "error": "timeout"})
+        cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
+
+    try:
+        total = int(
+            CharacterOwnership.objects.filter(user=user)
+            .values_list("character__character_id", flat=True)
+            .distinct()
+            .count()
+        )
+        has_assets_token = (
+            Token.objects.filter(user=user)
+            .require_scopes(["esi-assets.read_assets.v1"])
+            .require_valid()
+            .exists()
+        )
+    except Exception:
+        total = 0
+        has_assets_token = False
+
+    if total > 0 and not has_assets_token:
+        state = {
+            "running": False,
+            "finished": True,
+            "error": "missing_assets_scope",
+            "total": total,
+            "done": 0,
+            "failed": 0,
+        }
+        cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
+        return state
+
+    started_at = timezone.now().timestamp()
+    state = {
+        "running": True,
+        "finished": False,
+        "error": None,
+        "total": total,
+        "done": 0,
+        "failed": 0,
+        "started_at": started_at,
+        "last_progress_at": started_at,
+    }
+    cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
+
+    try:
+        task_result = refresh_material_exchange_sell_user_assets.delay(int(user.id))
+        logger.info(
+            "Started Craft stock asset refresh task for user %s (task_id=%s)",
+            user.id,
+            task_result.id,
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to start Craft stock asset refresh task for user %s: %s",
+            user.id,
+            exc,
+            exc_info=True,
+        )
+        state.update({"running": False, "finished": True, "error": "task_start_failed"})
+        cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
+
+    return state
+
+
+def _get_craft_project_stock_refresh_progress(user) -> dict:
+    latest_update = (
+        CachedCharacterAsset.objects.filter(user=user)
+        .order_by("-synced_at")
+        .values_list("synced_at", flat=True)
+        .first()
+    )
+    try:
+        stock_is_stale = (
+            not latest_update
+            or (timezone.now() - latest_update).total_seconds()
+            > CRAFT_PROJECT_STOCK_CACHE_MAX_AGE_MINUTES * 60
+        )
+    except Exception:
+        stock_is_stale = True
+
+    progress_key = _craft_project_stock_refresh_progress_key(int(user.id))
+    progress = cache.get(progress_key) or {}
+    if stock_is_stale:
+        progress = _ensure_craft_project_stock_refresh_started(user)
+    return progress
+
+
+def _get_latest_character_asset_sync(user):
+    return (
+        CachedCharacterAsset.objects.filter(user=user)
+        .order_by("-synced_at")
+        .values_list("synced_at", flat=True)
+        .first()
+    )
+
+
+@indy_hub_access_required
+@login_required
+@require_http_methods(["GET"])
+def craft_project_stock_refresh_status(request):
+    emit_view_analytics_event(
+        view_name="industry.craft_project_stock_refresh_status", request=request
+    )
+
+    progress_key = _craft_project_stock_refresh_progress_key(int(request.user.id))
+    state = cache.get(progress_key) or {
+        "running": False,
+        "finished": False,
+        "error": None,
+        "total": 0,
+        "done": 0,
+        "failed": 0,
+    }
+    if state.get("running"):
+        try:
+            started_at = float(state.get("started_at") or 0)
+            last_progress_at = float(state.get("last_progress_at") or started_at or 0)
+            elapsed = timezone.now().timestamp() - last_progress_at
+        except (TypeError, ValueError):
+            elapsed = 0
+        if not state.get("started_at") and not state.get("last_progress_at"):
+            elapsed = 999999
+        if elapsed > CRAFT_PROJECT_STOCK_REFRESH_STALE_PROGRESS_SECONDS:
+            state.update({"running": False, "finished": True, "error": "timeout"})
+            cache.set(
+                progress_key,
+                state,
+                CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS,
+            )
+
+    latest_update = _get_latest_character_asset_sync(request.user)
+    response = dict(state)
+    response["synced_at"] = latest_update.isoformat() if latest_update else ""
+    initial_synced_at = str(request.GET.get("since") or "").strip()
+    response["changed"] = bool(
+        latest_update and latest_update.isoformat() != initial_synced_at
+    )
+    return JsonResponse(response)
+
 
 try:
     # Alliance Auth
@@ -2556,6 +2746,7 @@ def craft_project(request, project_ref):
 
     render_workspace_state = dict(payload.get("workspace_state") or workspace_state)
     render_workspace_state["active_tab"] = active_tab
+    stock_refresh_progress = _get_craft_project_stock_refresh_progress(request.user)
 
     payload.update(
         {
@@ -2565,6 +2756,7 @@ def craft_project(request, project_ref):
                 request.user,
                 allow_refresh=False,
             ),
+            "character_stock_refresh": stock_refresh_progress,
             "urls": {
                 "save": reverse(
                     "indy_hub:save_production_project_workspace",
@@ -2576,6 +2768,9 @@ def craft_project(request, project_ref):
                 "craft_bp_payload": reverse(
                     "indy_hub:production_project_payload",
                     args=[project.project_ref],
+                ),
+                "craft_stock_refresh_status": reverse(
+                    "indy_hub:craft_project_stock_refresh_status"
                 ),
                 "structure_solar_system_search": reverse(
                     "indy_hub:industry_structure_solar_system_search"

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -105,6 +105,12 @@ from ..services.industry_structures import (
     search_solar_system_options,
 )
 from ..services.market_prices import MarketPriceError, fetch_adjusted_prices
+from ..services.material_exchange_assets import (
+    SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS,
+    ensure_sell_assets_refresh_started,
+    get_sell_assets_refresh_progress,
+    material_exchange_sell_assets_progress_key,
+)
 from ..services.production_projects import (
     build_project_workspace_payload,
     create_project_from_single_blueprint,
@@ -123,11 +129,6 @@ from ..tasks.industry import (
     MANUAL_REFRESH_KIND_JOBS,
     STRUCTURE_SCOPE,
     request_manual_refresh,
-)
-from ..tasks.material_exchange import (
-    ESI_DOWN_COOLDOWN_SECONDS,
-    me_sell_assets_esi_cooldown_key,
-    refresh_material_exchange_sell_user_assets,
 )
 from ..utils.analytics import emit_view_analytics_event
 from ..utils.discord_actions import (
@@ -174,111 +175,18 @@ else:  # pragma: no cover - eve_sde not installed
 
 logger = get_extension_logger(__name__)
 CRAFT_PROJECT_STOCK_CACHE_MAX_AGE_MINUTES = 60
-CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS = 10 * 60
-CRAFT_PROJECT_STOCK_REFRESH_STALE_PROGRESS_SECONDS = 180
+CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS = (
+    SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS
+)
 
 
 def _craft_project_stock_refresh_progress_key(user_id: int) -> str:
-    return f"indy_hub:material_exchange:sell_assets_refresh:{int(user_id)}"
+    return material_exchange_sell_assets_progress_key(int(user_id))
 
 
 def _ensure_craft_project_stock_refresh_started(user) -> dict:
     """Start an async character asset refresh for Craft stock when needed."""
-
-    progress_key = _craft_project_stock_refresh_progress_key(int(user.id))
-    state = cache.get(progress_key) or {}
-
-    cooldown_until = cache.get(me_sell_assets_esi_cooldown_key(int(user.id)))
-    if cooldown_until:
-        try:
-            retry_seconds = max(
-                0, int(float(cooldown_until) - timezone.now().timestamp())
-            )
-        except (TypeError, ValueError):
-            retry_seconds = int(ESI_DOWN_COOLDOWN_SECONDS)
-        state = {
-            "running": False,
-            "finished": True,
-            "error": "esi_down",
-            "retry_after_minutes": int((retry_seconds + 59) // 60),
-        }
-        cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
-        return state
-
-    if state.get("running"):
-        try:
-            started_at = float(state.get("started_at") or 0)
-            last_progress_at = float(state.get("last_progress_at") or started_at or 0)
-            elapsed = timezone.now().timestamp() - last_progress_at
-        except (TypeError, ValueError):
-            elapsed = 0
-        if not state.get("started_at") and not state.get("last_progress_at"):
-            elapsed = 999999
-        if elapsed <= CRAFT_PROJECT_STOCK_REFRESH_STALE_PROGRESS_SECONDS:
-            return state
-        state.update({"running": False, "finished": True, "error": "timeout"})
-        cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
-
-    try:
-        total = int(
-            CharacterOwnership.objects.filter(user=user)
-            .values_list("character__character_id", flat=True)
-            .distinct()
-            .count()
-        )
-        has_assets_token = (
-            Token.objects.filter(user=user)
-            .require_scopes(["esi-assets.read_assets.v1"])
-            .require_valid()
-            .exists()
-        )
-    except Exception:
-        total = 0
-        has_assets_token = False
-
-    if total > 0 and not has_assets_token:
-        state = {
-            "running": False,
-            "finished": True,
-            "error": "missing_assets_scope",
-            "total": total,
-            "done": 0,
-            "failed": 0,
-        }
-        cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
-        return state
-
-    started_at = timezone.now().timestamp()
-    state = {
-        "running": True,
-        "finished": False,
-        "error": None,
-        "total": total,
-        "done": 0,
-        "failed": 0,
-        "started_at": started_at,
-        "last_progress_at": started_at,
-    }
-    cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
-
-    try:
-        task_result = refresh_material_exchange_sell_user_assets.delay(int(user.id))
-        logger.info(
-            "Started Craft stock asset refresh task for user %s (task_id=%s)",
-            user.id,
-            task_result.id,
-        )
-    except Exception as exc:
-        logger.error(
-            "Failed to start Craft stock asset refresh task for user %s: %s",
-            user.id,
-            exc,
-            exc_info=True,
-        )
-        state.update({"running": False, "finished": True, "error": "task_start_failed"})
-        cache.set(progress_key, state, CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS)
-
-    return state
+    return ensure_sell_assets_refresh_started(user, log_context="Craft stock asset")
 
 
 def _get_craft_project_stock_refresh_progress(user) -> dict:
@@ -298,7 +206,8 @@ def _get_craft_project_stock_refresh_progress(user) -> dict:
         stock_is_stale = True
 
     progress_key = _craft_project_stock_refresh_progress_key(int(user.id))
-    progress = cache.get(progress_key) or {}
+    cached_progress = cache.get(progress_key)
+    progress = get_sell_assets_refresh_progress(int(user.id)) if cached_progress else {}
     if stock_is_stale:
         progress = _ensure_craft_project_stock_refresh_started(user)
     return progress
@@ -321,31 +230,7 @@ def craft_project_stock_refresh_status(request):
         view_name="industry.craft_project_stock_refresh_status", request=request
     )
 
-    progress_key = _craft_project_stock_refresh_progress_key(int(request.user.id))
-    state = cache.get(progress_key) or {
-        "running": False,
-        "finished": False,
-        "error": None,
-        "total": 0,
-        "done": 0,
-        "failed": 0,
-    }
-    if state.get("running"):
-        try:
-            started_at = float(state.get("started_at") or 0)
-            last_progress_at = float(state.get("last_progress_at") or started_at or 0)
-            elapsed = timezone.now().timestamp() - last_progress_at
-        except (TypeError, ValueError):
-            elapsed = 0
-        if not state.get("started_at") and not state.get("last_progress_at"):
-            elapsed = 999999
-        if elapsed > CRAFT_PROJECT_STOCK_REFRESH_STALE_PROGRESS_SECONDS:
-            state.update({"running": False, "finished": True, "error": "timeout"})
-            cache.set(
-                progress_key,
-                state,
-                CRAFT_PROJECT_STOCK_REFRESH_PROGRESS_TTL_SECONDS,
-            )
+    state = get_sell_assets_refresh_progress(int(request.user.id))
 
     latest_update = _get_latest_character_asset_sync(request.user)
     response = dict(state)

--- a/indy_hub/views/material_exchange.py
+++ b/indy_hub/views/material_exchange.py
@@ -41,6 +41,11 @@ from ..models import (
     SDEMarketGroup,
 )
 from ..services.asset_cache import get_corp_divisions_cached, get_user_assets_cached
+from ..services.material_exchange_assets import (
+    ensure_sell_assets_refresh_started,
+    get_sell_assets_refresh_progress,
+    material_exchange_sell_assets_progress_key,
+)
 from ..tasks.material_exchange import (
     ESI_DOWN_COOLDOWN_SECONDS,
     ME_STOCK_SYNC_CACHE_VERSION,
@@ -50,7 +55,6 @@ from ..tasks.material_exchange import (
     me_stock_sync_cache_version_key,
     me_user_assets_cache_version_key,
     refresh_material_exchange_buy_stock,
-    refresh_material_exchange_sell_user_assets,
     sync_material_exchange_prices,
     sync_material_exchange_stock,
 )
@@ -614,114 +618,12 @@ def _resolve_user_character_names_map(user) -> dict[int, str]:
 
 
 def _me_sell_assets_progress_key(user_id: int) -> str:
-    return f"indy_hub:material_exchange:sell_assets_refresh:{int(user_id)}"
+    return material_exchange_sell_assets_progress_key(int(user_id))
 
 
 def _ensure_sell_assets_refresh_started(user) -> dict:
     """Start (if needed) an async refresh of user assets and return the current progress state."""
-
-    progress_key = _me_sell_assets_progress_key(user.id)
-    ttl_seconds = 10 * 60
-    state = cache.get(progress_key) or {}
-
-    cooldown_until = cache.get(me_sell_assets_esi_cooldown_key(int(user.id)))
-    if cooldown_until:
-        try:
-            retry_seconds = max(
-                0, int(float(cooldown_until) - timezone.now().timestamp())
-            )
-        except (TypeError, ValueError):
-            retry_seconds = int(ESI_DOWN_COOLDOWN_SECONDS)
-        retry_minutes = int((retry_seconds + 59) // 60)
-        state = {
-            "running": False,
-            "finished": True,
-            "error": "esi_down",
-            "retry_after_minutes": retry_minutes,
-        }
-        cache.set(progress_key, state, ttl_seconds)
-        return state
-    if state.get("running"):
-        try:
-            started_at = float(state.get("started_at") or 0)
-            last_progress_at = float(state.get("last_progress_at") or started_at or 0)
-            elapsed = timezone.now().timestamp() - last_progress_at
-        except (TypeError, ValueError):
-            elapsed = 0
-        if not state.get("started_at") and not state.get("last_progress_at"):
-            elapsed = 999999
-        if elapsed <= 180:
-            return state
-        state.update({"running": False, "finished": True, "error": "timeout"})
-        cache.set(progress_key, state, ttl_seconds)
-
-    # Always refresh on page open unless explicitly suppressed.
-    try:
-        # Alliance Auth
-        from allianceauth.authentication.models import CharacterOwnership
-        from esi.models import Token
-
-        total = int(
-            CharacterOwnership.objects.filter(user=user)
-            .values_list("character__character_id", flat=True)
-            .distinct()
-            .count()
-        )
-
-        has_assets_token = (
-            Token.objects.filter(user=user)
-            .require_scopes(["esi-assets.read_assets.v1"])
-            .require_valid()
-            .exists()
-        )
-    except Exception:
-        total = 0
-        has_assets_token = False
-
-    if total > 0 and not has_assets_token:
-        state = {
-            "running": False,
-            "finished": True,
-            "error": "missing_assets_scope",
-            "total": total,
-            "done": 0,
-            "failed": 0,
-        }
-        cache.set(progress_key, state, ttl_seconds)
-        return state
-
-    started_at = timezone.now().timestamp()
-    state = {
-        "running": True,
-        "finished": False,
-        "error": None,
-        "total": total,
-        "done": 0,
-        "failed": 0,
-        "started_at": started_at,
-        "last_progress_at": started_at,
-    }
-    cache.set(progress_key, state, ttl_seconds)
-
-    try:
-        task_result = refresh_material_exchange_sell_user_assets.delay(int(user.id))
-        logger.info(
-            "Started asset refresh task for user %s (task_id=%s)",
-            user.id,
-            task_result.id,
-        )
-    except Exception as exc:
-        # Fallback: mark as finished; UI will stop polling.
-        logger.error(
-            "Failed to start asset refresh task for user %s: %s",
-            user.id,
-            exc,
-            exc_info=True,
-        )
-        state.update({"running": False, "finished": True, "error": "task_start_failed"})
-        cache.set(progress_key, state, ttl_seconds)
-
-    return state
+    return ensure_sell_assets_refresh_started(user, log_context="asset")
 
 
 @login_required
@@ -735,27 +637,7 @@ def material_exchange_sell_assets_refresh_status(request):
     if not _is_material_exchange_enabled():
         return JsonResponse({"running": False, "finished": True, "error": "disabled"})
 
-    progress_key = _me_sell_assets_progress_key(request.user.id)
-    state = cache.get(progress_key) or {
-        "running": False,
-        "finished": False,
-        "error": None,
-        "total": 0,
-        "done": 0,
-        "failed": 0,
-    }
-    if state.get("running"):
-        try:
-            started_at = float(state.get("started_at") or 0)
-            last_progress_at = float(state.get("last_progress_at") or started_at or 0)
-            elapsed = timezone.now().timestamp() - last_progress_at
-        except (TypeError, ValueError):
-            elapsed = 0
-        if not state.get("started_at") and not state.get("last_progress_at"):
-            elapsed = 999999
-        if elapsed > 180:
-            state.update({"running": False, "finished": True, "error": "timeout"})
-            cache.set(progress_key, state, 10 * 60)
+    state = get_sell_assets_refresh_progress(int(request.user.id))
     response = dict(state)
     try:
         last_update = (


### PR DESCRIPTION
## Description

Fixes #85

This PR fixes Craft project blueprint handling and refreshes the related Craft UI behavior.

Summary of changes:
- Ensures all blueprints used by a Craft project are present in the Blueprints tab, including final product blueprints such as Chimera Blueprint.
- Fixes ME/TE handling so owned blueprint values are used correctly and legacy 0/0 overrides do not incorrectly replace real values.
- Invalidates stale cached project payloads when required blueprint configuration data is missing.
- Updates the Plan tab live when blueprint ME/TE values are changed.
- Adds clearer zero-price warnings in the Buy / Financial Planner workflow.
- Improves Craft page startup performance and reduces browser console warnings.
- Updates the Stock tab to show only available stock lines and explain that zero-stock lines are hidden.
- Starts character asset refresh in the background using the existing Material Hub asset refresh pattern.
- Adds Stock tab refresh status polling with a visible reload prompt when refreshed asset data changes the cached stock snapshot.
- Improves final refresh messages so the Stock tab does not silently hide the background refresh status.

Motivation and context:
Craft projects could miss final blueprints in the Blueprints tab and could display incorrect ME/TE values in planning calculations. This made projects such as `/indy_hub/craft/project/yaomaljse2/` incomplete or misleading, especially when checking final product blueprints like Chimera. The Stock tab also needed clearer cache-aware refresh behavior compatible with Alliance Auth v4 and v5.

Dependencies:
No new dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings