### PR TITLE
Fix sell paste catalog JSON parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Material Exchange: sell-page paste import now renders its catalog as a JSON array, guards the browser parser against malformed catalog payloads, and falls back to normalized visible row names when matching pasted lines, so valid lines such as `Core Probe Launcher I\t7` or `tritanium 2500` are matched instead of being reported as unknown (issue #82).
 
+- Material Exchange: sell-page paste import now resolves names missing from the local page catalog against the SDE database before classifying them, so an item is only shown as unknown when the name cannot be found in the DB; found items are instead sorted into accepted, not bought, or other-character states as appropriate (issue #82).
+
 - Material Exchange: the sell page no longer keeps reloading its dynamic content after the character asset refresh completes. The browser now marks the refresh as completed before swapping in the refreshed fragment, and the server skips restarting a recently finished asset refresh, preventing repeated `?refreshed=1` reload loops when the cached asset timestamp remains stale or empty.
 
 - Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Material Exchange: sell-page paste import now renders its catalog as a JSON array and guards the browser parser against malformed catalog payloads, so valid lines such as `Core Probe Launcher I\t7` are matched instead of being reported as unknown because `sellPasteCatalogData` parsed as a string (issue #82).
 
+- Material Exchange: the sell page no longer keeps reloading its dynamic content after the character asset refresh completes. The browser now marks the refresh as completed before swapping in the refreshed fragment, preventing the original polling block from scheduling another `?refreshed=1` reload loop.
+
 - Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).
 
 - Crafting Projects: reaction formulas are kept in the project *Blueprints* tab inside a dedicated *Reactions* section rendered last, so players can still see which formulas the project consumes. The cards show ownership only (*Original owned* / *Copy owned* / *Not available* — never the orange *Available* state) and hide the ME/TE inputs and copy-request controls, since reaction blueprints have fixed ME/TE and cannot be copied (issue #69 follow-up).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Material Exchange: sell-page paste import now resolves names missing from the local page catalog against the SDE database before classifying them, so an item is only shown as unknown when the name cannot be found in the DB; found items are instead sorted into accepted, not bought, or other-character states as appropriate (issue #82).
 
+- Tests: fresh tox runs against Alliance Auth latest no longer fail during Django setup when the legacy `bootstrapform` package is absent from the AA5 dependency set.
+
 - Material Exchange: the sell page no longer keeps reloading its dynamic content after the character asset refresh completes. The browser now marks the refresh as completed before swapping in the refreshed fragment, and the server skips restarting a recently finished asset refresh, preventing repeated `?refreshed=1` reload loops when the cached asset timestamp remains stale or empty.
 
 - Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Material Exchange: saving the hub configuration on `/indy_hub/material-exchange/config/` no longer crashes with `TooManyFieldsSent` when many market groups are toggled at once.
 
+- Material Exchange: sell-page paste import now renders its catalog as a JSON array and guards the browser parser against malformed catalog payloads, so valid lines such as `Core Probe Launcher I\t7` are matched instead of being reported as unknown because `sellPasteCatalogData` parsed as a string (issue #82).
+
 - Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).
 
 - Crafting Projects: reaction formulas are kept in the project *Blueprints* tab inside a dedicated *Reactions* section rendered last, so players can still see which formulas the project consumes. The cards show ownership only (*Original owned* / *Copy owned* / *Not available* — never the orange *Available* state) and hide the ME/TE inputs and copy-request controls, since reaction blueprints have fixed ME/TE and cannot be copied (issue #69 follow-up).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Material Exchange: saving the hub configuration on `/indy_hub/material-exchange/config/` no longer crashes with `TooManyFieldsSent` when many market groups are toggled at once.
 
-- Material Exchange: sell-page paste import now renders its catalog as a JSON array and guards the browser parser against malformed catalog payloads, so valid lines such as `Core Probe Launcher I\t7` are matched instead of being reported as unknown because `sellPasteCatalogData` parsed as a string (issue #82).
+- Material Exchange: sell-page paste import now renders its catalog as a JSON array, guards the browser parser against malformed catalog payloads, and falls back to normalized visible row names when matching pasted lines, so valid lines such as `Core Probe Launcher I\t7` or `tritanium 2500` are matched instead of being reported as unknown (issue #82).
 
 - Material Exchange: the sell page no longer keeps reloading its dynamic content after the character asset refresh completes. The browser now marks the refresh as completed before swapping in the refreshed fragment, preventing the original polling block from scheduling another `?refreshed=1` reload loop.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Material Exchange: sell-page paste import now renders its catalog as a JSON array, guards the browser parser against malformed catalog payloads, and falls back to normalized visible row names when matching pasted lines, so valid lines such as `Core Probe Launcher I\t7` or `tritanium 2500` are matched instead of being reported as unknown (issue #82).
 
-- Material Exchange: the sell page no longer keeps reloading its dynamic content after the character asset refresh completes. The browser now marks the refresh as completed before swapping in the refreshed fragment, preventing the original polling block from scheduling another `?refreshed=1` reload loop.
+- Material Exchange: the sell page no longer keeps reloading its dynamic content after the character asset refresh completes. The browser now marks the refresh as completed before swapping in the refreshed fragment, and the server skips restarting a recently finished asset refresh, preventing repeated `?refreshed=1` reload loops when the cached asset timestamp remains stale or empty.
 
 - Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).
 

--- a/indy_hub/services/material_exchange_assets.py
+++ b/indy_hub/services/material_exchange_assets.py
@@ -11,6 +11,7 @@ logger = get_extension_logger(__name__)
 
 SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS = 10 * 60
 SELL_ASSETS_REFRESH_STALE_PROGRESS_SECONDS = 180
+SELL_ASSETS_REFRESH_RECENT_FINISH_SECONDS = SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS
 
 
 def material_exchange_sell_assets_progress_key(user_id: int) -> str:
@@ -62,6 +63,25 @@ def get_sell_assets_refresh_progress(user_id: int) -> dict:
     progress_key = material_exchange_sell_assets_progress_key(int(user_id))
     state = cache.get(progress_key) or _default_sell_assets_refresh_state()
     return _mark_stale_progress_if_needed(state, progress_key=progress_key)
+
+
+def sell_assets_refresh_finished_recently(state: dict) -> bool:
+    if not state or state.get("running") or not state.get("finished"):
+        return False
+    if state.get("error") == "task_start_failed":
+        return False
+
+    try:
+        last_progress_at = float(
+            state.get("last_progress_at") or state.get("started_at") or 0
+        )
+    except (TypeError, ValueError):
+        return False
+    if last_progress_at <= 0:
+        return False
+
+    elapsed = timezone.now().timestamp() - last_progress_at
+    return 0 <= elapsed <= SELL_ASSETS_REFRESH_RECENT_FINISH_SECONDS
 
 
 def ensure_sell_assets_refresh_started(user, *, log_context: str = "asset") -> dict:

--- a/indy_hub/templates/indy_hub/material_exchange/sell.html
+++ b/indy_hub/templates/indy_hub/material_exchange/sell.html
@@ -104,7 +104,11 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
 
     if (sellPasteCatalogNode) {
         try {
-            JSON.parse(sellPasteCatalogNode.textContent || '[]').forEach(item => {
+            const parsedCatalog = JSON.parse(sellPasteCatalogNode.textContent || '[]');
+            if (!Array.isArray(parsedCatalog)) {
+                throw new TypeError('sellPasteCatalogData must be a JSON array');
+            }
+            parsedCatalog.forEach(item => {
                 if (item && item.name_key) {
                     sellPasteCatalog.set(item.name_key, item);
                 }

--- a/indy_hub/templates/indy_hub/material_exchange/sell.html
+++ b/indy_hub/templates/indy_hub/material_exchange/sell.html
@@ -64,7 +64,8 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
         activePollToken: 0,
         pollTimer: null,
         swapTimer: null,
-        swapRequestToken: 0
+        swapRequestToken: 0,
+        refreshCompleted: false
     };
     const sellPageState = window.__indyHubSellPageState;
     const initToken = ++sellPageState.initToken;
@@ -1019,6 +1020,7 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
 
     // Live asset refresh progress (per character)
     {% if assets_refreshing %}
+    if (!sellPageState.refreshCompleted) {
     sellPageState.activePollToken = initToken;
     const statusUrl = '{% url "indy_hub:material_exchange_sell_assets_refresh_status" %}';
     const lastUpdateNode = document.querySelector('.js-local-time[data-utc]');
@@ -1065,6 +1067,7 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
             }
 
             if (data.finished && (!error || error === 'timeout' || error === 'no_assets_fetched')) {
+                sellPageState.refreshCompleted = true;
                 const url = new URL(window.location.href);
                 if (url.searchParams.get('refreshed') !== '1') {
                     const initialTime = initialLastUpdate ? Date.parse(initialLastUpdate) : null;
@@ -1093,6 +1096,7 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
     }
 
     pollAssetsProgress();
+    }
     {% endif %}
 };
 

--- a/indy_hub/templates/indy_hub/material_exchange/sell.html
+++ b/indy_hub/templates/indy_hub/material_exchange/sell.html
@@ -102,6 +102,12 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
     const sellPasteCatalogNode = query('#sellPasteCatalogData');
     const sellCharacterSelect = query('#sellCharacterSelect');
     const sellPasteCatalog = new Map();
+    const sellPasteResolvedDbItems = new Map();
+    const sellPasteResolveQueue = new Map();
+    const sellPasteResolvePending = new Set();
+    let sellPasteResolveTimer = null;
+    let sellPasteResolveToken = 0;
+    const sellPasteResolveUrl = '{% url "indy_hub:material_exchange_sell_resolve_paste_items" %}';
 
     function registerSellPasteCatalogItem(item) {
         if (!item || !item.type_name) {
@@ -561,6 +567,104 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
         updateInvoice();
     }
 
+    function getSellPasteCsrfToken() {
+        return query('input[name="csrfmiddlewaretoken"]')?.value || '';
+    }
+
+    function getSelectedCharacterId() {
+        const url = new URL(window.location.href);
+        const characterParam = url.searchParams.get('character') || '';
+        if (/^\d+$/.test(characterParam)) {
+            return characterParam;
+        }
+
+        const selectedUrl = sellCharacterSelect?.selectedOptions?.[0]?.value || '';
+        if (selectedUrl) {
+            try {
+                const optionUrl = new URL(selectedUrl, window.location.origin);
+                const optionCharacter = optionUrl.searchParams.get('character') || '';
+                if (/^\d+$/.test(optionCharacter)) {
+                    return optionCharacter;
+                }
+            } catch (error) {
+                return '';
+            }
+        }
+        return '';
+    }
+
+    function scheduleSellPasteDbResolution(entries) {
+        entries.forEach(entry => {
+            if (!entry || !entry.key || sellPasteResolvedDbItems.has(entry.key) || sellPasteResolvePending.has(entry.key)) {
+                return;
+            }
+            sellPasteResolveQueue.set(entry.key, entry.label);
+        });
+
+        if (!sellPasteResolveQueue.size || !sellPasteResolveUrl) {
+            return;
+        }
+
+        if (sellPasteResolveTimer) {
+            window.clearTimeout(sellPasteResolveTimer);
+        }
+        const resolveToken = ++sellPasteResolveToken;
+        sellPasteResolveTimer = window.setTimeout(async () => {
+            sellPasteResolveTimer = null;
+            const pendingEntries = Array.from(sellPasteResolveQueue.entries());
+            sellPasteResolveQueue.clear();
+            pendingEntries.forEach(([key]) => {
+                sellPasteResolvePending.add(key);
+            });
+            const namesToResolve = pendingEntries.map(([, label]) => label);
+            try {
+                const response = await fetch(sellPasteResolveUrl, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'X-CSRFToken': getSellPasteCsrfToken()
+                    },
+                    body: JSON.stringify({
+                        names: namesToResolve,
+                        character_id: getSelectedCharacterId()
+                    })
+                });
+                if (!response.ok) {
+                    throw new Error('Paste item resolver request failed');
+                }
+
+                const payload = await response.json();
+                const items = payload && typeof payload.items === 'object' ? payload.items : {};
+                Object.entries(items).forEach(([key, result]) => {
+                    sellPasteResolvePending.delete(key);
+                    if (result && result.found && result.item) {
+                        sellPasteResolvedDbItems.set(key, result.item);
+                        registerSellPasteCatalogItem(result.item);
+                    } else {
+                        sellPasteResolvedDbItems.set(key, null);
+                    }
+                });
+                pendingEntries.forEach(([key]) => {
+                    if (sellPasteResolvePending.has(key)) {
+                        sellPasteResolvePending.delete(key);
+                        sellPasteResolvedDbItems.set(key, null);
+                    }
+                });
+            } catch (error) {
+                console.error('Failed to resolve pasted item names:', error);
+                pendingEntries.forEach(([key]) => {
+                    sellPasteResolvePending.delete(key);
+                });
+            } finally {
+                if (resolveToken === sellPasteResolveToken) {
+                    updatePasteImport();
+                }
+            }
+        }, 150);
+    }
+
     function updatePasteImport() {
         if (!sellPasteTextarea) {
             return;
@@ -598,11 +702,28 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
             label: line,
             detail: sellPasteMessages.parseError
         }));
+        const entriesNeedingDbResolution = [];
         const quantitiesByType = {};
         let acceptedTotalCents = 0;
 
         parsed.entries.forEach(entry => {
-            const catalogItem = sellPasteCatalog.get(entry.key);
+            let catalogItem = sellPasteCatalog.get(entry.key);
+            if (!catalogItem) {
+                const resolvedItem = sellPasteResolvedDbItems.get(entry.key);
+                if (resolvedItem) {
+                    catalogItem = resolvedItem;
+                } else if (resolvedItem === null) {
+                    unknownItems.push({
+                        label: `${entry.label} x ${entry.quantity.toLocaleString()}`,
+                        detail: sellPasteMessages.unknown
+                    });
+                    return;
+                } else {
+                    entriesNeedingDbResolution.push(entry);
+                    return;
+                }
+            }
+
             if (!catalogItem) {
                 unknownItems.push({
                     label: `${entry.label} x ${entry.quantity.toLocaleString()}`,
@@ -649,6 +770,8 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
                 subtotalCents
             });
         });
+
+        scheduleSellPasteDbResolution(entriesNeedingDbResolution);
 
         applyPasteQuantities(quantitiesByType);
 

--- a/indy_hub/templates/indy_hub/material_exchange/sell.html
+++ b/indy_hub/templates/indy_hub/material_exchange/sell.html
@@ -103,15 +103,26 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
     const sellCharacterSelect = query('#sellCharacterSelect');
     const sellPasteCatalog = new Map();
 
+    function registerSellPasteCatalogItem(item) {
+        if (!item || !item.type_name) {
+            return;
+        }
+
+        [item.name_key, item.type_name]
+            .map(normalizePasteName)
+            .filter(Boolean)
+            .forEach(key => {
+                if (!sellPasteCatalog.has(key)) {
+                    sellPasteCatalog.set(key, item);
+                }
+            });
+    }
+
     if (sellPasteCatalogNode) {
         try {
             const parsedCatalog = JSON.parse(sellPasteCatalogNode.textContent || '[]');
             if (Array.isArray(parsedCatalog)) {
-                parsedCatalog.forEach(item => {
-                    if (item && item.name_key) {
-                        sellPasteCatalog.set(item.name_key, item);
-                    }
-                });
+                parsedCatalog.forEach(registerSellPasteCatalogItem);
             } else {
                 console.error('Failed to parse sell paste catalog: expected an array');
             }
@@ -119,6 +130,27 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
             console.error('Failed to parse sell paste catalog:', error);
         }
     }
+
+    stockRows.forEach(row => {
+        const typeName = row.dataset.typeName || '';
+        const typeId = Number.parseInt(row.dataset.typeId || '0', 10);
+        const availableQty = Number.parseInt(row.dataset.maxQty || '0', 10) || 0;
+        if (!typeName || !typeId || availableQty <= 0) {
+            return;
+        }
+
+        registerSellPasteCatalogItem({
+            type_id: typeId,
+            type_name: typeName,
+            name_key: normalizePasteName(typeName),
+            group_name: row.dataset.groupName || 'Other',
+            available_qty: availableQty,
+            total_available_qty: availableQty,
+            status: 'accepted',
+            reason: '',
+            unit_price: row.dataset.unitPrice || ''
+        });
+    });
 
     const sellPasteMessages = {
         notBought: '{% trans "Not bought by the hub" %}',

--- a/indy_hub/templates/indy_hub/material_exchange/sell.html
+++ b/indy_hub/templates/indy_hub/material_exchange/sell.html
@@ -105,14 +105,15 @@ window.initMaterialExchangeSellPage = function initMaterialExchangeSellPage(root
     if (sellPasteCatalogNode) {
         try {
             const parsedCatalog = JSON.parse(sellPasteCatalogNode.textContent || '[]');
-            if (!Array.isArray(parsedCatalog)) {
-                throw new TypeError('sellPasteCatalogData must be a JSON array');
+            if (Array.isArray(parsedCatalog)) {
+                parsedCatalog.forEach(item => {
+                    if (item && item.name_key) {
+                        sellPasteCatalog.set(item.name_key, item);
+                    }
+                });
+            } else {
+                console.error('Failed to parse sell paste catalog: expected an array');
             }
-            parsedCatalog.forEach(item => {
-                if (item && item.name_key) {
-                    sellPasteCatalog.set(item.name_key, item);
-                }
-            });
         } catch (error) {
             console.error('Failed to parse sell paste catalog:', error);
         }

--- a/indy_hub/tests/test_material_exchange_sell_paste.py
+++ b/indy_hub/tests/test_material_exchange_sell_paste.py
@@ -28,7 +28,10 @@ from indy_hub.services.material_exchange_assets import (
     SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS,
     material_exchange_sell_assets_progress_key,
 )
-from indy_hub.views.material_exchange import material_exchange_sell
+from indy_hub.views.material_exchange import (
+    _build_sell_paste_catalog,
+    material_exchange_sell,
+)
 
 
 def assign_main_character(user: User, *, character_id: int) -> EveCharacter:
@@ -369,6 +372,38 @@ class MaterialExchangeSellPasteTests(TestCase):
         self.assertEqual(catalog["Large Skill Injector"]["total_available_qty"], 3)
         self.assertEqual(catalog["Unrefined Goo"]["status"], "rejected")
         self.assertEqual(catalog["Unrefined Goo"]["reason"], "not_bought")
+
+    def test_paste_catalog_keeps_accepted_visible_items(self) -> None:
+        with (
+            patch(
+                "indy_hub.views.material_exchange.get_type_name",
+                side_effect=lambda type_id: {34: "Tritanium", 35: "Pyerite"}[type_id],
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_group_map",
+                return_value={34: "Minerals", 35: "Minerals"},
+            ),
+            patch("indy_hub.views.material_exchange.batch_cache_type_names"),
+        ):
+            catalog = {
+                entry["type_name"]: entry
+                for entry in _build_sell_paste_catalog(
+                    raw_assets_by_type={35: 5},
+                    selected_raw_assets_by_type={34: 10, 35: 5},
+                    accepted_by_type_id={
+                        34: {
+                            "type_id": 34,
+                            "type_name": "Tritanium",
+                            "group_name": "Minerals",
+                            "buy_price_from_member": Decimal("5.25"),
+                        }
+                    },
+                )
+            }
+
+        self.assertEqual(catalog["Tritanium"]["status"], "accepted")
+        self.assertEqual(catalog["Tritanium"]["name_key"], "tritanium")
+        self.assertEqual(catalog["Tritanium"]["available_qty"], 10)
 
     def test_get_ajax_character_switch_returns_fragment_html(self) -> None:
         other_character = assign_main_character(

--- a/indy_hub/tests/test_material_exchange_sell_paste.py
+++ b/indy_hub/tests/test_material_exchange_sell_paste.py
@@ -11,6 +11,7 @@ from django.contrib.auth.models import Permission, User
 from django.contrib.messages import get_messages
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.cache import cache
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase
@@ -23,6 +24,10 @@ from allianceauth.eveonline.models import EveCharacter
 
 # AA Example App
 from indy_hub.models import MaterialExchangeConfig, MaterialExchangeSellOrder
+from indy_hub.services.material_exchange_assets import (
+    SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS,
+    material_exchange_sell_assets_progress_key,
+)
 from indy_hub.views.material_exchange import material_exchange_sell
 
 
@@ -442,3 +447,57 @@ class MaterialExchangeSellPasteTests(TestCase):
         self.assertIn('id="sellCharacterSelect"', payload["html"])
         self.assertIn("Pyerite", payload["html"])
         self.assertNotIn('<div class="page-header mb-4">', payload["html"])
+
+    def test_get_does_not_restart_recent_finished_asset_refresh(self) -> None:
+        request = self._prepare_request(
+            self.factory.get(reverse("indy_hub:material_exchange_sell"))
+        )
+        progress_key = material_exchange_sell_assets_progress_key(self.user.id)
+        now_ts = timezone.now().timestamp()
+        cache.set(
+            progress_key,
+            {
+                "running": False,
+                "finished": True,
+                "error": "no_assets_fetched",
+                "total": 1,
+                "done": 1,
+                "failed": 0,
+                "started_at": now_ts - 30,
+                "last_progress_at": now_ts,
+            },
+            SELL_ASSETS_REFRESH_PROGRESS_TTL_SECONDS,
+        )
+
+        def fake_render(_request, _template_name, context):
+            return HttpResponse("ok")
+
+        try:
+            with (
+                patch("indy_hub.views.material_exchange.emit_view_analytics_event"),
+                patch(
+                    "indy_hub.views.material_exchange._is_material_exchange_enabled",
+                    return_value=True,
+                ),
+                patch(
+                    "indy_hub.views.material_exchange._get_material_exchange_config",
+                    return_value=self.config,
+                ),
+                patch(
+                    "indy_hub.views.material_exchange._ensure_sell_assets_refresh_started"
+                ) as ensure_refresh_started,
+                patch(
+                    "indy_hub.views.material_exchange._fetch_user_assets_for_structure_data",
+                    return_value=({}, {}, False),
+                ),
+                patch(
+                    "indy_hub.views.material_exchange.render",
+                    side_effect=fake_render,
+                ),
+            ):
+                response = self.view(request, tokens=[])
+        finally:
+            cache.delete(progress_key)
+
+        self.assertEqual(response.status_code, 200)
+        ensure_refresh_started.assert_not_called()

--- a/indy_hub/tests/test_material_exchange_sell_paste.py
+++ b/indy_hub/tests/test_material_exchange_sell_paste.py
@@ -31,6 +31,7 @@ from indy_hub.services.material_exchange_assets import (
 from indy_hub.views.material_exchange import (
     _build_sell_paste_catalog,
     material_exchange_sell,
+    material_exchange_sell_resolve_paste_items,
 )
 
 
@@ -404,6 +405,173 @@ class MaterialExchangeSellPasteTests(TestCase):
         self.assertEqual(catalog["Tritanium"]["status"], "accepted")
         self.assertEqual(catalog["Tritanium"]["name_key"], "tritanium")
         self.assertEqual(catalog["Tritanium"]["available_qty"], 10)
+
+    def test_resolve_paste_items_finds_accepted_item_from_sde(self) -> None:
+        request = self._prepare_request(
+            self.factory.post(
+                reverse("indy_hub:material_exchange_sell_resolve_paste_items"),
+                data=json.dumps(
+                    {
+                        "names": ["tritanium"],
+                        "character_id": self.character.character_id,
+                    }
+                ),
+                content_type="application/json",
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+        )
+
+        with (
+            patch("indy_hub.views.material_exchange.emit_view_analytics_event"),
+            patch(
+                "indy_hub.views.material_exchange._is_material_exchange_enabled",
+                return_value=True,
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_material_exchange_config",
+                return_value=self.config,
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_material_exchange_location_ids",
+                return_value=[self.config.structure_id],
+            ),
+            patch(
+                "indy_hub.views.material_exchange._resolve_sde_item_types_by_name",
+                return_value={
+                    "tritanium": {
+                        "type_id": 34,
+                        "type_name": "Tritanium",
+                        "group_name": "Minerals",
+                    }
+                },
+            ),
+            patch(
+                "indy_hub.views.material_exchange._fetch_user_assets_for_structure_data",
+                return_value=(
+                    {34: 2_500},
+                    {self.character.character_id: {34: 2_500}},
+                    False,
+                ),
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_allowed_type_ids_for_config",
+                return_value={34},
+            ),
+            patch(
+                "indy_hub.views.material_exchange._fetch_fuzzwork_prices",
+                return_value={34: {"buy": Decimal("5.00"), "sell": Decimal("6.00")}},
+            ),
+        ):
+            response = material_exchange_sell_resolve_paste_items(request)
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content)
+        tritanium = payload["items"]["tritanium"]
+        self.assertTrue(tritanium["found"])
+        self.assertEqual(tritanium["item"]["status"], "accepted")
+        self.assertEqual(tritanium["item"]["type_name"], "Tritanium")
+        self.assertEqual(tritanium["item"]["available_qty"], 2_500)
+        self.assertEqual(tritanium["item"]["unit_price"], "5.25")
+
+    def test_resolve_paste_items_keeps_db_found_item_out_of_unknown(self) -> None:
+        request = self._prepare_request(
+            self.factory.post(
+                reverse("indy_hub:material_exchange_sell_resolve_paste_items"),
+                data=json.dumps({"names": ["Tritanium"]}),
+                content_type="application/json",
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+        )
+
+        with (
+            patch("indy_hub.views.material_exchange.emit_view_analytics_event"),
+            patch(
+                "indy_hub.views.material_exchange._is_material_exchange_enabled",
+                return_value=True,
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_material_exchange_config",
+                return_value=self.config,
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_material_exchange_location_ids",
+                return_value=[self.config.structure_id],
+            ),
+            patch(
+                "indy_hub.views.material_exchange._resolve_sde_item_types_by_name",
+                return_value={
+                    "tritanium": {
+                        "type_id": 34,
+                        "type_name": "Tritanium",
+                        "group_name": "Minerals",
+                    }
+                },
+            ),
+            patch(
+                "indy_hub.views.material_exchange._fetch_user_assets_for_structure_data",
+                return_value=({}, {}, False),
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_allowed_type_ids_for_config",
+                return_value=set(),
+            ),
+            patch(
+                "indy_hub.views.material_exchange._fetch_fuzzwork_prices",
+            ) as fetch_prices,
+        ):
+            response = material_exchange_sell_resolve_paste_items(request)
+
+        self.assertEqual(response.status_code, 200)
+        fetch_prices.assert_not_called()
+        payload = json.loads(response.content)
+        tritanium = payload["items"]["tritanium"]
+        self.assertTrue(tritanium["found"])
+        self.assertEqual(tritanium["item"]["status"], "rejected")
+        self.assertEqual(tritanium["item"]["reason"], "not_bought")
+
+    def test_resolve_paste_items_marks_only_db_misses_unknown(self) -> None:
+        request = self._prepare_request(
+            self.factory.post(
+                reverse("indy_hub:material_exchange_sell_resolve_paste_items"),
+                data=json.dumps({"names": ["Definitely Not An Eve Item"]}),
+                content_type="application/json",
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+        )
+
+        with (
+            patch("indy_hub.views.material_exchange.emit_view_analytics_event"),
+            patch(
+                "indy_hub.views.material_exchange._is_material_exchange_enabled",
+                return_value=True,
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_material_exchange_config",
+                return_value=self.config,
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_material_exchange_location_ids",
+                return_value=[self.config.structure_id],
+            ),
+            patch(
+                "indy_hub.views.material_exchange._resolve_sde_item_types_by_name",
+                return_value={},
+            ),
+            patch(
+                "indy_hub.views.material_exchange._fetch_user_assets_for_structure_data",
+                return_value=({}, {}, False),
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_allowed_type_ids_for_config",
+                return_value={34},
+            ),
+        ):
+            response = material_exchange_sell_resolve_paste_items(request)
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content)
+        missing = payload["items"]["definitely not an eve item"]
+        self.assertFalse(missing["found"])
 
     def test_get_ajax_character_switch_returns_fragment_html(self) -> None:
         other_character = assign_main_character(

--- a/indy_hub/tests/test_material_exchange_sell_paste.py
+++ b/indy_hub/tests/test_material_exchange_sell_paste.py
@@ -573,6 +573,45 @@ class MaterialExchangeSellPasteTests(TestCase):
         missing = payload["items"]["definitely not an eve item"]
         self.assertFalse(missing["found"])
 
+    def test_resolve_paste_items_ignores_invalid_utf8_body(self) -> None:
+        request = self._prepare_request(
+            self.factory.generic(
+                "POST",
+                reverse("indy_hub:material_exchange_sell_resolve_paste_items"),
+                data=b"\xff\xfe\x00",
+                content_type="application/json",
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+        )
+
+        with (
+            patch("indy_hub.views.material_exchange.emit_view_analytics_event"),
+            patch(
+                "indy_hub.views.material_exchange._is_material_exchange_enabled",
+                return_value=True,
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_material_exchange_config",
+                return_value=self.config,
+            ),
+            patch(
+                "indy_hub.views.material_exchange._resolve_sde_item_types_by_name",
+            ) as resolve_names,
+            patch(
+                "indy_hub.views.material_exchange._fetch_user_assets_for_structure_data",
+                return_value=({}, {}, False),
+            ),
+            patch(
+                "indy_hub.views.material_exchange._get_allowed_type_ids_for_config",
+                return_value={34},
+            ),
+        ):
+            response = material_exchange_sell_resolve_paste_items(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"items": {}})
+        resolve_names.assert_called_once_with([])
+
     def test_get_ajax_character_switch_returns_fragment_html(self) -> None:
         other_character = assign_main_character(
             self.user, character_id=self.character.character_id + 1

--- a/indy_hub/tests/test_material_exchange_sell_paste.py
+++ b/indy_hub/tests/test_material_exchange_sell_paste.py
@@ -260,7 +260,9 @@ class MaterialExchangeSellPasteTests(TestCase):
         self.assertEqual(catalog["Unrefined Goo"]["reason"], "not_bought")
 
         rendered = render_to_string(
-            "indy_hub/material_exchange/includes/sell_page_content.html", context
+            "indy_hub/material_exchange/includes/sell_page_content.html",
+            context,
+            request=request,
         )
         match = re.search(
             r'<script id="sellPasteCatalogData" type="application/json">(.*?)</script>',

--- a/indy_hub/tests/test_material_exchange_sell_paste.py
+++ b/indy_hub/tests/test_material_exchange_sell_paste.py
@@ -272,7 +272,8 @@ class MaterialExchangeSellPasteTests(TestCase):
         self.assertIsNotNone(match)
         rendered_catalog = json.loads(match.group(1))
         self.assertIsInstance(rendered_catalog, list)
-        self.assertEqual(rendered_catalog[0]["type_name"], "Tritanium")
+        self.assertGreater(len(rendered_catalog), 0)
+        self.assertIn("Tritanium", {entry["type_name"] for entry in rendered_catalog})
 
     def test_get_marks_known_item_on_other_character_as_unavailable(self) -> None:
         request = self._prepare_request(

--- a/indy_hub/tests/test_material_exchange_sell_paste.py
+++ b/indy_hub/tests/test_material_exchange_sell_paste.py
@@ -2,6 +2,7 @@
 
 # Standard Library
 import json
+import re
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -11,6 +12,7 @@ from django.contrib.messages import get_messages
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
+from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -256,6 +258,19 @@ class MaterialExchangeSellPasteTests(TestCase):
         self.assertEqual(catalog["Tritanium"]["unit_price"], "5.25")
         self.assertEqual(catalog["Unrefined Goo"]["status"], "rejected")
         self.assertEqual(catalog["Unrefined Goo"]["reason"], "not_bought")
+
+        rendered = render_to_string(
+            "indy_hub/material_exchange/includes/sell_page_content.html", context
+        )
+        match = re.search(
+            r'<script id="sellPasteCatalogData" type="application/json">(.*?)</script>',
+            rendered,
+            re.S,
+        )
+        self.assertIsNotNone(match)
+        rendered_catalog = json.loads(match.group(1))
+        self.assertIsInstance(rendered_catalog, list)
+        self.assertEqual(rendered_catalog[0]["type_name"], "Tritanium")
 
     def test_get_marks_known_item_on_other_character_as_unavailable(self) -> None:
         request = self._prepare_request(

--- a/indy_hub/urls.py
+++ b/indy_hub/urls.py
@@ -80,6 +80,7 @@ from .views.material_exchange import (
     material_exchange_reject_sell,
     material_exchange_sell,
     material_exchange_sell_assets_refresh_status,
+    material_exchange_sell_resolve_paste_items,
     material_exchange_stats_history,
     material_exchange_sync_prices,
     material_exchange_sync_stock,
@@ -503,6 +504,11 @@ urlpatterns = [
         "material-exchange/api/sell-assets-refresh-status/",
         material_exchange_sell_assets_refresh_status,
         name="material_exchange_sell_assets_refresh_status",
+    ),
+    path(
+        "material-exchange/api/sell-resolve-paste-items/",
+        material_exchange_sell_resolve_paste_items,
+        name="material_exchange_sell_resolve_paste_items",
     ),
     path(
         "material-exchange/buy/",

--- a/indy_hub/views/material_exchange.py
+++ b/indy_hub/views/material_exchange.py
@@ -45,6 +45,7 @@ from ..services.material_exchange_assets import (
     ensure_sell_assets_refresh_started,
     get_sell_assets_refresh_progress,
     material_exchange_sell_assets_progress_key,
+    sell_assets_refresh_finished_recently,
 )
 from ..tasks.material_exchange import (
     ESI_DOWN_COOLDOWN_SECONDS,
@@ -1235,10 +1236,15 @@ def material_exchange_sell(request, tokens):
 
     # Start async refresh of the user's assets on page open (GET only).
     progress_key = _me_sell_assets_progress_key(request.user.id)
-    sell_assets_progress = cache.get(progress_key) or {}
+    sell_assets_progress = get_sell_assets_refresh_progress(int(request.user.id))
+    recent_refresh_finished = sell_assets_refresh_finished_recently(
+        sell_assets_progress
+    )
     if request.method == "GET" and (user_assets_stale or user_assets_version_refresh):
         # The refreshed=1 guard prevents loops, but version migrations should override it.
-        if request.GET.get("refreshed") != "1" or user_assets_version_refresh:
+        if (request.GET.get("refreshed") != "1" or user_assets_version_refresh) and (
+            user_assets_version_refresh or not recent_refresh_finished
+        ):
             sell_assets_progress = _ensure_sell_assets_refresh_started(request.user)
     assets_refreshing = bool(sell_assets_progress.get("running"))
 

--- a/indy_hub/views/material_exchange.py
+++ b/indy_hub/views/material_exchange.py
@@ -893,15 +893,21 @@ def _build_sell_paste_catalog(
     group_map = _get_group_map(list(raw_assets_by_type.keys()))
 
     catalog: list[dict] = []
-    for type_id, available_qty in raw_assets_by_type.items():
-        if int(available_qty or 0) <= 0:
+    catalog_type_ids = {int(type_id) for type_id in raw_assets_by_type}
+    catalog_type_ids.update(int(type_id) for type_id in accepted_by_type_id)
+    for type_id in catalog_type_ids:
+        selected_available_qty = int(
+            selected_raw_assets_by_type.get(int(type_id), 0) or 0
+        )
+        available_qty = max(
+            int(raw_assets_by_type.get(int(type_id), 0) or 0),
+            selected_available_qty,
+        )
+        if available_qty <= 0:
             continue
 
         type_name = get_type_name(type_id)
         accepted_item = accepted_by_type_id.get(int(type_id))
-        selected_available_qty = int(
-            selected_raw_assets_by_type.get(int(type_id), 0) or 0
-        )
         status = "accepted"
         reason = ""
         unit_price = ""

--- a/indy_hub/views/material_exchange.py
+++ b/indy_hub/views/material_exchange.py
@@ -13,7 +13,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import Permission
 from django.core.cache import cache
 from django.core.paginator import Paginator
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import Count, Q, Sum
 from django.db.models.functions import TruncMonth
 from django.http import JsonResponse
@@ -660,6 +660,119 @@ def material_exchange_sell_assets_refresh_status(request):
     return JsonResponse(response)
 
 
+@login_required
+@indy_hub_permission_required("can_access_indy_hub")
+@require_http_methods(["POST"])
+def material_exchange_sell_resolve_paste_items(request):
+    """Resolve pasted sell item names against SDE and current Material Exchange rules."""
+    emit_view_analytics_event(
+        view_name="material_exchange.sell_resolve_paste_items", request=request
+    )
+
+    if not _is_material_exchange_enabled():
+        return JsonResponse({"items": {}, "error": "disabled"}, status=403)
+
+    config = _get_material_exchange_config()
+    if not config:
+        return JsonResponse({"items": {}, "error": "not_configured"}, status=400)
+
+    try:
+        payload = json.loads(request.body.decode("utf-8") or "{}")
+    except (TypeError, ValueError, json.JSONDecodeError):
+        payload = {}
+
+    names_payload = payload.get("names") if isinstance(payload, dict) else []
+    if not isinstance(names_payload, list):
+        names_payload = []
+
+    names: list[str] = []
+    seen_names: set[str] = set()
+    for raw_name in names_payload[:100]:
+        name = " ".join(str(raw_name or "").split()).strip()
+        key = normalize_text(name)
+        if not key or key in seen_names:
+            continue
+        seen_names.add(key)
+        names.append(name)
+
+    resolved_by_key = _resolve_sde_item_types_by_name(names)
+    type_ids = [int(item["type_id"]) for item in resolved_by_key.values()]
+
+    accepted_locations = _get_material_exchange_location_ids(config) or [
+        int(config.structure_id)
+    ]
+    raw_assets_by_type, assets_by_character, _scope_missing = (
+        _fetch_user_assets_for_structure_data(
+            request.user,
+            accepted_locations,
+            allow_refresh=False,
+        )
+    )
+
+    selected_character_id = 0
+    try:
+        selected_character_id = int(payload.get("character_id") or 0)
+    except (TypeError, ValueError, AttributeError):
+        selected_character_id = 0
+    selected_assets_by_type = (
+        assets_by_character.get(selected_character_id, {})
+        if selected_character_id > 0
+        else raw_assets_by_type
+    )
+
+    accepted_by_type_id: dict[int, dict] = {}
+    allowed_type_ids = _get_allowed_type_ids_for_config(config, "sell")
+    candidate_type_ids = [
+        type_id
+        for type_id in type_ids
+        if allowed_type_ids is None or type_id in allowed_type_ids
+    ]
+    price_data = (
+        _fetch_fuzzwork_prices(candidate_type_ids) if candidate_type_ids else {}
+    )
+    for type_id in candidate_type_ids:
+        fuzz_prices = price_data.get(type_id, {})
+        jita_buy = fuzz_prices.get("buy") or Decimal(0)
+        jita_sell = fuzz_prices.get("sell") or Decimal(0)
+        if jita_buy <= 0 and jita_sell <= 0:
+            continue
+
+        buy_price = compute_buy_price_from_member(
+            config=config,
+            jita_buy=jita_buy,
+            jita_sell=jita_sell,
+        )
+        if buy_price <= 0:
+            continue
+
+        accepted_by_type_id[int(type_id)] = {
+            "buy_price_from_member": buy_price,
+        }
+
+    response_items: dict[str, dict] = {}
+    for name in names:
+        key = normalize_text(name)
+        type_info = resolved_by_key.get(key)
+        if not type_info:
+            response_items[key] = {"found": False}
+            continue
+
+        type_id = int(type_info["type_id"])
+        response_items[key] = {
+            "found": True,
+            "item": _build_resolved_sell_paste_item(
+                type_info=type_info,
+                selected_available_qty=int(
+                    selected_assets_by_type.get(type_id, 0) or 0
+                ),
+                total_available_qty=int(raw_assets_by_type.get(type_id, 0) or 0),
+                accepted_item=accepted_by_type_id.get(type_id),
+            ),
+        }
+
+    return JsonResponse({"items": response_items})
+
+
 def _ensure_buy_stock_refresh_started(config) -> dict:
     """Start (if needed) an async refresh of buy stock and return the current progress state."""
 
@@ -943,6 +1056,80 @@ def _build_sell_paste_catalog(
         )
     )
     return catalog
+
+
+def _resolve_sde_item_types_by_name(names: list[str]) -> dict[str, dict[str, object]]:
+    normalized_names = []
+    seen_names = set()
+    for name in names:
+        normalized_name = normalize_text(name)
+        if not normalized_name or normalized_name in seen_names:
+            continue
+        seen_names.add(normalized_name)
+        normalized_names.append(normalized_name)
+
+    if not normalized_names:
+        return {}
+
+    placeholders = ", ".join(["%s"] * len(normalized_names))
+    query = f"""
+        SELECT t.id, t.name, COALESCE(g.name, '')
+        FROM eve_sde_itemtype t
+        LEFT JOIN eve_sde_itemgroup g ON t.group_id = g.id
+        WHERE LOWER(t.name) IN ({placeholders})
+            AND COALESCE(t.published, 0) = 1
+    """
+
+    resolved: dict[str, dict[str, object]] = {}
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(query, normalized_names)
+            for type_id, type_name, group_name in cursor.fetchall():
+                resolved[normalize_text(type_name)] = {
+                    "type_id": int(type_id),
+                    "type_name": str(type_name),
+                    "group_name": str(group_name or ""),
+                }
+    except Exception as exc:
+        logger.warning("Failed to resolve sell paste item names from SDE: %s", exc)
+    return resolved
+
+
+def _build_resolved_sell_paste_item(
+    *,
+    type_info: dict[str, object],
+    selected_available_qty: int,
+    total_available_qty: int,
+    accepted_item: dict | None,
+) -> dict:
+    type_id = int(type_info["type_id"])
+    type_name = str(type_info["type_name"])
+    group_name = str(type_info.get("group_name") or "Other")
+
+    status = "accepted"
+    reason = ""
+    unit_price = ""
+    if accepted_item and selected_available_qty > 0:
+        unit_price = format(Decimal(accepted_item["buy_price_from_member"]), ".2f")
+    elif accepted_item:
+        status = "unavailable"
+        reason = "not_on_character"
+        unit_price = format(Decimal(accepted_item["buy_price_from_member"]), ".2f")
+    else:
+        status = "rejected"
+        reason = "not_bought"
+
+    return {
+        "type_id": type_id,
+        "type_name": type_name,
+        "name_key": normalize_text(type_name),
+        "group_name": group_name,
+        "available_qty": selected_available_qty,
+        "total_available_qty": total_available_qty,
+        "status": status,
+        "reason": reason,
+        "unit_price": unit_price,
+    }
 
 
 @login_required

--- a/indy_hub/views/material_exchange.py
+++ b/indy_hub/views/material_exchange.py
@@ -678,7 +678,7 @@ def material_exchange_sell_resolve_paste_items(request):
 
     try:
         payload = json.loads(request.body.decode("utf-8") or "{}")
-    except (TypeError, ValueError, json.JSONDecodeError):
+    except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
         payload = {}
 
     names_payload = payload.get("names") if isinstance(payload, dict) else []

--- a/testauth/settings/local.py
+++ b/testauth/settings/local.py
@@ -13,7 +13,9 @@ from .base import *
 try:
     # Third Party
     import bootstrapform  # noqa: F401
-except ModuleNotFoundError:
+except ModuleNotFoundError as exc:
+    if exc.name != "bootstrapform":
+        raise
     INSTALLED_APPS = [app for app in INSTALLED_APPS if app != "bootstrapform"]
 
 PACKAGE = "indy_hub"

--- a/testauth/settings/local.py
+++ b/testauth/settings/local.py
@@ -10,6 +10,12 @@ Test settings
 
 from .base import *
 
+try:
+    # Third Party
+    import bootstrapform  # noqa: F401
+except ModuleNotFoundError:
+    INSTALLED_APPS = [app for app in INSTALLED_APPS if app != "bootstrapform"]
+
 PACKAGE = "indy_hub"
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
Fixes #82

Summary:
- Guard the sell paste-import catalog parser so malformed/non-array payloads cannot throw `JSON.parse(...).forEach is not a function` during page initialization.
- Register normalized catalog and visible-row item names so pasted lines such as `tritanium 2500` match accepted items reliably.
- Resolve pasted item names that are missing from the page catalog against the SDE database before classifying them, so Unknown is only used when the item name cannot be found in DB.
- Classify DB-found pasted items as accepted, not bought, or other-character based on the current Material Exchange rules, prices, and cached user assets without starting another asset refresh.
- Treat invalid UTF-8 resolver request bodies as an empty payload instead of returning a 500.
- Ensure accepted sell-paste catalog entries are kept when selected-character/display data has an item that the raw aggregate map missed.
- Keep fresh tox runs compatible with Alliance Auth latest by dropping the legacy `bootstrapform` test app only when that exact package is absent from the AA5 dependency set.
- Add regression assertions that the sell page content renders `sellPasteCatalogData` as a JSON array with catalog entries, accepted catalog entries keep a normalized key, invalid UTF-8 resolver requests do not crash, and the SDE-backed resolver keeps DB-found names out of Unknown.
- Stop the sell page from repeatedly swapping/reloading its dynamic content after the character asset refresh completes.
- Prevent the server from immediately restarting a recently finished sell asset refresh when cached asset timestamps stay stale or empty.
- Document the Material Exchange paste-import, DB resolver, refresh-loop, and tox setup fixes in the Unreleased changelog.

Validation:
- `tox -r -e py312 -q` (359 tests, OK)
- `tox -r -e py310 -q` (358 tests, OK)
- `pre-commit run --all-files`
- `git diff --check`
- `/home/aadev/venv-v5/bin/python runtests.py indy_hub.tests.test_material_exchange_sell_paste` (11 tests, OK)
- `DJANGO_SETTINGS_MODULE=testauth.settings.local /home/aadev/venv-v5/bin/python -m django check`

Note: `py311` could not be run locally because that interpreter is not installed in this workspace; the fresh-env failure reproduced and was fixed with `py312`, and `py310` was also validated.