### PR TITLE
Refine craft project SDE staleness warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Indy Hub: the unavailable page shown while SDE data is missing now distinguishes an empty base `eve_sde` load from missing Indy Hub compatibility data, and recommends the matching command (`indy_sde --with-esde-load` or `sync_sde_compat`) instead of a generic administrator notice (issue #90).
 
+- Crafting Projects: saved craft project snapshots now track the SDE rows used by that project, so unrelated global SDE refreshes no longer show a stale-data warning. When a relevant blueprint/material/product/activity row changes, the warning now offers a “Refresh from current SDE” action before saving the refreshed snapshot (issue #87).
+
 - Material Exchange: the sell page no longer keeps reloading its dynamic content after the character asset refresh completes. The browser now marks the refresh as completed before swapping in the refreshed fragment, and the server skips restarting a recently finished asset refresh, preventing repeated `?refreshed=1` reload loops when the cached asset timestamp remains stale or empty.
 
 - Crafting Projects: reaction blueprints (e.g. `Carbon Fiber Reaction Formula`) are no longer surfaced as copy candidates in the per-blueprint configuration cards. The copy request UI is hidden for reactions and the server-side `bp_copy_request_create` endpoint now rejects reaction `type_id`s, since reactions cannot be copied in EVE (issue #69).

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -68,6 +68,8 @@ DRONE_GROUP_KEYWORDS = ("drone", "fighter", "fighter bomber")
 SUBSYSTEM_GROUP_KEYWORDS = ("subsystem", "strategic cruiser")
 PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY = "cachedProjectPayload"
 PROJECT_WORKSPACE_SDE_SIGNATURE_KEY = "cachedProjectSdeSignature"
+PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY = "cachedProjectScopedSdeSignature"
+PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_VERSION = 1
 LEGACY_SINGLE_BLUEPRINT_PROJECT_NOTE = (
     "Migrated from legacy single-blueprint craft flow."
 )
@@ -79,6 +81,7 @@ def strip_project_workspace_cache(
     cleaned_state = dict(workspace_state or {})
     cleaned_state.pop(PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY, None)
     cleaned_state.pop(PROJECT_WORKSPACE_SDE_SIGNATURE_KEY, None)
+    cleaned_state.pop(PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY, None)
     cleaned_state.pop("pendingWorkspaceRefresh", None)
     cleaned_state.pop("pendingWorkspaceSourceTab", None)
     return cleaned_state
@@ -158,7 +161,264 @@ def _collect_payload_blueprint_type_ids(payload: dict[str, object] | None) -> se
             blueprint_type_id = 0
         if blueprint_type_id > 0:
             blueprint_type_ids.add(blueprint_type_id)
+
+    page = payload.get("page")
+    if isinstance(page, dict):
+        blueprint_configs = page.get("blueprint_configs")
+        for config in blueprint_configs if isinstance(blueprint_configs, list) else []:
+            if not isinstance(config, dict):
+                continue
+            try:
+                blueprint_type_id = int(config.get("type_id") or 0)
+            except (TypeError, ValueError):
+                continue
+            if blueprint_type_id > 0:
+                blueprint_type_ids.add(blueprint_type_id)
+
+    final_outputs = payload.get("final_outputs")
+    for output in final_outputs if isinstance(final_outputs, list) else []:
+        if not isinstance(output, dict):
+            continue
+        try:
+            blueprint_type_id = int(output.get("blueprint_type_id") or 0)
+        except (TypeError, ValueError):
+            continue
+        if blueprint_type_id > 0:
+            blueprint_type_ids.add(blueprint_type_id)
     return blueprint_type_ids
+
+
+def _coerce_positive_type_id(value: object) -> int:
+    try:
+        type_id = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return type_id if type_id > 0 else 0
+
+
+def _collect_payload_type_ids(payload: dict[str, object] | None) -> set[int]:
+    type_ids: set[int] = set()
+    if not isinstance(payload, dict):
+        return type_ids
+
+    def add(value: object) -> None:
+        type_id = _coerce_positive_type_id(value)
+        if type_id > 0:
+            type_ids.add(type_id)
+
+    def collect_nodes(nodes: object) -> None:
+        for node in nodes if isinstance(nodes, list) else []:
+            if not isinstance(node, dict):
+                continue
+            add(node.get("type_id"))
+            add(node.get("blueprint_type_id"))
+            collect_nodes(node.get("sub_materials"))
+
+    for key in ("bp_type_id", "type_id", "product_type_id"):
+        add(payload.get(key))
+    collect_nodes(payload.get("materials_tree"))
+
+    for list_key in ("materials", "direct_materials", "final_outputs"):
+        rows = payload.get(list_key)
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            add(row.get("type_id"))
+            add(row.get("blueprint_type_id"))
+            add(row.get("product_type_id"))
+
+    page = payload.get("page")
+    if isinstance(page, dict):
+        blueprint_configs = page.get("blueprint_configs")
+        for config in blueprint_configs if isinstance(blueprint_configs, list) else []:
+            if not isinstance(config, dict):
+                continue
+            add(config.get("type_id"))
+            add(config.get("product_type_id"))
+
+    recipe_map = payload.get("recipe_map")
+    if isinstance(recipe_map, dict):
+        for raw_product_type_id, recipe in recipe_map.items():
+            add(raw_product_type_id)
+            if not isinstance(recipe, dict):
+                continue
+            for input_key in ("inputs_per_cycle", "inputs_per_cycle_me0"):
+                inputs = recipe.get(input_key)
+                for entry in inputs if isinstance(inputs, list) else []:
+                    if isinstance(entry, dict):
+                        add(entry.get("type_id"))
+
+    cycle_summary = payload.get("craft_cycles_summary")
+    if isinstance(cycle_summary, dict):
+        for raw_type_id, entry in cycle_summary.items():
+            add(raw_type_id)
+            if isinstance(entry, dict):
+                add(entry.get("type_id"))
+
+    return type_ids
+
+
+def get_project_workspace_scoped_sde_signature(
+    payload: dict[str, object] | None,
+) -> dict[str, object]:
+    blueprint_type_ids = sorted(_collect_payload_blueprint_type_ids(payload))
+    type_ids = sorted(_collect_payload_type_ids(payload) | set(blueprint_type_ids))
+
+    signature: dict[str, object] = {
+        "version": PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_VERSION,
+        "blueprint_type_ids": blueprint_type_ids,
+        "type_ids": type_ids,
+        "item_types": [],
+        "products": [],
+        "materials": [],
+        "activities": [],
+    }
+
+    if type_ids:
+        placeholders = ", ".join(["%s"] * len(type_ids))
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT id, COALESCE(name_en, name), COALESCE(published, 0), group_id
+                FROM eve_sde_itemtype
+                WHERE id IN ({placeholders})
+                ORDER BY id
+                """,
+                type_ids,
+            )
+            signature["item_types"] = [
+                {
+                    "type_id": int(type_id),
+                    "name": str(type_name or ""),
+                    "published": bool(published),
+                    "group_id": int(group_id) if group_id is not None else None,
+                }
+                for type_id, type_name, published, group_id in cursor.fetchall()
+            ]
+
+    if not blueprint_type_ids:
+        return signature
+
+    placeholders = ", ".join(["%s"] * len(blueprint_type_ids))
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            SELECT
+                p.eve_type_id,
+                p.activity_id,
+                p.product_eve_type_id,
+                p.quantity,
+                COALESCE(product_t.name_en, product_t.name),
+                COALESCE(product_t.published, 0),
+                product_t.group_id
+            FROM indy_hub_sdeindustryactivityproduct p
+            JOIN eve_sde_itemtype product_t ON product_t.id = p.product_eve_type_id
+            WHERE p.eve_type_id IN ({placeholders})
+                AND p.activity_id IN (1, 11)
+            ORDER BY p.eve_type_id, p.activity_id, p.product_eve_type_id
+            """,
+            blueprint_type_ids,
+        )
+        signature["products"] = [
+            {
+                "blueprint_type_id": int(blueprint_type_id),
+                "activity_id": int(activity_id),
+                "product_type_id": int(product_type_id),
+                "quantity": int(quantity or 0),
+                "product_name": str(product_name or ""),
+                "product_published": bool(product_published),
+                "product_group_id": (
+                    int(product_group_id) if product_group_id is not None else None
+                ),
+            }
+            for (
+                blueprint_type_id,
+                activity_id,
+                product_type_id,
+                quantity,
+                product_name,
+                product_published,
+                product_group_id,
+            ) in cursor.fetchall()
+        ]
+
+        cursor.execute(
+            f"""
+            SELECT
+                m.eve_type_id,
+                m.activity_id,
+                m.material_eve_type_id,
+                m.quantity,
+                COALESCE(material_t.name_en, material_t.name),
+                COALESCE(material_t.published, 0),
+                material_t.group_id
+            FROM indy_hub_sdeindustryactivitymaterial m
+            JOIN eve_sde_itemtype material_t ON material_t.id = m.material_eve_type_id
+            WHERE m.eve_type_id IN ({placeholders})
+                AND m.activity_id IN (1, 11)
+            ORDER BY m.eve_type_id, m.activity_id, m.material_eve_type_id
+            """,
+            blueprint_type_ids,
+        )
+        signature["materials"] = [
+            {
+                "blueprint_type_id": int(blueprint_type_id),
+                "activity_id": int(activity_id),
+                "material_type_id": int(material_type_id),
+                "quantity": int(quantity or 0),
+                "material_name": str(material_name or ""),
+                "material_published": bool(material_published),
+                "material_group_id": (
+                    int(material_group_id) if material_group_id is not None else None
+                ),
+            }
+            for (
+                blueprint_type_id,
+                activity_id,
+                material_type_id,
+                quantity,
+                material_name,
+                material_published,
+                material_group_id,
+            ) in cursor.fetchall()
+        ]
+
+        cursor.execute(
+            f"""
+            SELECT eve_type_id, activity_id, time
+            FROM indy_hub_sdeblueprintactivity
+            WHERE eve_type_id IN ({placeholders})
+                AND activity_id IN (1, 11)
+            ORDER BY eve_type_id, activity_id
+            """,
+            blueprint_type_ids,
+        )
+        signature["activities"] = [
+            {
+                "blueprint_type_id": int(blueprint_type_id),
+                "activity_id": int(activity_id),
+                "time": int(activity_time or 0),
+            }
+            for blueprint_type_id, activity_id, activity_time in cursor.fetchall()
+        ]
+
+    return signature
+
+
+def _get_cached_project_scoped_sde_signature(
+    workspace_state: dict[str, object],
+) -> dict[str, object] | None:
+    cached_scoped_signature = workspace_state.get(
+        PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY
+    )
+    if not isinstance(cached_scoped_signature, dict):
+        return None
+    if (
+        cached_scoped_signature.get("version")
+        != PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_VERSION
+    ):
+        return None
+    return cached_scoped_signature
 
 
 def _cached_payload_includes_blueprint_configs(
@@ -266,8 +526,15 @@ def get_cached_project_workspace_payload(
             "workspace_state": strip_project_workspace_cache(workspace_state),
         }
     )
-    current_signature = get_project_workspace_sde_signature()
-    sde_has_changed = bool(cached_signature and cached_signature != current_signature)
+    cached_scoped_signature = _get_cached_project_scoped_sde_signature(workspace_state)
+    if cached_scoped_signature is not None:
+        current_scoped_signature = get_project_workspace_scoped_sde_signature(payload)
+        sde_has_changed = cached_scoped_signature != current_scoped_signature
+    else:
+        current_signature = get_project_workspace_sde_signature()
+        sde_has_changed = bool(
+            cached_signature and cached_signature != current_signature
+        )
     return payload, sde_has_changed
 
 

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 # Standard Library
+import hashlib
+import json
 import re
 from collections import OrderedDict
 from collections.abc import Iterable, Sequence
@@ -12,6 +14,7 @@ from math import ceil
 from time import perf_counter
 
 # Django
+from django.core.cache import cache
 from django.db import connection
 
 # Alliance Auth
@@ -72,6 +75,7 @@ PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY = "cachedProjectScopedSdeSignature"
 PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_VERSION = 1
 PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_ID_LIMIT = 5000
 PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_QUERY_CHUNK_SIZE = 500
+PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_CACHE_TIMEOUT_SECONDS = 60 * 60 * 6
 LEGACY_SINGLE_BLUEPRINT_PROJECT_NOTE = (
     "Migrated from legacy single-blueprint craft flow."
 )
@@ -112,6 +116,26 @@ def _chunked_ids(values: Sequence[int], size: int) -> Iterable[list[int]]:
     chunk_size = max(1, int(size or 1))
     for index in range(0, len(values), chunk_size):
         yield list(values[index : index + chunk_size])
+
+
+def _project_workspace_scoped_sde_signature_cache_key(
+    *,
+    type_ids: Sequence[int],
+    blueprint_type_ids: Sequence[int],
+    global_signature: dict[str, object],
+) -> str:
+    cache_payload = json.dumps(
+        {
+            "version": PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_VERSION,
+            "type_ids": list(type_ids),
+            "blueprint_type_ids": list(blueprint_type_ids),
+            "global_signature": global_signature,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(cache_payload.encode("utf-8")).hexdigest()
+    return f"indy_hub:craft-project:scoped-sde-signature:{digest}"
 
 
 def _payload_uses_unpublished_blueprints(payload: dict[str, object] | None) -> bool:
@@ -278,6 +302,7 @@ def get_project_workspace_scoped_sde_signature(
 ) -> dict[str, object]:
     blueprint_type_ids = sorted(_collect_payload_blueprint_type_ids(payload))
     type_ids = sorted(_collect_payload_type_ids(payload) | set(blueprint_type_ids))
+    global_signature = get_project_workspace_sde_signature()
 
     if (
         len(type_ids) > PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_ID_LIMIT
@@ -288,8 +313,17 @@ def get_project_workspace_scoped_sde_signature(
             "scope": "global-fallback",
             "type_id_count": len(type_ids),
             "blueprint_type_id_count": len(blueprint_type_ids),
-            "global_signature": get_project_workspace_sde_signature(),
+            "global_signature": global_signature,
         }
+
+    cache_key = _project_workspace_scoped_sde_signature_cache_key(
+        type_ids=type_ids,
+        blueprint_type_ids=blueprint_type_ids,
+        global_signature=global_signature,
+    )
+    cached_signature = cache.get(cache_key)
+    if isinstance(cached_signature, dict):
+        return cached_signature
 
     signature: dict[str, object] = {
         "version": PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_VERSION,
@@ -333,6 +367,11 @@ def get_project_workspace_scoped_sde_signature(
         ]
 
     if not blueprint_type_ids:
+        cache.set(
+            cache_key,
+            signature,
+            PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_CACHE_TIMEOUT_SECONDS,
+        )
         return signature
 
     product_rows = []
@@ -458,6 +497,11 @@ def get_project_workspace_scoped_sde_signature(
         )
     ]
 
+    cache.set(
+        cache_key,
+        signature,
+        PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_CACHE_TIMEOUT_SECONDS,
+    )
     return signature
 
 

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -70,6 +70,8 @@ PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY = "cachedProjectPayload"
 PROJECT_WORKSPACE_SDE_SIGNATURE_KEY = "cachedProjectSdeSignature"
 PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY = "cachedProjectScopedSdeSignature"
 PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_VERSION = 1
+PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_ID_LIMIT = 5000
+PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_QUERY_CHUNK_SIZE = 500
 LEGACY_SINGLE_BLUEPRINT_PROJECT_NOTE = (
     "Migrated from legacy single-blueprint craft flow."
 )
@@ -106,6 +108,12 @@ def get_project_workspace_sde_signature() -> dict[str, object]:
     }
 
 
+def _chunked_ids(values: Sequence[int], size: int) -> Iterable[list[int]]:
+    chunk_size = max(1, int(size or 1))
+    for index in range(0, len(values), chunk_size):
+        yield list(values[index : index + chunk_size])
+
+
 def _payload_uses_unpublished_blueprints(payload: dict[str, object] | None) -> bool:
     if not isinstance(payload, dict):
         return False
@@ -125,18 +133,25 @@ def _payload_uses_unpublished_blueprints(payload: dict[str, object] | None) -> b
     if not blueprint_type_ids:
         return False
 
-    placeholders = ", ".join(["%s"] * len(blueprint_type_ids))
+    sorted_blueprint_type_ids = sorted(blueprint_type_ids)
     with connection.cursor() as cursor:
-        cursor.execute(
-            f"""
-            SELECT id
-            FROM eve_sde_itemtype
-            WHERE id IN ({placeholders}) AND COALESCE(published, 0) = 0
-            LIMIT 1
-            """,
-            list(sorted(blueprint_type_ids)),
-        )
-        return cursor.fetchone() is not None
+        for chunk in _chunked_ids(
+            sorted_blueprint_type_ids,
+            PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_QUERY_CHUNK_SIZE,
+        ):
+            placeholders = ", ".join(["%s"] * len(chunk))
+            cursor.execute(
+                f"""
+                SELECT id
+                FROM eve_sde_itemtype
+                WHERE id IN ({placeholders}) AND COALESCE(published, 0) = 0
+                LIMIT 1
+                """,
+                chunk,
+            )
+            if cursor.fetchone() is not None:
+                return True
+    return False
 
 
 def _collect_payload_blueprint_type_ids(payload: dict[str, object] | None) -> set[int]:
@@ -264,6 +279,18 @@ def get_project_workspace_scoped_sde_signature(
     blueprint_type_ids = sorted(_collect_payload_blueprint_type_ids(payload))
     type_ids = sorted(_collect_payload_type_ids(payload) | set(blueprint_type_ids))
 
+    if (
+        len(type_ids) > PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_ID_LIMIT
+        or len(blueprint_type_ids) > PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_ID_LIMIT
+    ):
+        return {
+            "version": PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_VERSION,
+            "scope": "global-fallback",
+            "type_id_count": len(type_ids),
+            "blueprint_type_id_count": len(blueprint_type_ids),
+            "global_signature": get_project_workspace_sde_signature(),
+        }
+
     signature: dict[str, object] = {
         "version": PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_VERSION,
         "blueprint_type_ids": blueprint_type_ids,
@@ -275,132 +302,161 @@ def get_project_workspace_scoped_sde_signature(
     }
 
     if type_ids:
-        placeholders = ", ".join(["%s"] * len(type_ids))
+        item_type_rows = []
         with connection.cursor() as cursor:
-            cursor.execute(
-                f"""
-                SELECT id, COALESCE(name_en, name), COALESCE(published, 0), group_id
-                FROM eve_sde_itemtype
-                WHERE id IN ({placeholders})
-                ORDER BY id
-                """,
+            for chunk in _chunked_ids(
                 type_ids,
+                PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_QUERY_CHUNK_SIZE,
+            ):
+                placeholders = ", ".join(["%s"] * len(chunk))
+                cursor.execute(
+                    f"""
+                    SELECT id, COALESCE(name_en, name), COALESCE(published, 0), group_id
+                    FROM eve_sde_itemtype
+                    WHERE id IN ({placeholders})
+                    ORDER BY id
+                    """,
+                    chunk,
+                )
+                item_type_rows.extend(cursor.fetchall())
+        signature["item_types"] = [
+            {
+                "type_id": int(type_id),
+                "name": str(type_name or ""),
+                "published": bool(published),
+                "group_id": int(group_id) if group_id is not None else None,
+            }
+            for type_id, type_name, published, group_id in sorted(
+                item_type_rows,
+                key=lambda row: int(row[0]),
             )
-            signature["item_types"] = [
-                {
-                    "type_id": int(type_id),
-                    "name": str(type_name or ""),
-                    "published": bool(published),
-                    "group_id": int(group_id) if group_id is not None else None,
-                }
-                for type_id, type_name, published, group_id in cursor.fetchall()
-            ]
+        ]
 
     if not blueprint_type_ids:
         return signature
 
-    placeholders = ", ".join(["%s"] * len(blueprint_type_ids))
+    product_rows = []
+    material_rows = []
+    activity_rows = []
     with connection.cursor() as cursor:
-        cursor.execute(
-            f"""
-            SELECT
-                p.eve_type_id,
-                p.activity_id,
-                p.product_eve_type_id,
-                p.quantity,
-                COALESCE(product_t.name_en, product_t.name),
-                COALESCE(product_t.published, 0),
-                product_t.group_id
-            FROM indy_hub_sdeindustryactivityproduct p
-            JOIN eve_sde_itemtype product_t ON product_t.id = p.product_eve_type_id
-            WHERE p.eve_type_id IN ({placeholders})
-                AND p.activity_id IN (1, 11)
-            ORDER BY p.eve_type_id, p.activity_id, p.product_eve_type_id
-            """,
+        for chunk in _chunked_ids(
             blueprint_type_ids,
-        )
-        signature["products"] = [
-            {
-                "blueprint_type_id": int(blueprint_type_id),
-                "activity_id": int(activity_id),
-                "product_type_id": int(product_type_id),
-                "quantity": int(quantity or 0),
-                "product_name": str(product_name or ""),
-                "product_published": bool(product_published),
-                "product_group_id": (
-                    int(product_group_id) if product_group_id is not None else None
-                ),
-            }
-            for (
-                blueprint_type_id,
-                activity_id,
-                product_type_id,
-                quantity,
-                product_name,
-                product_published,
-                product_group_id,
-            ) in cursor.fetchall()
-        ]
+            PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_QUERY_CHUNK_SIZE,
+        ):
+            placeholders = ", ".join(["%s"] * len(chunk))
+            cursor.execute(
+                f"""
+                SELECT
+                    p.eve_type_id,
+                    p.activity_id,
+                    p.product_eve_type_id,
+                    p.quantity,
+                    COALESCE(product_t.name_en, product_t.name),
+                    COALESCE(product_t.published, 0),
+                    product_t.group_id
+                FROM indy_hub_sdeindustryactivityproduct p
+                JOIN eve_sde_itemtype product_t ON product_t.id = p.product_eve_type_id
+                WHERE p.eve_type_id IN ({placeholders})
+                    AND p.activity_id IN (1, 11)
+                ORDER BY p.eve_type_id, p.activity_id, p.product_eve_type_id
+                """,
+                chunk,
+            )
+            product_rows.extend(cursor.fetchall())
 
-        cursor.execute(
-            f"""
-            SELECT
-                m.eve_type_id,
-                m.activity_id,
-                m.material_eve_type_id,
-                m.quantity,
-                COALESCE(material_t.name_en, material_t.name),
-                COALESCE(material_t.published, 0),
-                material_t.group_id
-            FROM indy_hub_sdeindustryactivitymaterial m
-            JOIN eve_sde_itemtype material_t ON material_t.id = m.material_eve_type_id
-            WHERE m.eve_type_id IN ({placeholders})
-                AND m.activity_id IN (1, 11)
-            ORDER BY m.eve_type_id, m.activity_id, m.material_eve_type_id
-            """,
-            blueprint_type_ids,
-        )
-        signature["materials"] = [
-            {
-                "blueprint_type_id": int(blueprint_type_id),
-                "activity_id": int(activity_id),
-                "material_type_id": int(material_type_id),
-                "quantity": int(quantity or 0),
-                "material_name": str(material_name or ""),
-                "material_published": bool(material_published),
-                "material_group_id": (
-                    int(material_group_id) if material_group_id is not None else None
-                ),
-            }
-            for (
-                blueprint_type_id,
-                activity_id,
-                material_type_id,
-                quantity,
-                material_name,
-                material_published,
-                material_group_id,
-            ) in cursor.fetchall()
-        ]
+            cursor.execute(
+                f"""
+                SELECT
+                    m.eve_type_id,
+                    m.activity_id,
+                    m.material_eve_type_id,
+                    m.quantity,
+                    COALESCE(material_t.name_en, material_t.name),
+                    COALESCE(material_t.published, 0),
+                    material_t.group_id
+                FROM indy_hub_sdeindustryactivitymaterial m
+                JOIN eve_sde_itemtype material_t ON material_t.id = m.material_eve_type_id
+                WHERE m.eve_type_id IN ({placeholders})
+                    AND m.activity_id IN (1, 11)
+                ORDER BY m.eve_type_id, m.activity_id, m.material_eve_type_id
+                """,
+                chunk,
+            )
+            material_rows.extend(cursor.fetchall())
 
-        cursor.execute(
-            f"""
-            SELECT eve_type_id, activity_id, time
-            FROM indy_hub_sdeblueprintactivity
-            WHERE eve_type_id IN ({placeholders})
-                AND activity_id IN (1, 11)
-            ORDER BY eve_type_id, activity_id
-            """,
-            blueprint_type_ids,
+            cursor.execute(
+                f"""
+                SELECT eve_type_id, activity_id, time
+                FROM indy_hub_sdeblueprintactivity
+                WHERE eve_type_id IN ({placeholders})
+                    AND activity_id IN (1, 11)
+                ORDER BY eve_type_id, activity_id
+                """,
+                chunk,
+            )
+            activity_rows.extend(cursor.fetchall())
+
+    signature["products"] = [
+        {
+            "blueprint_type_id": int(blueprint_type_id),
+            "activity_id": int(activity_id),
+            "product_type_id": int(product_type_id),
+            "quantity": int(quantity or 0),
+            "product_name": str(product_name or ""),
+            "product_published": bool(product_published),
+            "product_group_id": (
+                int(product_group_id) if product_group_id is not None else None
+            ),
+        }
+        for (
+            blueprint_type_id,
+            activity_id,
+            product_type_id,
+            quantity,
+            product_name,
+            product_published,
+            product_group_id,
+        ) in sorted(
+            product_rows,
+            key=lambda row: (int(row[0]), int(row[1]), int(row[2])),
         )
-        signature["activities"] = [
-            {
-                "blueprint_type_id": int(blueprint_type_id),
-                "activity_id": int(activity_id),
-                "time": int(activity_time or 0),
-            }
-            for blueprint_type_id, activity_id, activity_time in cursor.fetchall()
-        ]
+    ]
+    signature["materials"] = [
+        {
+            "blueprint_type_id": int(blueprint_type_id),
+            "activity_id": int(activity_id),
+            "material_type_id": int(material_type_id),
+            "quantity": int(quantity or 0),
+            "material_name": str(material_name or ""),
+            "material_published": bool(material_published),
+            "material_group_id": (
+                int(material_group_id) if material_group_id is not None else None
+            ),
+        }
+        for (
+            blueprint_type_id,
+            activity_id,
+            material_type_id,
+            quantity,
+            material_name,
+            material_published,
+            material_group_id,
+        ) in sorted(
+            material_rows,
+            key=lambda row: (int(row[0]), int(row[1]), int(row[2])),
+        )
+    ]
+    signature["activities"] = [
+        {
+            "blueprint_type_id": int(blueprint_type_id),
+            "activity_id": int(activity_id),
+            "time": int(activity_time or 0),
+        }
+        for blueprint_type_id, activity_id, activity_time in sorted(
+            activity_rows,
+            key=lambda row: (int(row[0]), int(row[1])),
+        )
+    ]
 
     return signature
 

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -20,6 +20,18 @@
         Changes pending. Switch tabs to refresh calculations.
     </div>
 
+    {% if sde_snapshot_has_changed %}
+    <div class="alert alert-warning d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4" role="alert">
+        <div>
+            <div class="fw-semibold">{% trans "Saved snapshot uses older SDE data" %}</div>
+            <div class="small mb-0">{% trans "One of this project's blueprints, materials, products, or activity times changed since the last save. Refresh the plan from current SDE data, then save it again to update the snapshot." %}</div>
+        </div>
+        <a class="btn btn-warning btn-sm flex-shrink-0" href="{{ sde_refresh_url }}">
+            <i class="fas fa-arrows-rotate me-1"></i>{% trans "Refresh from current SDE" %}
+        </a>
+    </div>
+    {% endif %}
+
     <div id="bpTabs-loading" class="craft-bp-loading-inline" aria-live="polite" aria-busy="true">
         <svg class="craft-bp-loading-spinner" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <g>

--- a/indy_hub/tests/test_legacy_simulation_unification.py
+++ b/indy_hub/tests/test_legacy_simulation_unification.py
@@ -32,6 +32,7 @@ from indy_hub.models import (
 from indy_hub.services.production_projects import (
     LEGACY_SINGLE_BLUEPRINT_PROJECT_NOTE,
     PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY,
+    PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_ID_LIMIT,
     PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY,
     PROJECT_WORKSPACE_SDE_SIGNATURE_KEY,
     _scale_project_selected_items_for_runs,
@@ -377,6 +378,83 @@ class LegacySimulationUnificationTests(TestCase):
         project.refresh_from_db()
         self.assertEqual(project.workspace_state["blueprint_type_id"], 950)
         self.assertEqual(project.workspace_state["blueprint_name"], "Merlin Blueprint")
+
+    @patch("indy_hub.views.api.build_project_workspace_payload")
+    def test_save_workspace_scoped_signature_ignores_client_cached_payload_ids(
+        self,
+        mock_build_project_workspace_payload,
+    ):
+        project = ProductionProject.objects.create(
+            user=self.user,
+            name="Trusted Signature",
+            status=ProductionProject.Status.DRAFT,
+            source_kind=ProductionProject.SourceKind.MANUAL,
+        )
+        mock_build_project_workspace_payload.return_value = {
+            "materials_tree": [
+                {
+                    "type_id": 34,
+                    "type_name": "Tritanium",
+                    "quantity": 1,
+                    "sub_materials": [],
+                }
+            ],
+        }
+
+        request = self._prepare_request(
+            self.factory.post(
+                reverse(
+                    "indy_hub:save_production_project_workspace",
+                    args=[project.project_ref],
+                ),
+                data=json.dumps(
+                    {
+                        "runs": 1,
+                        "cachedPayload": {
+                            "materials_tree": [
+                                {
+                                    "type_id": 999999999,
+                                    "type_name": "Client supplied row",
+                                    "quantity": 1,
+                                    "sub_materials": [],
+                                }
+                            ],
+                        },
+                    }
+                ),
+                content_type="application/json",
+            )
+        )
+        response = self._save_workspace_view(request, project.project_ref)
+
+        self.assertEqual(response.status_code, 200)
+        mock_build_project_workspace_payload.assert_called_once()
+        project.refresh_from_db()
+        scoped_signature = project.workspace_state[
+            PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY
+        ]
+        self.assertIn(34, scoped_signature["type_ids"])
+        self.assertNotIn(999999999, scoped_signature["type_ids"])
+
+    def test_scoped_sde_signature_falls_back_for_oversized_payload_scope(self):
+        oversized_payload = {
+            "materials_tree": [
+                {"type_id": type_id, "sub_materials": []}
+                for type_id in range(
+                    1,
+                    PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_ID_LIMIT + 2,
+                )
+            ]
+        }
+
+        scoped_signature = get_project_workspace_scoped_sde_signature(oversized_payload)
+
+        self.assertEqual(scoped_signature["scope"], "global-fallback")
+        self.assertEqual(
+            scoped_signature["type_id_count"],
+            PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_ID_LIMIT + 1,
+        )
+        self.assertIn("global_signature", scoped_signature)
 
     def test_save_production_project_workspace_normalizes_revenue_mode(self):
         """`revenueMode` defaults to per_unit; 'total' is accepted; bad

--- a/indy_hub/tests/test_legacy_simulation_unification.py
+++ b/indy_hub/tests/test_legacy_simulation_unification.py
@@ -28,6 +28,7 @@ from indy_hub.models import (
     SDEBlueprintActivityMaterial,
     SDEBlueprintActivityProduct,
     SDEIndustryActivity,
+    SDESyncCompatState,
 )
 from indy_hub.services.production_projects import (
     LEGACY_SINGLE_BLUEPRINT_PROJECT_NOTE,
@@ -165,6 +166,13 @@ class LegacySimulationUnificationTests(TestCase):
             activity_id=1,
             material_eve_type_id=34,
             defaults={"quantity": material_quantity},
+        )
+        SDESyncCompatState.objects.update_or_create(
+            pk=1,
+            defaults={
+                "last_source_build_number": material_quantity,
+                "last_synced_at": timezone.now(),
+            },
         )
 
     def _create_cached_merlin_project(self) -> ProductionProject:
@@ -337,12 +345,7 @@ class LegacySimulationUnificationTests(TestCase):
         self.assertIn("cachedProjectPayload", project.workspace_state)
         self.assertIn("cachedProjectSdeSignature", project.workspace_state)
         self.assertIn("cachedProjectScopedSdeSignature", project.workspace_state)
-        self.assertEqual(
-            project.workspace_state["cachedProjectPayload"]["materials_tree"][0][
-                "project_inclusion_mode"
-            ],
-            "buy",
-        )
+        self.assertIsInstance(project.workspace_state["cachedProjectPayload"], dict)
 
     def test_save_production_project_workspace_preserves_blueprint_context(self):
         project = ProductionProject.objects.create(
@@ -433,8 +436,33 @@ class LegacySimulationUnificationTests(TestCase):
         scoped_signature = project.workspace_state[
             PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY
         ]
+        cached_payload = project.workspace_state[PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY]
+        self.assertEqual(cached_payload["materials_tree"][0]["type_id"], 34)
+        self.assertNotEqual(cached_payload["materials_tree"][0]["type_id"], 999999999)
         self.assertIn(34, scoped_signature["type_ids"])
         self.assertNotIn(999999999, scoped_signature["type_ids"])
+
+    def test_scoped_sde_signature_uses_cache_for_repeated_payload(self):
+        self._ensure_project_sde_rows()
+        cache.clear()
+        payload = {
+            "materials_tree": [
+                {
+                    "type_id": 603,
+                    "blueprint_type_id": 950,
+                    "sub_materials": [
+                        {"type_id": 34, "sub_materials": []},
+                    ],
+                }
+            ],
+        }
+
+        first_signature = get_project_workspace_scoped_sde_signature(payload)
+        with patch("indy_hub.services.production_projects._chunked_ids") as chunked_ids:
+            second_signature = get_project_workspace_scoped_sde_signature(payload)
+
+        chunked_ids.assert_not_called()
+        self.assertEqual(second_signature, first_signature)
 
     def test_scoped_sde_signature_falls_back_for_oversized_payload_scope(self):
         oversized_payload = {

--- a/indy_hub/tests/test_legacy_simulation_unification.py
+++ b/indy_hub/tests/test_legacy_simulation_unification.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 # Django
+from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.messages.storage.fallback import FallbackStorage
@@ -23,12 +24,21 @@ from indy_hub.models import (
     IndustryJob,
     ProductionProject,
     ProductionProjectItem,
+    SDEBlueprintActivity,
+    SDEBlueprintActivityMaterial,
+    SDEBlueprintActivityProduct,
+    SDEIndustryActivity,
 )
 from indy_hub.services.production_projects import (
     LEGACY_SINGLE_BLUEPRINT_PROJECT_NOTE,
+    PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY,
+    PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY,
+    PROJECT_WORKSPACE_SDE_SIGNATURE_KEY,
     _scale_project_selected_items_for_runs,
+    build_project_workspace_payload,
     create_project_from_single_blueprint,
     get_cached_project_workspace_payload,
+    get_project_workspace_scoped_sde_signature,
     strip_project_workspace_cache,
 )
 from indy_hub.services.project_progress import normalize_project_progress
@@ -122,6 +132,76 @@ class LegacySimulationUnificationTests(TestCase):
         request.session.save()
         setattr(request, "_messages", FallbackStorage(request))
         return request
+
+    def _ensure_project_sde_rows(self, *, material_quantity: int = 10) -> None:
+        item_type_model = apps.get_model("eve_sde", "ItemType")
+        for type_id, type_name in (
+            (34, "Tritanium"),
+            (603, "Merlin"),
+            (950, "Merlin Blueprint"),
+        ):
+            item_type_model.objects.update_or_create(
+                id=type_id,
+                defaults={"name": type_name, "published": True},
+            )
+        SDEIndustryActivity.objects.update_or_create(
+            id=1,
+            defaults={"name": "Manufacturing"},
+        )
+        SDEBlueprintActivity.objects.update_or_create(
+            eve_type_id=950,
+            activity_id=1,
+            defaults={"time": 120},
+        )
+        SDEBlueprintActivityProduct.objects.update_or_create(
+            eve_type_id=950,
+            activity_id=1,
+            product_eve_type_id=603,
+            defaults={"quantity": 1},
+        )
+        SDEBlueprintActivityMaterial.objects.update_or_create(
+            eve_type_id=950,
+            activity_id=1,
+            material_eve_type_id=34,
+            defaults={"quantity": material_quantity},
+        )
+
+    def _create_cached_merlin_project(self) -> ProductionProject:
+        self._ensure_project_sde_rows()
+        project = ProductionProject.objects.create(
+            user=self.user,
+            name="Merlin Project",
+            status=ProductionProject.Status.DRAFT,
+            source_kind=ProductionProject.SourceKind.MANUAL,
+            workspace_state={"runs": 1},
+        )
+        ProductionProjectItem.objects.create(
+            project=project,
+            type_id=603,
+            type_name="Merlin",
+            quantity_requested=1,
+            category_key="manual",
+            category_label="Manual list",
+            category_order=90,
+            is_selected=True,
+            is_craftable=True,
+            inclusion_mode=ProductionProjectItem.InclusionMode.PRODUCE,
+            blueprint_type_id=950,
+        )
+        cached_payload = build_project_workspace_payload(
+            project,
+            include_full_structure_options=False,
+        )
+        project.workspace_state = {
+            "runs": 1,
+            PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY: cached_payload,
+            PROJECT_WORKSPACE_SDE_SIGNATURE_KEY: {"global": "older"},
+            PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY: (
+                get_project_workspace_scoped_sde_signature(cached_payload)
+            ),
+        }
+        project.save(update_fields=["workspace_state", "updated_at"])
+        return project
 
     @patch("indy_hub.views.industry.create_project_from_single_blueprint")
     def test_craft_bp_redirects_to_project_workspace(self, mock_create_project):
@@ -255,6 +335,7 @@ class LegacySimulationUnificationTests(TestCase):
         )
         self.assertIn("cachedProjectPayload", project.workspace_state)
         self.assertIn("cachedProjectSdeSignature", project.workspace_state)
+        self.assertIn("cachedProjectScopedSdeSignature", project.workspace_state)
         self.assertEqual(
             project.workspace_state["cachedProjectPayload"]["materials_tree"][0][
                 "project_inclusion_mode"
@@ -452,6 +533,46 @@ class LegacySimulationUnificationTests(TestCase):
 
         self.assertIsNone(payload)
         self.assertFalse(sde_has_changed)
+
+    def test_cached_project_ignores_unrelated_global_sde_signature_change(self):
+        project = self._create_cached_merlin_project()
+
+        payload, sde_has_changed = get_cached_project_workspace_payload(project)
+
+        self.assertIsNotNone(payload)
+        self.assertFalse(sde_has_changed)
+
+        request = self._prepare_request(
+            self.factory.get(
+                reverse("indy_hub:craft_project", args=[project.project_ref])
+            )
+        )
+        response = self._craft_project_view(request, project.project_ref)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Saved snapshot uses older SDE data")
+        self.assertNotContains(response, "Refresh from current SDE")
+
+    def test_cached_project_warns_for_relevant_material_sde_change(self):
+        project = self._create_cached_merlin_project()
+        self._ensure_project_sde_rows(material_quantity=12)
+
+        payload, sde_has_changed = get_cached_project_workspace_payload(project)
+
+        self.assertIsNotNone(payload)
+        self.assertTrue(sde_has_changed)
+
+        request = self._prepare_request(
+            self.factory.get(
+                reverse("indy_hub:craft_project", args=[project.project_ref])
+            )
+        )
+        response = self._craft_project_view(request, project.project_ref)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Saved snapshot uses older SDE data")
+        self.assertContains(response, "Refresh from current SDE")
+        self.assertContains(response, "refresh_sde=1")
 
     def test_strip_project_workspace_cache_removes_pending_refresh_flags(self):
         self.assertEqual(
@@ -660,6 +781,69 @@ class LegacySimulationUnificationTests(TestCase):
         self.assertContains(response, 'id="runsInput"', html=False)
         self.assertContains(response, 'value="7"', html=False)
         self.assertContains(response, 'id="recalcNowBtn"', html=False)
+
+    @patch("indy_hub.views.industry.build_user_asset_inventory_snapshot")
+    @patch("indy_hub.views.industry._get_craft_project_stock_refresh_progress")
+    @patch("indy_hub.views.industry.build_project_workspace_payload")
+    @patch("indy_hub.views.industry.get_cached_project_workspace_payload")
+    def test_craft_project_refresh_from_sde_bypasses_saved_snapshot(
+        self,
+        mock_get_cached_project_workspace_payload,
+        mock_build_project_workspace_payload,
+        mock_get_stock_refresh_progress,
+        mock_build_user_asset_inventory_snapshot,
+    ):
+        project = ProductionProject.objects.create(
+            user=self.user,
+            name="Refresh Workspace",
+            status=ProductionProject.Status.DRAFT,
+            source_kind=ProductionProject.SourceKind.MANUAL,
+        )
+        mock_build_project_workspace_payload.return_value = {
+            "bp_type_id": 950,
+            "num_runs": 1,
+            "final_product_qty": 1,
+            "product_type_id": 603,
+            "me": 0,
+            "te": 0,
+            "materials": [],
+            "direct_materials": [],
+            "materials_tree": [],
+            "craft_cycles_summary": {},
+            "blueprint_configs_grouped": [],
+            "materials_by_group": {},
+            "market_group_map": {},
+            "recipe_map": {},
+            "debug": {},
+            "fuzzwork_price_url": "",
+            "main_bp_info": {},
+            "copy_request_preview": {},
+            "copy_request_pages": [],
+            "production_time_map": {},
+            "craft_character_advisor": {},
+            "structure_planner": {},
+            "final_outputs": [{"type_id": 603, "quantity": 1}],
+        }
+        mock_build_user_asset_inventory_snapshot.return_value = {
+            "scope_missing": False,
+            "synced_at": "",
+            "totals_by_type": {},
+            "characters": [],
+        }
+        mock_get_stock_refresh_progress.return_value = {"running": False}
+
+        request = self._prepare_request(
+            self.factory.get(
+                reverse("indy_hub:craft_project", args=[project.project_ref]),
+                data={"refresh_sde": "1"},
+            )
+        )
+        response = self._craft_project_view(request, project.project_ref)
+
+        self.assertEqual(response.status_code, 200)
+        mock_get_cached_project_workspace_payload.assert_not_called()
+        mock_build_project_workspace_payload.assert_called_once()
+        self.assertNotContains(response, "Saved snapshot uses older SDE data")
 
     @patch("indy_hub.views.industry._ensure_craft_project_stock_refresh_started")
     def test_craft_project_stock_refresh_progress_skips_recent_asset_cache(

--- a/indy_hub/views/api.py
+++ b/indy_hub/views/api.py
@@ -46,7 +46,6 @@ from ..services.production_projects import (
     PROJECT_WORKSPACE_SDE_SIGNATURE_KEY,
     build_project_import_preview,
     build_project_workspace_payload,
-    cached_project_workspace_payload_matches_state,
     create_project_from_entries,
     get_project_workspace_scoped_sde_signature,
     get_project_workspace_sde_signature,
@@ -321,19 +320,6 @@ def save_production_project_workspace(request, project_ref: str):
         "total_prod_items": int(data.get("total_prod_items") or 0),
     }
 
-    cache_validation_state = dict(workspace_state)
-    cache_validation_state["pendingWorkspaceRefresh"] = bool(
-        data.get("pendingWorkspaceRefresh")
-    )
-    cache_validation_state["pendingWorkspaceSourceTab"] = str(
-        data.get("pendingWorkspaceSourceTab") or ""
-    )
-
-    provided_cached_payload = data.get("cachedPayload")
-    reuse_cached_payload = cached_project_workspace_payload_matches_state(
-        provided_cached_payload, cache_validation_state
-    )
-
     new_name = workspace_state["simulation_name"]
     update_fields = ["workspace_state", "updated_at"]
     project.workspace_state = workspace_state
@@ -342,28 +328,19 @@ def save_production_project_workspace(request, project_ref: str):
         update_fields.append("name")
     project.save(update_fields=update_fields)
 
-    server_scoped_signature_payload = None
-    if reuse_cached_payload:
-        cached_payload = _to_serializable(provided_cached_payload)
-    else:
-        server_scoped_signature_payload = build_project_workspace_payload(
-            project,
-            skill_cache_ttl=SKILL_CACHE_TTL,
-            include_full_structure_options=False,
-        )
-        cached_payload = _to_serializable(server_scoped_signature_payload)
-    if server_scoped_signature_payload is None:
-        server_scoped_signature_payload = build_project_workspace_payload(
-            project,
-            skill_cache_ttl=SKILL_CACHE_TTL,
-            include_full_structure_options=False,
-        )
-    workspace_state[PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY] = cached_payload
+    server_cached_payload = build_project_workspace_payload(
+        project,
+        skill_cache_ttl=SKILL_CACHE_TTL,
+        include_full_structure_options=False,
+    )
+    workspace_state[PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY] = _to_serializable(
+        server_cached_payload
+    )
     workspace_state[PROJECT_WORKSPACE_SDE_SIGNATURE_KEY] = (
         get_project_workspace_sde_signature()
     )
     workspace_state[PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY] = (
-        get_project_workspace_scoped_sde_signature(server_scoped_signature_payload)
+        get_project_workspace_scoped_sde_signature(server_cached_payload)
     )
     project.workspace_state = workspace_state
     project.save(update_fields=["workspace_state", "updated_at"])

--- a/indy_hub/views/api.py
+++ b/indy_hub/views/api.py
@@ -42,11 +42,13 @@ from ..services.industry_skills import build_craft_character_advisor
 from ..services.industry_structures import resolve_solar_system_reference
 from ..services.production_projects import (
     PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY,
+    PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY,
     PROJECT_WORKSPACE_SDE_SIGNATURE_KEY,
     build_project_import_preview,
     build_project_workspace_payload,
     cached_project_workspace_payload_matches_state,
     create_project_from_entries,
+    get_project_workspace_scoped_sde_signature,
     get_project_workspace_sde_signature,
     normalize_production_project_ref,
     parse_project_me_te_overrides,
@@ -353,6 +355,9 @@ def save_production_project_workspace(request, project_ref: str):
     workspace_state[PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY] = cached_payload
     workspace_state[PROJECT_WORKSPACE_SDE_SIGNATURE_KEY] = (
         get_project_workspace_sde_signature()
+    )
+    workspace_state[PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY] = (
+        get_project_workspace_scoped_sde_signature(cached_payload)
     )
     project.workspace_state = workspace_state
     project.save(update_fields=["workspace_state", "updated_at"])

--- a/indy_hub/views/api.py
+++ b/indy_hub/views/api.py
@@ -342,22 +342,28 @@ def save_production_project_workspace(request, project_ref: str):
         update_fields.append("name")
     project.save(update_fields=update_fields)
 
+    server_scoped_signature_payload = None
     if reuse_cached_payload:
         cached_payload = _to_serializable(provided_cached_payload)
     else:
-        cached_payload = _to_serializable(
-            build_project_workspace_payload(
-                project,
-                skill_cache_ttl=SKILL_CACHE_TTL,
-                include_full_structure_options=False,
-            )
+        server_scoped_signature_payload = build_project_workspace_payload(
+            project,
+            skill_cache_ttl=SKILL_CACHE_TTL,
+            include_full_structure_options=False,
+        )
+        cached_payload = _to_serializable(server_scoped_signature_payload)
+    if server_scoped_signature_payload is None:
+        server_scoped_signature_payload = build_project_workspace_payload(
+            project,
+            skill_cache_ttl=SKILL_CACHE_TTL,
+            include_full_structure_options=False,
         )
     workspace_state[PROJECT_WORKSPACE_PAYLOAD_CACHE_KEY] = cached_payload
     workspace_state[PROJECT_WORKSPACE_SDE_SIGNATURE_KEY] = (
         get_project_workspace_sde_signature()
     )
     workspace_state[PROJECT_WORKSPACE_SCOPED_SDE_SIGNATURE_KEY] = (
-        get_project_workspace_scoped_sde_signature(cached_payload)
+        get_project_workspace_scoped_sde_signature(server_scoped_signature_payload)
     )
     project.workspace_state = workspace_state
     project.save(update_fields=["workspace_state", "updated_at"])

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -2602,6 +2602,11 @@ def craft_project(request, project_ref):
             runs_override = 1
     else:
         runs_override = None
+    refresh_from_current_sde = str(request.GET.get("refresh_sde") or "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
 
     workspace_state = strip_project_workspace_cache(project.workspace_state)
     active_tab = request.GET.get("active_tab") or workspace_state.get(
@@ -2609,7 +2614,7 @@ def craft_project(request, project_ref):
     )
     payload = None
     sde_has_changed = False
-    if runs_override is None:
+    if runs_override is None and not refresh_from_current_sde:
         payload, sde_has_changed = get_cached_project_workspace_payload(project)
     if payload is None:
         payload = build_project_workspace_payload(
@@ -2621,12 +2626,14 @@ def craft_project(request, project_ref):
         )
         sde_has_changed = False
 
+    sde_refresh_url = ""
     if sde_has_changed:
-        messages.warning(
-            request,
-            _(
-                "This craft table was loaded from its saved snapshot. The SDE changed since the last save, so the plan may differ from current data until you save it again."
-            ),
+        refresh_query = request.GET.copy()
+        refresh_query["refresh_sde"] = "1"
+        refresh_query["active_tab"] = active_tab
+        sde_refresh_url = (
+            f"{reverse('indy_hub:craft_project', args=[project.project_ref])}"
+            f"?{refresh_query.urlencode()}"
         )
 
     render_workspace_state = dict(payload.get("workspace_state") or workspace_state)
@@ -2715,6 +2722,8 @@ def craft_project(request, project_ref):
         "final_outputs": final_outputs,
         "is_project_workspace": True,
         "project": project,
+        "sde_snapshot_has_changed": sde_has_changed,
+        "sde_refresh_url": sde_refresh_url,
     }
     context.update(build_nav_context(request.user, active_tab="industry"))
     return render(request, "indy_hub/industry/Craft_BP_v2.html", context)


### PR DESCRIPTION
Fixes #87

Summary:
- Store a project-scoped SDE signature alongside saved Craft workspace snapshots.
- Compare only the SDE rows used by the project before showing the stale snapshot warning, so unrelated global SDE refreshes no longer scare users.
- Add a `Refresh from current SDE` action that bypasses the saved snapshot and rebuilds the Craft project payload from current SDE data.
- Persist server-built workspace snapshots on save so `cachedProjectPayload` and `cachedProjectScopedSdeSignature` stay consistent and do not depend on client-provided cached payloads.
- Cache scoped SDE signatures by sorted id scope plus the current global SDE signature/build state to avoid repeating chunked SDE queries on every cached project page load.
- Chunk scoped SDE signature queries and fall back to the global SDE signature for oversized scopes to avoid DB parameter limits.
- Update the changelog and add regression tests for unrelated global SDE changes, relevant material changes, refresh bypass, trusted snapshot persistence, signature cache reuse, and oversized scope fallback.

Validation:
- `/home/aadev/venv-v5/bin/python runtests.py indy_hub.tests.test_legacy_simulation_unification.LegacySimulationUnificationTests.test_save_workspace_scoped_signature_ignores_client_cached_payload_ids indy_hub.tests.test_legacy_simulation_unification.LegacySimulationUnificationTests.test_scoped_sde_signature_uses_cache_for_repeated_payload indy_hub.tests.test_legacy_simulation_unification.LegacySimulationUnificationTests.test_scoped_sde_signature_falls_back_for_oversized_payload_scope indy_hub.tests.test_legacy_simulation_unification.LegacySimulationUnificationTests.test_save_production_project_workspace_persists_workspace_state indy_hub.tests.test_legacy_simulation_unification.LegacySimulationUnificationTests.test_cached_project_warns_for_relevant_material_sde_change`
- `/home/aadev/venv-v5/bin/python runtests.py indy_hub.tests.test_legacy_simulation_unification.LegacySimulationUnificationTests`
- `DJANGO_SETTINGS_MODULE=testauth.settings.local /home/aadev/venv-v5/bin/python -m django check`
- `pre-commit run --files indy_hub/services/production_projects.py indy_hub/views/api.py indy_hub/tests/test_legacy_simulation_unification.py`
- `git diff --check`
- `tox -e py312 -q` (366 tests, OK)