### PR TITLE
Fix blueprint original classification on sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,11 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Internals: replaced removed Django 5 timezone helpers (`django.utils.timezone.utc`) with `datetime.timezone.utc` across industry tasks, job notifications, and Material Exchange flows so the same code path runs on Django 4.2 and Django 5.2.
 - Migrations: added schema-alignment migrations (`0098`, `0099`) that normalize corporation sharing scope choices and rename a few indexes, eliminating Django `makemigrations` drift on both Django 4.2 and Django 5.2.
 - Crafting Projects: the project *Blueprints* tab now organises blueprint cards into one accordion section per product category (Battlecruiser, Battleship, Combat Drone, Module, Charge, …), sorted alphabetically. Cards whose product has no resolved category land in a single "Other" group rendered last. Mixed projects are much easier to scan than the single flat "Project blueprints" list.
+- Admin: the Blueprint changelist now displays the blueprint type, ownership scope, real owner entity, and corporation id, with matching filters and search fields, so corporation blueprints are no longer easy to confuse with personal character blueprints.
 
 ### Fixed
+
+- Blueprints: ESI rows with `runs=-1` are now classified as originals even when ESI also reports `quantity=-2`, character and corporation blueprint syncs persist a freshly computed `bp_type`, and a data migration repairs stale rows left behind by older releases where BPOs could remain labelled as copies after upgrade (issue #86).
 
 - Material Exchange: clicking a stale Discord link to a sell or buy order that has been completed, cancelled, or deleted now lands on a friendly "order no longer available" page (HTTP 404) with a button back to the Material Exchange index, instead of Django's raw 404 debug message. Honors the `next=` query parameter when present and safe (issue #68).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - CharLink hook: added the `esi-location.read_online.v1` scope to the personal authorization set so freshly-linked characters keep online-status access without an extra ESI re-authorization round trip.
 - Forms: Indy Hub now raises Django's `DATA_UPLOAD_MAX_NUMBER_FIELDS` to 50 000 at startup (configurable via `INDY_HUB_MAX_FORM_FIELDS`) so Material Exchange and craft project configuration pages no longer raise `TooManyFieldsSent` when thousands of EVE market groups or type ids are submitted at once.
 - Forms: Indy Hub now also raises Django's `DATA_UPLOAD_MAX_MEMORY_SIZE` to 50 MB at startup (configurable via `INDY_HUB_MAX_REQUEST_BODY_BYTES`) so saving a craft project workspace no longer fails with a generic "Failed to save table" notification when the JSON payload (cached project snapshot, decisions, structures, …) exceeds Django's 2.5 MB default body limit.
+- Blueprint Sharing: added a copy-installation cost breakdown modal to the fulfill queue, including EIV-derived install cost, structure and rig bonuses, SCI, facility/SCC taxes, and Alpha clone tax rows.
 
 ### Changed
 
@@ -24,10 +25,15 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Migrations: added schema-alignment migrations (`0098`, `0099`) that normalize corporation sharing scope choices and rename a few indexes, eliminating Django `makemigrations` drift on both Django 4.2 and Django 5.2.
 - Crafting Projects: the project *Blueprints* tab now organises blueprint cards into one accordion section per product category (Battlecruiser, Battleship, Combat Drone, Module, Charge, …), sorted alphabetically. Cards whose product has no resolved category land in a single "Other" group rendered last. Mixed projects are much easier to scan than the single flat "Project blueprints" list.
 - Admin: the Blueprint changelist now displays the blueprint type, ownership scope, real owner entity, and corporation id, with matching filters and search fields, so corporation blueprints are no longer easy to confuse with personal character blueprints.
+- Blueprint Sharing: copy-request price estimates are now fetched lazily when the request modal opens and displayed as an indicative amount, avoiding page-load work for estimates the user never views (issue #84).
 
 ### Fixed
 
 - Blueprints: ESI rows with `runs=-1` are now classified as originals even when ESI also reports `quantity=-2`, character and corporation blueprint syncs persist a freshly computed `bp_type`, and a data migration repairs stale rows left behind by older releases where BPOs could remain labelled as copies after upgrade (issue #86).
+
+- Navigation: Indy Hub dropdown labels remain visible in the mobile Alliance Auth menu instead of collapsing to icon-only entries (issue #78).
+
+- Blueprint Sharing: copy-installation estimates on fulfill requests now use manufacturing material EIV, scale totals by the selected copy count, round ISK rows consistently, use two-decimal SCI percentages, and keep the grand-total label aligned with the requested number of copies.
 
 - Material Exchange: clicking a stale Discord link to a sell or buy order that has been completed, cancelled, or deleted now lands on a friendly "order no longer available" page (HTTP 404) with a button back to the Material Exchange index, instead of Django's raw 404 debug message. Honors the `next=` query parameter when present and safe (issue #68).
 

--- a/indy_hub/admin.py
+++ b/indy_hub/admin.py
@@ -104,17 +104,39 @@ admin.site.register(User, IndyHubUserAdmin)
 class BlueprintAdmin(admin.ModelAdmin):
     list_display = [
         "type_name",
+        "bp_type",
+        "owner_scope",
+        "owner_entity",
         "owner_user",
         "character_id",
+        "corporation_id",
         "quantity",
         "material_efficiency",
         "time_efficiency",
         "runs",
         "last_updated",
     ]
-    list_filter = ["owner_user", "character_id", "quantity", "last_updated"]
-    search_fields = ["type_name", "type_id", "owner_user__username"]
+    list_filter = [
+        "owner_kind",
+        "bp_type",
+        "owner_user",
+        "character_id",
+        "corporation_id",
+        "quantity",
+        "last_updated",
+    ]
+    search_fields = [
+        "type_name",
+        "type_id",
+        "item_id",
+        "owner_user__username",
+        "character_id",
+        "character_name",
+        "corporation_id",
+        "corporation_name",
+    ]
     readonly_fields = ["item_id", "last_updated", "created_at"]
+    list_select_related = ["owner_user"]
 
     fieldsets = (
         (
@@ -122,7 +144,11 @@ class BlueprintAdmin(admin.ModelAdmin):
             {
                 "fields": (
                     "owner_user",
+                    "owner_kind",
                     "character_id",
+                    "character_name",
+                    "corporation_id",
+                    "corporation_name",
                     "item_id",
                     "type_id",
                     "type_name",
@@ -132,13 +158,31 @@ class BlueprintAdmin(admin.ModelAdmin):
         ("Location", {"fields": ("location_id", "location_name", "location_flag")}),
         (
             "Blueprint Details",
-            {"fields": ("quantity", "material_efficiency", "time_efficiency", "runs")},
+            {
+                "fields": (
+                    "bp_type",
+                    "quantity",
+                    "material_efficiency",
+                    "time_efficiency",
+                    "runs",
+                )
+            },
         ),
         (
             "Timestamps",
             {"fields": ("created_at", "last_updated"), "classes": ("collapse",)},
         ),
     )
+
+    @admin.display(description="Scope", ordering="owner_kind")
+    def owner_scope(self, obj):
+        return obj.get_owner_kind_display()
+
+    @admin.display(description="Owner entity")
+    def owner_entity(self, obj):
+        if obj.owner_kind == Blueprint.OwnerKind.CORPORATION:
+            return obj.corporation_name or obj.corporation_id or "-"
+        return obj.character_name or obj.character_id or "-"
 
 
 @admin.register(IndustryJob)

--- a/indy_hub/migrations/0100_repair_blueprint_bp_type_classification.py
+++ b/indy_hub/migrations/0100_repair_blueprint_bp_type_classification.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+# Django
+from django.db import migrations
+
+BP_TYPE_REACTION = "REACTION"
+BP_TYPE_ORIGINAL = "ORIGINAL"
+BP_TYPE_COPY = "COPY"
+
+
+def classify_blueprint(
+    *, quantity, runs, type_name, type_id, reaction_ids: set[int]
+) -> str:
+    try:
+        normalized_type_id = int(type_id or 0)
+    except (TypeError, ValueError):
+        normalized_type_id = 0
+
+    if normalized_type_id and normalized_type_id in reaction_ids:
+        return BP_TYPE_REACTION
+
+    name = (type_name or "").lower()
+    if "formula" in name or "reaction" in name:
+        return BP_TYPE_REACTION
+
+    if quantity == -1 or runs == -1:
+        return BP_TYPE_ORIGINAL
+    if quantity == -2:
+        return BP_TYPE_COPY
+    if quantity and quantity > 0:
+        return BP_TYPE_COPY
+
+    return BP_TYPE_ORIGINAL
+
+
+def repair_blueprint_bp_type(apps, schema_editor):
+    Blueprint = apps.get_model("indy_hub", "Blueprint")
+
+    try:
+        EveIndustryActivityProduct = apps.get_model(
+            "eveuniverse", "EveIndustryActivityProduct"
+        )
+    except LookupError:
+        EveIndustryActivityProduct = None
+
+    reaction_ids: set[int] = set()
+    if EveIndustryActivityProduct is not None:
+        reaction_ids = set(
+            EveIndustryActivityProduct.objects.filter(
+                activity_id__in=[9, 11]
+            ).values_list("eve_type_id", flat=True)
+        )
+
+    to_update = []
+    batch_size = 500
+    queryset = Blueprint.objects.only(
+        "id",
+        "bp_type",
+        "quantity",
+        "runs",
+        "type_name",
+        "type_id",
+    )
+    for blueprint in queryset.iterator():
+        desired_type = classify_blueprint(
+            quantity=blueprint.quantity,
+            runs=blueprint.runs,
+            type_name=blueprint.type_name,
+            type_id=blueprint.type_id,
+            reaction_ids=reaction_ids,
+        )
+        if blueprint.bp_type != desired_type:
+            blueprint.bp_type = desired_type
+            to_update.append(blueprint)
+
+        if len(to_update) >= batch_size:
+            Blueprint.objects.bulk_update(to_update, ["bp_type"])
+            to_update.clear()
+
+    if to_update:
+        Blueprint.objects.bulk_update(to_update, ["bp_type"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("indy_hub", "0099_align_index_names"),
+    ]
+
+    operations = [
+        migrations.RunPython(repair_blueprint_bp_type, migrations.RunPython.noop),
+    ]

--- a/indy_hub/models.py
+++ b/indy_hub/models.py
@@ -199,6 +199,7 @@ class Blueprint(models.Model):
         quantity: int | None,
         type_name: str | None,
         type_id: int | None,
+        runs: int | None = None,
     ) -> str:
         if type_id and is_reaction_blueprint(type_id):
             return cls.BPType.REACTION
@@ -207,10 +208,10 @@ class Blueprint(models.Model):
         if "formula" in name or "reaction" in name:
             return cls.BPType.REACTION
 
+        if quantity == -1 or runs == -1:
+            return cls.BPType.ORIGINAL
         if quantity == -2:
             return cls.BPType.COPY
-        if quantity == -1:
-            return cls.BPType.ORIGINAL
         if quantity and quantity > 0:
             return cls.BPType.COPY
 
@@ -221,6 +222,7 @@ class Blueprint(models.Model):
             quantity=self.quantity,
             type_name=self.type_name,
             type_id=self.type_id,
+            runs=self.runs,
         )
         if self.bp_type == "STACK":
             self.bp_type = self.BPType.COPY

--- a/indy_hub/tasks/industry.py
+++ b/indy_hub/tasks/industry.py
@@ -1205,6 +1205,8 @@ def update_blueprints_for_user(
                         )
                         if location_key is not None and not location_name:
                             location_name = f"{PLACEHOLDER_PREFIX}{location_key}"
+                        type_id = bp.get("type_id")
+                        type_name = get_type_name(type_id)
                         Blueprint.objects.update_or_create(
                             item_id=item_id,
                             defaults={
@@ -1214,7 +1216,7 @@ def update_blueprints_for_user(
                                 "corporation_name": "",
                                 "character_id": char_id,
                                 "blueprint_id": bp.get("blueprint_id"),
-                                "type_id": bp.get("type_id"),
+                                "type_id": type_id,
                                 "location_id": location_id,
                                 "location_name": location_name,
                                 "location_flag": bp.get("location_flag", ""),
@@ -1223,7 +1225,13 @@ def update_blueprints_for_user(
                                 "material_efficiency": bp.get("material_efficiency", 0),
                                 "runs": bp.get("runs", 0),
                                 "character_name": character_name,
-                                "type_name": get_type_name(bp.get("type_id")),
+                                "type_name": type_name,
+                                "bp_type": Blueprint.classify_bp_type(
+                                    quantity=bp.get("quantity"),
+                                    type_name=type_name,
+                                    type_id=type_id,
+                                    runs=bp.get("runs", 0),
+                                ),
                             },
                         )
 
@@ -1350,6 +1358,8 @@ def update_blueprints_for_user(
                         )
                         if location_key is not None and not location_name:
                             location_name = f"{PLACEHOLDER_PREFIX}{location_key}"
+                        type_id = bp.get("type_id")
+                        type_name = get_type_name(type_id)
                         Blueprint.objects.update_or_create(
                             item_id=item_id,
                             defaults={
@@ -1360,7 +1370,7 @@ def update_blueprints_for_user(
                                 "character_id": None,
                                 "character_name": acting_character_name,
                                 "blueprint_id": bp.get("blueprint_id"),
-                                "type_id": bp.get("type_id"),
+                                "type_id": type_id,
                                 "location_id": location_id,
                                 "location_name": location_name,
                                 "location_flag": bp.get("location_flag", ""),
@@ -1368,7 +1378,13 @@ def update_blueprints_for_user(
                                 "time_efficiency": bp.get("time_efficiency", 0),
                                 "material_efficiency": bp.get("material_efficiency", 0),
                                 "runs": bp.get("runs", 0),
-                                "type_name": get_type_name(bp.get("type_id")),
+                                "type_name": type_name,
+                                "bp_type": Blueprint.classify_bp_type(
+                                    quantity=bp.get("quantity"),
+                                    type_name=type_name,
+                                    type_id=type_id,
+                                    runs=bp.get("runs", 0),
+                                ),
                             },
                         )
 

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -790,6 +790,24 @@ class BlueprintModelClassificationTests(TestCase):
         blueprint.refresh_from_db()
         self.assertEqual(blueprint.bp_type, Blueprint.BPType.COPY)
 
+    def test_runs_minus_one_infers_original_type(self) -> None:
+        blueprint = Blueprint.objects.create(
+            owner_user=self.user,
+            character_id=9003,
+            item_id=9003001,
+            blueprint_id=9004001,
+            type_id=434343,
+            location_id=PUBLIC_STATION_ID,
+            location_flag="hangar",
+            quantity=-2,
+            time_efficiency=0,
+            material_efficiency=0,
+            runs=-1,
+            character_name="Classifier",
+            type_name="Widget Blueprint",
+        )
+        self.assertEqual(blueprint.bp_type, Blueprint.BPType.ORIGINAL)
+
     def test_update_or_create_persists_reclassified_bp_type(self) -> None:
         blueprint = Blueprint.objects.create(
             owner_user=self.user,
@@ -811,6 +829,32 @@ class BlueprintModelClassificationTests(TestCase):
         Blueprint.objects.update_or_create(
             item_id=blueprint.item_id,
             defaults={"quantity": -1},
+        )
+
+        blueprint.refresh_from_db()
+        self.assertEqual(blueprint.bp_type, Blueprint.BPType.ORIGINAL)
+
+    def test_update_or_create_reclassifies_runs_minus_one_as_original(self) -> None:
+        blueprint = Blueprint.objects.create(
+            owner_user=self.user,
+            character_id=9005,
+            item_id=9005001,
+            blueprint_id=9006001,
+            type_id=464646,
+            location_id=PUBLIC_STATION_ID,
+            location_flag="hangar",
+            quantity=-2,
+            time_efficiency=0,
+            material_efficiency=0,
+            runs=1,
+            character_name="Classifier",
+            type_name="Widget Blueprint",
+        )
+        self.assertEqual(blueprint.bp_type, Blueprint.BPType.COPY)
+
+        Blueprint.objects.update_or_create(
+            item_id=blueprint.item_id,
+            defaults={"quantity": -2, "runs": -1},
         )
 
         blueprint.refresh_from_db()


### PR DESCRIPTION
Fixes #86

Summary:
- Treat ESI blueprint rows with `runs=-1` as originals, even when `quantity=-2` is present.
- Persist a freshly computed `bp_type` during character and corporation blueprint syncs so existing rows cannot keep stale copy/original classifications.
- Add a data migration to repair existing stale blueprint rows after upgrade.
- Add regression tests for `runs=-1` original classification and `update_or_create` reclassification.

Validation:
- `/home/aadev/venv-v5/bin/python runtests.py indy_hub.tests.test_smoke.BlueprintModelClassificationTests`
- `DJANGO_SETTINGS_MODULE=testauth.settings.local /home/aadev/venv-v5/bin/python -m django makemigrations indy_hub --check --dry-run`
- `pre-commit run --files indy_hub/models.py indy_hub/tasks/industry.py indy_hub/tests/test_smoke.py indy_hub/migrations/0100_repair_blueprint_bp_type_classification.py`
- `git diff --check`