### PR TITLE
Clarify missing SDE unavailable page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Tests: fresh tox runs against Alliance Auth latest no longer fail during Django setup when the legacy `bootstrapform` package is absent from the AA5 dependency set.
 
+- Indy Hub: the unavailable page shown while SDE data is missing now distinguishes an empty base `eve_sde` load from missing Indy Hub compatibility data, and recommends the matching command (`indy_sde --with-esde-load` or `sync_sde_compat`) instead of a generic administrator notice (issue #90).
+
 - Material Exchange: the sell page no longer keeps reloading its dynamic content after the character asset refresh completes. The browser now marks the refresh as completed before swapping in the refreshed fragment, and the server skips restarting a recently finished asset refresh, preventing repeated `?refreshed=1` reload loops when the cached asset timestamp remains stale or empty.
 
 - Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).

--- a/indy_hub/templates/indy_hub/sde_not_ready.html
+++ b/indy_hub/templates/indy_hub/sde_not_ready.html
@@ -10,7 +10,24 @@
             <div class="card border-danger shadow-sm">
                 <div class="card-body p-4 text-center">
                     <h2 class="h4 text-danger mb-3">{% trans "Indy Hub unavailable" %}</h2>
-                    <p class="mb-0">{{ sde_blocking_message|default:_("Indy Hub static data is not loaded yet. Please contact your administrator.") }}</p>
+                    {% if sde_missing_dependency %}
+                        <p class="text-uppercase text-muted small fw-semibold mb-2">{% trans "Missing dependency" %}</p>
+                        <p class="h5 mb-3">{{ sde_missing_dependency }}</p>
+                    {% endif %}
+                    <p class="mb-2">{{ sde_blocking_message|default:_("Indy Hub static data is not loaded yet. Please contact your administrator.") }}</p>
+                    {% if sde_blocking_detail %}
+                        <p class="text-muted mb-0">{{ sde_blocking_detail }}</p>
+                    {% endif %}
+                    {% if sde_recommended_commands %}
+                        <div class="text-start mt-4">
+                            <p class="text-uppercase text-muted small fw-semibold mb-2">{% trans "Recommended command" %}</p>
+                            <div class="list-group list-group-flush border rounded">
+                                {% for command in sde_recommended_commands %}
+                                    <code class="list-group-item bg-light text-body">{{ command }}</code>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/indy_hub/templates/indy_hub/sde_not_ready.html
+++ b/indy_hub/templates/indy_hub/sde_not_ready.html
@@ -11,7 +11,7 @@
                 <div class="card-body p-4 text-center">
                     <h2 class="h4 text-danger mb-3">{% trans "Indy Hub unavailable" %}</h2>
                     {% if sde_missing_dependency %}
-                        <p class="text-uppercase text-muted small fw-semibold mb-2">{% trans "Missing dependency" %}</p>
+                        <p class="text-uppercase text-muted small fw-semibold mb-2">{% trans "What is missing" %}</p>
                         <p class="h5 mb-3">{{ sde_missing_dependency }}</p>
                     {% endif %}
                     <p class="mb-2">{{ sde_blocking_message|default:_("Indy Hub static data is not loaded yet. Please contact your administrator.") }}</p>
@@ -20,10 +20,13 @@
                     {% endif %}
                     {% if sde_recommended_commands %}
                         <div class="text-start mt-4">
-                            <p class="text-uppercase text-muted small fw-semibold mb-2">{% trans "Recommended command" %}</p>
+                            <p class="text-uppercase text-muted small fw-semibold mb-2">{% trans "Run this" %}</p>
                             <div class="list-group list-group-flush border rounded">
-                                {% for command in sde_recommended_commands %}
-                                    <code class="list-group-item bg-light text-body">{{ command }}</code>
+                                {% for command_info in sde_recommended_commands %}
+                                    <div class="list-group-item bg-light">
+                                        <div class="small text-muted mb-1">{{ command_info.label }}</div>
+                                        <code class="text-body">{{ command_info.command }}</code>
+                                    </div>
                                 {% endfor %}
                             </div>
                         </div>

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -66,6 +66,14 @@ from indy_hub.utils.menu_badge import compute_menu_badge_count, menu_badge_cache
 PUBLIC_STATION_ID = 60003760
 
 
+def ensure_base_eve_sde_loaded() -> None:
+    item_type_model = apps.get_model("eve_sde", "ItemType")
+    item_type_model.objects.update_or_create(
+        id=34,
+        defaults={"name": "Tritanium", "published": True},
+    )
+
+
 def assign_main_character(user: User, *, character_id: int) -> EveCharacter:
     character, _ = EveCharacter.objects.get_or_create(
         character_id=character_id,
@@ -280,6 +288,7 @@ class NavbarBlueprintSharingTests(TestCase):
         self.user = User.objects.create_user("navbaruser", password="secret123")
         assign_main_character(self.user, character_id=7003001)
         grant_indy_permissions(self.user)
+        ensure_base_eve_sde_loaded()
         SDESyncCompatState.objects.update_or_create(
             pk=1,
             defaults={"last_synced_at": timezone.now()},
@@ -356,7 +365,11 @@ class IndexSDEGuardTests(TestCase):
         grant_indy_permissions(self.user)
         self.client.force_login(self.user)
 
-    def test_index_is_blocked_when_sde_sync_never_ran(self) -> None:
+    def test_index_shows_full_load_command_when_base_eve_sde_is_missing(
+        self,
+    ) -> None:
+        item_type_model = apps.get_model("eve_sde", "ItemType")
+        item_type_model.objects.all().delete()
         SDESyncCompatState.objects.all().delete()
 
         response = self.client.get(reverse("indy_hub:index"))
@@ -365,10 +378,31 @@ class IndexSDEGuardTests(TestCase):
         self.assertTemplateUsed(response, "indy_hub/sde_not_ready.html")
         self.assertContains(
             response,
-            "Indy Hub static data is not loaded yet. Please contact your administrator.",
+            "Base EVE SDE data is not loaded yet.",
         )
+        self.assertContains(response, "python manage.py indy_sde --with-esde-load")
+        self.assertNotContains(response, "python manage.py sync_sde_compat")
+
+    def test_index_shows_compat_sync_command_when_only_indy_hub_sde_is_missing(
+        self,
+    ) -> None:
+        ensure_base_eve_sde_loaded()
+        SDESyncCompatState.objects.all().delete()
+
+        response = self.client.get(reverse("indy_hub:index"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "indy_hub/sde_not_ready.html")
+        self.assertContains(
+            response,
+            "Indy Hub compatibility SDE data is not loaded yet.",
+        )
+        self.assertContains(response, "python manage.py sync_sde_compat")
+        self.assertContains(response, "auth sync_sde_compat")
+        self.assertNotContains(response, "python manage.py indy_sde --with-esde-load")
 
     def test_index_loads_normally_when_sde_sync_has_timestamp(self) -> None:
+        ensure_base_eve_sde_loaded()
         SDESyncCompatState.objects.update_or_create(
             pk=1,
             defaults={"last_synced_at": timezone.now()},
@@ -380,7 +414,7 @@ class IndexSDEGuardTests(TestCase):
         self.assertTemplateUsed(response, "indy_hub/overview_intro.html")
         self.assertNotContains(
             response,
-            "Indy Hub static data is not loaded yet. Please contact your administrator.",
+            "Indy Hub compatibility SDE data is not loaded yet.",
         )
 
 
@@ -3790,6 +3824,7 @@ class DashboardNotificationCountsTests(TestCase):
     def test_dashboard_overview_action_center_shows_pending_sharing_and_orders(
         self,
     ) -> None:
+        ensure_base_eve_sde_loaded()
         SDESyncCompatState.objects.update_or_create(
             pk=1,
             defaults={"last_synced_at": timezone.now()},
@@ -3845,6 +3880,7 @@ class DashboardUnusedSlotsSummaryTests(TestCase):
         self.character = assign_main_character(self.user, character_id=101222)
         grant_indy_permissions(self.user, "can_manage_corp_bp_requests")
         self.client.force_login(self.user)
+        ensure_base_eve_sde_loaded()
         SDESyncCompatState.objects.update_or_create(
             pk=1,
             defaults={"last_synced_at": timezone.now()},

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -378,8 +378,9 @@ class IndexSDEGuardTests(TestCase):
         self.assertTemplateUsed(response, "indy_hub/sde_not_ready.html")
         self.assertContains(
             response,
-            "Base EVE SDE data is not loaded yet.",
+            "The EVE SDE tables are empty or unavailable",
         )
+        self.assertContains(response, "Full SDE setup")
         self.assertContains(response, "python manage.py indy_sde --with-esde-load")
         self.assertNotContains(response, "python manage.py sync_sde_compat")
 
@@ -395,9 +396,12 @@ class IndexSDEGuardTests(TestCase):
         self.assertTemplateUsed(response, "indy_hub/sde_not_ready.html")
         self.assertContains(
             response,
-            "Indy Hub compatibility SDE data is not loaded yet.",
+            "Indy Hub has not built its own compact SDE cache yet.",
         )
+        self.assertContains(response, "Do not roll back eve_sde migrations")
+        self.assertContains(response, "Standard Django command")
         self.assertContains(response, "python manage.py sync_sde_compat")
+        self.assertContains(response, "Alliance Auth / Docker command")
         self.assertContains(response, "auth sync_sde_compat")
         self.assertNotContains(response, "python manage.py indy_sde --with-esde-load")
 
@@ -414,7 +418,7 @@ class IndexSDEGuardTests(TestCase):
         self.assertTemplateUsed(response, "indy_hub/overview_intro.html")
         self.assertNotContains(
             response,
-            "Indy Hub compatibility SDE data is not loaded yet.",
+            "Indy Hub has not built its own compact SDE cache yet.",
         )
 
 

--- a/indy_hub/views/user.py
+++ b/indy_hub/views/user.py
@@ -9,6 +9,7 @@ from typing import Any
 from urllib.parse import quote
 
 # Django
+from django.apps import apps
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
@@ -2189,6 +2190,81 @@ def _build_dashboard_context(request):
     return context
 
 
+def _is_base_eve_sde_loaded() -> bool:
+    try:
+        item_type_model = apps.get_model("eve_sde", "ItemType")
+    except LookupError:
+        logger.warning("Unable to resolve eve_sde ItemType model", exc_info=True)
+        return False
+
+    try:
+        return item_type_model.objects.exists()
+    except DatabaseError:
+        logger.warning(
+            "Unable to read eve_sde ItemType while rendering index", exc_info=True
+        )
+        return False
+
+
+def _is_indy_hub_sde_compat_loaded() -> bool:
+    try:
+        sde_state = (
+            SDESyncCompatState.objects.filter(pk=1).only("last_synced_at").first()
+        )
+        return bool(sde_state and sde_state.last_synced_at)
+    except DatabaseError:
+        logger.warning(
+            "Unable to read SDESyncCompatState while rendering index",
+            exc_info=True,
+        )
+        return False
+
+
+def _build_sde_readiness_context() -> dict[str, Any]:
+    base_sde_loaded = _is_base_eve_sde_loaded()
+    compat_sde_loaded = _is_indy_hub_sde_compat_loaded()
+    context: dict[str, Any] = {
+        "base_eve_sde_loaded": base_sde_loaded,
+        "indy_hub_sde_compat_loaded": compat_sde_loaded,
+        "sde_ready": base_sde_loaded and compat_sde_loaded,
+        "sde_recommended_commands": [],
+    }
+
+    if not base_sde_loaded:
+        context.update(
+            {
+                "sde_missing_dependency": _("Base EVE SDE data"),
+                "sde_blocking_message": _(
+                    "Base EVE SDE data is not loaded yet. Load the EVE SDE and Indy Hub compatibility data before using Indy Hub."
+                ),
+                "sde_blocking_detail": _(
+                    "Run the full Indy Hub SDE loader so eve_sde is populated before the compact Indy Hub tables are synced."
+                ),
+                "sde_recommended_commands": [
+                    "python manage.py indy_sde --with-esde-load"
+                ],
+            }
+        )
+    elif not compat_sde_loaded:
+        context.update(
+            {
+                "sde_missing_dependency": _("Indy Hub compatibility SDE data"),
+                "sde_blocking_message": _(
+                    "Indy Hub compatibility SDE data is not loaded yet. The base EVE SDE data is present."
+                ),
+                "sde_blocking_detail": _(
+                    "Run only the Indy Hub compatibility sync; the full eve_sde load is not required for this case."
+                ),
+                "sde_recommended_commands": [
+                    "python manage.py sync_sde_compat",
+                    "auth sync_sde_compat",
+                ],
+            }
+        )
+
+    return context
+
+
 @indy_hub_access_required
 @login_required
 def index(request):
@@ -2203,23 +2279,9 @@ def index(request):
     )
     context["current_dashboard"] = "personal"
 
-    sde_state_ready = False
-    try:
-        sde_state = (
-            SDESyncCompatState.objects.filter(pk=1).only("last_synced_at").first()
-        )
-        sde_state_ready = bool(sde_state and sde_state.last_synced_at)
-    except DatabaseError:
-        logger.warning(
-            "Unable to read SDESyncCompatState while rendering index",
-            exc_info=True,
-        )
-        sde_state_ready = False
-
-    if not sde_state_ready:
-        context["sde_blocking_message"] = _(
-            "Indy Hub static data is not loaded yet. Please contact your administrator."
-        )
+    sde_readiness_context = _build_sde_readiness_context()
+    if not sde_readiness_context["sde_ready"]:
+        context.update(sde_readiness_context)
         return render(request, "indy_hub/sde_not_ready.html", context)
 
     progress, _created = UserOnboardingProgress.objects.get_or_create(user=request.user)

--- a/indy_hub/views/user.py
+++ b/indy_hub/views/user.py
@@ -2233,31 +2233,40 @@ def _build_sde_readiness_context() -> dict[str, Any]:
     if not base_sde_loaded:
         context.update(
             {
-                "sde_missing_dependency": _("Base EVE SDE data"),
+                "sde_missing_dependency": _("Base EVE SDE database"),
                 "sde_blocking_message": _(
-                    "Base EVE SDE data is not loaded yet. Load the EVE SDE and Indy Hub compatibility data before using Indy Hub."
+                    "The EVE SDE tables are empty or unavailable, so Indy Hub cannot read item and blueprint names yet."
                 ),
                 "sde_blocking_detail": _(
-                    "Run the full Indy Hub SDE loader so eve_sde is populated before the compact Indy Hub tables are synced."
+                    "Run the full setup command once. It loads eve_sde first, then builds the Indy Hub SDE cache."
                 ),
                 "sde_recommended_commands": [
-                    "python manage.py indy_sde --with-esde-load"
+                    {
+                        "label": _("Full SDE setup"),
+                        "command": "python manage.py indy_sde --with-esde-load",
+                    }
                 ],
             }
         )
     elif not compat_sde_loaded:
         context.update(
             {
-                "sde_missing_dependency": _("Indy Hub compatibility SDE data"),
+                "sde_missing_dependency": _("Indy Hub SDE cache"),
                 "sde_blocking_message": _(
-                    "Indy Hub compatibility SDE data is not loaded yet. The base EVE SDE data is present."
+                    "The base EVE SDE is already loaded, but Indy Hub has not built its own compact SDE cache yet."
                 ),
                 "sde_blocking_detail": _(
-                    "Run only the Indy Hub compatibility sync; the full eve_sde load is not required for this case."
+                    "Run one of the commands below on the Alliance Auth server. Do not roll back eve_sde migrations for this case."
                 ),
                 "sde_recommended_commands": [
-                    "python manage.py sync_sde_compat",
-                    "auth sync_sde_compat",
+                    {
+                        "label": _("Standard Django command"),
+                        "command": "python manage.py sync_sde_compat",
+                    },
+                    {
+                        "label": _("Alliance Auth / Docker command"),
+                        "command": "auth sync_sde_compat",
+                    },
                 ],
             }
         )


### PR DESCRIPTION
Fixes #90

Summary:
- Add an Indy Hub SDE readiness diagnosis for the index unavailable page.
- Detect whether the base `eve_sde` item type table is empty or whether only Indy Hub's compact compatibility SDE sync is missing.
- Show `python manage.py indy_sde --with-esde-load` when the base SDE data is absent.
- Show only `python manage.py sync_sde_compat` and `auth sync_sde_compat` when base `eve_sde` data is already present and only the Indy Hub compatibility tables are missing.
- Update the unavailable template to show the missing dependency, explanatory copy, and recommended command list without exposing a traceback.
- Add regression tests for both missing-data cases and update the changelog.

Validation:
- `/home/aadev/venv-v5/bin/python runtests.py indy_hub.tests.test_smoke.IndexSDEGuardTests`
- `/home/aadev/venv-v5/bin/python runtests.py indy_hub.tests.test_smoke`
- `DJANGO_SETTINGS_MODULE=testauth.settings.local /home/aadev/venv-v5/bin/python -m django check`
- `pre-commit run --files CHANGELOG.md indy_hub/views/user.py indy_hub/templates/indy_hub/sde_not_ready.html indy_hub/tests/test_smoke.py`
- `git diff --check`
- `tox -e py312 -q` (360 tests, OK)