### PR TITLE
Add structure scan import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Forms: Indy Hub now raises Django's `DATA_UPLOAD_MAX_NUMBER_FIELDS` to 50 000 at startup (configurable via `INDY_HUB_MAX_FORM_FIELDS`) so Material Exchange and craft project configuration pages no longer raise `TooManyFieldsSent` when thousands of EVE market groups or type ids are submitted at once.
 - Forms: Indy Hub now also raises Django's `DATA_UPLOAD_MAX_MEMORY_SIZE` to 50 MB at startup (configurable via `INDY_HUB_MAX_REQUEST_BODY_BYTES`) so saving a craft project workspace no longer fails with a generic "Failed to save table" notification when the JSON payload (cached project snapshot, decisions, structures, …) exceeds Django's 2.5 MB default body limit.
 - Blueprint Sharing: added a copy-installation cost breakdown modal to the fulfill queue, including EIV-derived install cost, structure and rig bonuses, SCI, facility/SCC taxes, and Alpha clone tax rows.
+- Industry Structures: added a structure scan importer to the Add / Edit Structure form. Pasting an EVE structure scan now applies supported Service Slots to the activity toggles and fills matching Rig Slots while ignoring combat fitting sections (issue #77).
 
 ### Changed
 

--- a/indy_hub/services/industry_structure_import.py
+++ b/indy_hub/services/industry_structure_import.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 # Standard Library
+import re
 from dataclasses import dataclass
 
 # Django
@@ -14,10 +15,13 @@ from allianceauth.services.hooks import get_extension_logger
 # AA Example App
 from indy_hub.models import IndustryStructure, IndustryStructureRig
 from indy_hub.services.industry_structures import (
+    get_industry_rig_catalog,
     get_structure_type_options,
+    is_rig_compatible_with_structure_type,
     resolve_item_type_reference,
     resolve_solar_system_location_reference,
     resolve_solar_system_reference,
+    structure_type_supports_rigs,
 )
 
 logger = get_extension_logger(__name__)
@@ -51,6 +55,36 @@ DEFAULT_DISABLED_ACTIVITY_FLAGS = {
     "enable_composite_reactions": False,
 }
 
+STRUCTURE_SCAN_MAX_LENGTH = 20000
+
+STRUCTURE_SCAN_SECTION_ALIASES = {
+    "rig slot": "rigs",
+    "rig slots": "rigs",
+    "rigs": "rigs",
+    "service slot": "services",
+    "service slots": "services",
+    "services": "services",
+    "high power slots": "ignored",
+    "medium power slots": "ignored",
+    "low power slots": "ignored",
+    "subsystem slots": "ignored",
+    "drone bay": "ignored",
+    "fighters": "ignored",
+    "cargo": "ignored",
+}
+
+STRUCTURE_SCAN_SERVICE_ACTIVITY_MAP = (
+    ("standup manufacturing plant", ("enable_manufacturing",)),
+    ("standup capital shipyard", ("enable_manufacturing_capitals",)),
+    ("standup supercapital shipyard", ("enable_manufacturing_super_capitals",)),
+    ("standup research lab", ("enable_research", "enable_invention")),
+    ("standup hyasyoda research lab", ("enable_research", "enable_invention")),
+    ("standup invention lab", ("enable_invention",)),
+    ("standup biochemical reactor", ("enable_biochemical_reactions",)),
+    ("standup hybrid reactor", ("enable_hybrid_reactions",)),
+    ("standup composite reactor", ("enable_composite_reactions",)),
+)
+
 
 @dataclass(frozen=True)
 class ParsedIndyPasteStructure:
@@ -59,6 +93,208 @@ class ParsedIndyPasteStructure:
     service_text: str
     rig_names: tuple[str, ...]
     solar_system_name: str
+
+
+@dataclass(frozen=True)
+class ParsedStructureScanLoadout:
+    service_names: tuple[str, ...]
+    rig_names: tuple[str, ...]
+    has_service_section: bool = False
+    has_rig_section: bool = False
+
+
+def _normalize_scan_value(value: str | None) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip())
+
+
+def _normalize_scan_key(value: str | None) -> str:
+    return _normalize_scan_value(value).casefold()
+
+
+def _normalize_scan_section_header(value: str | None) -> str:
+    normalized = _normalize_scan_key(value)
+    normalized = normalized.strip("[]")
+    normalized = normalized.rstrip(":")
+    return _normalize_scan_value(normalized)
+
+
+def _scan_line_item_name(line: str) -> str:
+    item_name = _normalize_scan_value(str(line or "").split("\t", 1)[0])
+    item_name = re.sub(r"\s+x\d+$", "", item_name, flags=re.IGNORECASE)
+    return item_name
+
+
+def _is_empty_scan_slot(item_name: str) -> bool:
+    normalized = _normalize_scan_key(item_name).strip("[]")
+    return not normalized or normalized.startswith("empty ") or normalized == "offline"
+
+
+def parse_structure_scan_loadout(raw_text: str) -> ParsedStructureScanLoadout:
+    services: list[str] = []
+    rigs: list[str] = []
+    active_section: str | None = None
+    has_service_section = False
+    has_rig_section = False
+
+    for raw_line in str(raw_text or "").splitlines():
+        line = _normalize_scan_value(raw_line)
+        if not line:
+            continue
+
+        section_name = _normalize_scan_section_header(line)
+        if section_name in STRUCTURE_SCAN_SECTION_ALIASES:
+            active_section = STRUCTURE_SCAN_SECTION_ALIASES[section_name]
+            if active_section == "services":
+                has_service_section = True
+            elif active_section == "rigs":
+                has_rig_section = True
+            continue
+
+        item_name = _scan_line_item_name(line)
+        if _is_empty_scan_slot(item_name):
+            continue
+
+        if active_section == "services":
+            services.append(item_name)
+        elif active_section == "rigs":
+            rigs.append(item_name)
+
+    return ParsedStructureScanLoadout(
+        service_names=tuple(services),
+        rig_names=tuple(rigs),
+        has_service_section=has_service_section,
+        has_rig_section=has_rig_section,
+    )
+
+
+def _activity_flags_from_scan_service(service_name: str) -> tuple[str, ...]:
+    normalized_service = _normalize_scan_key(service_name)
+    for service_prefix, field_names in STRUCTURE_SCAN_SERVICE_ACTIVITY_MAP:
+        if normalized_service.startswith(service_prefix):
+            return field_names
+    return ()
+
+
+def resolve_structure_scan_loadout(
+    raw_text: str,
+    *,
+    structure_type_id: int | None = None,
+) -> dict[str, object]:
+    scan_text = str(raw_text or "").strip()
+    if not scan_text:
+        return {
+            "activity_flags": dict(DEFAULT_DISABLED_ACTIVITY_FLAGS),
+            "has_service_section": False,
+            "has_rig_section": False,
+            "services": [],
+            "rigs": [],
+            "warnings": ["Paste a structure scan before importing."],
+        }
+    if len(scan_text) > STRUCTURE_SCAN_MAX_LENGTH:
+        return {
+            "activity_flags": dict(DEFAULT_DISABLED_ACTIVITY_FLAGS),
+            "has_service_section": False,
+            "has_rig_section": False,
+            "services": [],
+            "rigs": [],
+            "warnings": ["Structure scan is too large to import from this screen."],
+        }
+
+    parsed_scan = parse_structure_scan_loadout(scan_text)
+    activity_flags = dict(DEFAULT_DISABLED_ACTIVITY_FLAGS)
+    matched_services: list[dict[str, object]] = []
+    warnings: list[str] = []
+
+    for service_name in parsed_scan.service_names:
+        field_names = _activity_flags_from_scan_service(service_name)
+        if not field_names:
+            warnings.append(f"Ignored unsupported service module: {service_name}.")
+            continue
+        for field_name in field_names:
+            activity_flags[field_name] = True
+        matched_services.append(
+            {
+                "name": service_name,
+                "fields": list(field_names),
+            }
+        )
+
+    if parsed_scan.has_service_section:
+        if parsed_scan.service_names and not matched_services:
+            warnings.append(
+                "No supported industry service was found in the Service Slots section."
+            )
+        elif not parsed_scan.service_names:
+            warnings.append("No service module was found in the Service Slots section.")
+    else:
+        warnings.append("No Service Slots section was found in the pasted scan.")
+
+    resolved_structure_type_id = None
+    try:
+        resolved_structure_type_id = (
+            int(structure_type_id) if structure_type_id not in {None, ""} else None
+        )
+    except (TypeError, ValueError):
+        resolved_structure_type_id = None
+
+    supports_rigs = (
+        True
+        if resolved_structure_type_id is None
+        else structure_type_supports_rigs(resolved_structure_type_id)
+    )
+    rig_catalog_by_name = {
+        _normalize_scan_key(entry.get("name")): entry
+        for entry in get_industry_rig_catalog()
+    }
+    matched_rigs: list[dict[str, object]] = []
+
+    for rig_name in parsed_scan.rig_names[:3]:
+        if not supports_rigs:
+            warnings.append(
+                f"Ignored rig '{rig_name}': the selected structure has no rig slots."
+            )
+            continue
+
+        rig_entry = rig_catalog_by_name.get(_normalize_scan_key(rig_name))
+        if rig_entry is None:
+            warnings.append(f"Ignored unknown industrial rig: {rig_name}.")
+            continue
+
+        rig_type_id = int(rig_entry["type_id"])
+        if (
+            resolved_structure_type_id is not None
+            and not is_rig_compatible_with_structure_type(
+                rig_type_id=rig_type_id,
+                structure_type_id=resolved_structure_type_id,
+            )
+        ):
+            warnings.append(
+                f"Ignored incompatible rig '{rig_entry['name']}' for the selected structure type."
+            )
+            continue
+
+        matched_rigs.append(
+            {
+                "type_id": rig_type_id,
+                "name": str(rig_entry["name"]),
+            }
+        )
+
+    if len(parsed_scan.rig_names) > 3:
+        warnings.append("Only the first three Rig Slots entries were imported.")
+    if parsed_scan.has_rig_section and not parsed_scan.rig_names:
+        warnings.append("No rig entry was found in the Rig Slots section.")
+    elif not parsed_scan.has_rig_section:
+        warnings.append("No Rig Slots section was found in the pasted scan.")
+
+    return {
+        "activity_flags": activity_flags,
+        "has_service_section": parsed_scan.has_service_section,
+        "has_rig_section": parsed_scan.has_rig_section,
+        "services": matched_services,
+        "rigs": matched_rigs,
+        "warnings": warnings,
+    }
 
 
 def _split_tab_columns(line: str) -> list[str]:

--- a/indy_hub/static/indy_hub/css/industry_structures.css
+++ b/indy_hub/static/indy_hub/css/industry_structures.css
@@ -146,6 +146,49 @@
     flex-wrap: wrap;
 }
 
+.structure-scan-import {
+    background: var(--bs-body-bg);
+}
+
+.structure-scan-import__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.structure-scan-import__eyebrow {
+    color: var(--bs-secondary-color);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.structure-scan-import__actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.structure-scan-import__textarea {
+    font-family: var(--bs-font-monospace);
+    min-height: 9rem;
+    resize: vertical;
+}
+
+.structure-scan-import__status {
+    background: var(--bs-tertiary-bg);
+}
+
+.structure-scan-import__status--error {
+    color: var(--bs-danger-text-emphasis);
+    background: var(--bs-danger-bg-subtle);
+    border-color: var(--bs-danger-border-subtle) !important;
+}
+
 .structure-toolbar {
     display: flex;
     align-items: flex-start;

--- a/indy_hub/templates/indy_hub/industry/structure_add.html
+++ b/indy_hub/templates/indy_hub/industry/structure_add.html
@@ -144,6 +144,26 @@
                                     </div>
                                 </div>
                                 <div class="card-body px-4 py-4">
+                                    {% if not is_synced_structure_locked %}
+                                        <div class="structure-scan-import rounded-3 border p-3 mb-4" id="structure-scan-import-panel">
+                                            <div class="structure-scan-import__header">
+                                                <div>
+                                                    <div class="structure-scan-import__eyebrow">{% trans "Scan import" %}</div>
+                                                    <label class="form-label mb-1" for="structure-scan-import-input">{% trans "Import From Structure Scan" %}</label>
+                                                </div>
+                                                <div class="structure-scan-import__actions">
+                                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="structure-scan-import-clear">
+                                                        <i class="fas fa-eraser me-1"></i>{% trans "Clear" %}
+                                                    </button>
+                                                    <button type="button" class="btn btn-sm btn-primary" id="structure-scan-import-apply">
+                                                        <i class="fas fa-file-import me-1"></i>{% trans "Apply Scan" %}
+                                                    </button>
+                                                </div>
+                                            </div>
+                                            <textarea id="structure-scan-import-input" class="form-control structure-scan-import__textarea" rows="7" spellcheck="false" placeholder="{% trans 'Paste Rig Slots and Service Slots from the structure scan...' %}"></textarea>
+                                            <div id="structure-scan-import-status" class="structure-scan-import__status d-none" aria-live="polite"></div>
+                                        </div>
+                                    {% endif %}
                                     <div class="structure-services-layout">
                                         <div class="structure-services-layout__lead">
                                             <div class="structure-services-layout__eyebrow">{% trans "Service matrix" %}</div>
@@ -456,6 +476,7 @@
         const costIndexBody = document.getElementById('solar-system-cost-index-body');
         const bonusPreviewUrl = '{% url "indy_hub:industry_structure_bonus_preview" %}';
         const rigAdvisorUrl = '{% url "indy_hub:industry_structure_rig_advisor" %}';
+        const scanImportUrl = '{% url "indy_hub:industry_structure_scan_import" %}';
         const bonusPreview = document.getElementById('structure-bonus-preview');
         const bonusPreviewBody = document.getElementById('structure-bonus-preview-body');
         const rigBonusDetailModalElement = document.getElementById('rig-bonus-detail-modal');
@@ -492,6 +513,11 @@
         const rigAdvisorContextStructure = document.getElementById('rig-advisor-context-structure');
         const rigAdvisorContextSystem = document.getElementById('rig-advisor-context-system');
         const rigAdvisorContextActivities = document.getElementById('rig-advisor-context-activities');
+        const scanImportInput = document.getElementById('structure-scan-import-input');
+        const scanImportApplyButton = document.getElementById('structure-scan-import-apply');
+        const scanImportClearButton = document.getElementById('structure-scan-import-clear');
+        const scanImportStatus = document.getElementById('structure-scan-import-status');
+        const csrfTokenInput = document.querySelector('input[name="csrfmiddlewaretoken"]');
         const currentStructureId = Number('{{ structure.id|default:"" }}') || null;
         const rigSelects = Array.from(document.querySelectorAll('select[name$="-rig_type_id"]'));
         const activityToggleInputs = {
@@ -566,6 +592,144 @@
             if (commandRigsInline) {
                 commandRigsInline.textContent = installedRigs + '/3';
             }
+        }
+
+        function clearScanImportStatus() {
+            if (!scanImportStatus) {
+                return;
+            }
+            scanImportStatus.className = 'structure-scan-import__status d-none';
+            scanImportStatus.innerHTML = '';
+        }
+
+        function appendScanStatusLine(container, text, className) {
+            const line = document.createElement('div');
+            line.className = className || 'small';
+            line.textContent = text;
+            container.appendChild(line);
+        }
+
+        function renderScanImportStatus(payload, isError) {
+            if (!scanImportStatus) {
+                return;
+            }
+            scanImportStatus.innerHTML = '';
+            scanImportStatus.className = 'structure-scan-import__status rounded-3 border p-2 mt-2';
+            scanImportStatus.classList.toggle('structure-scan-import__status--error', Boolean(isError));
+
+            if (isError) {
+                appendScanStatusLine(scanImportStatus, payload && payload.message ? payload.message : 'Structure scan import failed.', 'small fw-semibold');
+                return;
+            }
+
+            const services = (payload && payload.services) || [];
+            const rigs = (payload && payload.rigs) || [];
+            const warnings = (payload && payload.warnings) || [];
+            if (services.length || rigs.length) {
+                appendScanStatusLine(scanImportStatus, 'Applied ' + services.length + ' service module(s) and ' + rigs.length + ' rig(s).', 'small fw-semibold');
+            } else {
+                appendScanStatusLine(scanImportStatus, 'No supported service module or rig was applied.', 'small fw-semibold');
+            }
+            warnings.forEach(function (warning) {
+                appendScanStatusLine(scanImportStatus, warning, 'small text-muted');
+            });
+        }
+
+        function setScanImportLoading(isLoading) {
+            if (!scanImportApplyButton) {
+                return;
+            }
+            scanImportApplyButton.disabled = Boolean(isLoading);
+            scanImportApplyButton.classList.toggle('disabled', Boolean(isLoading));
+        }
+
+        function applyScanActivityFlags(activityFlags) {
+            Object.keys(activityToggleInputs).forEach(function (fieldName) {
+                const input = activityToggleInputs[fieldName];
+                if (!input || !activityFlags || !Object.prototype.hasOwnProperty.call(activityFlags, fieldName)) {
+                    return;
+                }
+                input.checked = Boolean(activityFlags[fieldName]);
+                input.dispatchEvent(new Event('change', { bubbles: true }));
+            });
+        }
+
+        function applyScanRigs(rigs) {
+            renderRigOptions();
+            rigSelects.forEach(function (select) {
+                select.value = '';
+            });
+            (rigs || []).slice(0, rigSelects.length).forEach(function (rig, index) {
+                const select = rigSelects[index];
+                if (!select) {
+                    return;
+                }
+                const rigTypeId = String(rig.type_id || '');
+                if (!Array.from(select.options).some(function (option) { return option.value === rigTypeId; })) {
+                    return;
+                }
+                select.value = rigTypeId;
+                select.classList.add('structure-rig-slot-applied');
+                window.setTimeout(function () {
+                    select.classList.remove('structure-rig-slot-applied');
+                }, 1200);
+            });
+            rigSelects.forEach(function (select) {
+                select.dispatchEvent(new Event('change', { bubbles: true }));
+            });
+        }
+
+        function applyStructureScanPayload(payload) {
+            if (payload.has_service_section) {
+                applyScanActivityFlags(payload.activity_flags || {});
+            }
+            if (payload.has_rig_section) {
+                applyScanRigs(payload.rigs || []);
+            }
+            syncVisibleTaxFields();
+            syncRigSectionVisibility();
+            invalidateRigAdvisorCache();
+            updateRigAdvisorAvailability();
+            loadBonusPreview();
+            renderCommandDeck();
+            renderScanImportStatus(payload, false);
+        }
+
+        function importStructureScan() {
+            if (!scanImportInput) {
+                return;
+            }
+            const rawText = scanImportInput.value.trim();
+            if (!rawText) {
+                renderScanImportStatus({ message: 'Paste a structure scan before importing.' }, true);
+                return;
+            }
+            setScanImportLoading(true);
+            fetch(scanImportUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRFToken': csrfTokenInput ? csrfTokenInput.value : ''
+                },
+                body: JSON.stringify({
+                    raw_text: rawText,
+                    structure_type_id: structureTypeInput ? structureTypeInput.value : ''
+                })
+            })
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('Structure scan import failed.');
+                    }
+                    return response.json();
+                })
+                .then(applyStructureScanPayload)
+                .catch(function (error) {
+                    renderScanImportStatus({ message: error.message }, true);
+                })
+                .finally(function () {
+                    setScanImportLoading(false);
+                });
         }
 
         function syncIdentityAsideState() {
@@ -1937,6 +2101,16 @@
                 })
                 .then(renderCostIndexPreview)
                 .catch(clearCostIndexPreview);
+        }
+
+        if (scanImportApplyButton) {
+            scanImportApplyButton.addEventListener('click', importStructureScan);
+        }
+        if (scanImportClearButton && scanImportInput) {
+            scanImportClearButton.addEventListener('click', function () {
+                scanImportInput.value = '';
+                clearScanImportStatus();
+            });
         }
 
         if (!solarInput || !suggestionList) {

--- a/indy_hub/tests/test_industry_structure_registry_view.py
+++ b/indy_hub/tests/test_industry_structure_registry_view.py
@@ -726,6 +726,45 @@ Standup Composite Reactor I
             structure_type_id=35826,
         )
 
+    @patch("indy_hub.views.industry.resolve_structure_scan_loadout")
+    def test_structure_scan_import_endpoint_rejects_non_object_json_payload(
+        self, mock_resolve_structure_scan_loadout
+    ) -> None:
+        request = self._prepare_request(
+            self.factory.post(
+                reverse("indy_hub:industry_structure_scan_import"),
+                data=json.dumps([]),
+                content_type="application/json",
+            )
+        )
+
+        response = self._scan_import_view(request)
+
+        self.assertEqual(response.status_code, 400)
+        payload = json.loads(response.content.decode())
+        self.assertEqual(payload["error"], "invalid_payload")
+        mock_resolve_structure_scan_loadout.assert_not_called()
+
+    @patch("indy_hub.views.industry.resolve_structure_scan_loadout")
+    def test_structure_scan_import_endpoint_rejects_invalid_utf8_body(
+        self, mock_resolve_structure_scan_loadout
+    ) -> None:
+        request = self._prepare_request(
+            self.factory.generic(
+                "POST",
+                reverse("indy_hub:industry_structure_scan_import"),
+                data=b"\xff",
+                content_type="application/json",
+            )
+        )
+
+        response = self._scan_import_view(request)
+
+        self.assertEqual(response.status_code, 400)
+        payload = json.loads(response.content.decode())
+        self.assertEqual(payload["error"], "invalid_payload")
+        mock_resolve_structure_scan_loadout.assert_not_called()
+
     @patch(
         "indy_hub.forms.industry_structures.sde_item_types_loaded", return_value=True
     )

--- a/indy_hub/tests/test_industry_structure_registry_view.py
+++ b/indy_hub/tests/test_industry_structure_registry_view.py
@@ -21,6 +21,7 @@ from indy_hub.models import (
     IndustryStructureRig,
     IndustrySystemCostIndex,
 )
+from indy_hub.services.industry_structure_import import resolve_structure_scan_loadout
 from indy_hub.services.industry_structures import NPC_STATION_STRUCTURE_TYPE_ID
 from indy_hub.views.industry import (
     industry_structure_add,
@@ -34,6 +35,7 @@ from indy_hub.views.industry import (
     industry_structure_existing_system_structures,
     industry_structure_registry,
     industry_structure_rig_advisor,
+    industry_structure_scan_import,
     industry_structure_solar_system_cost_indices,
     industry_structure_solar_system_search,
 )
@@ -115,6 +117,10 @@ class IndustryStructureRegistryViewTests(TestCase):
     @property
     def _rig_advisor_view(self):
         return industry_structure_rig_advisor.__wrapped__.__wrapped__
+
+    @property
+    def _scan_import_view(self):
+        return industry_structure_scan_import.__wrapped__.__wrapped__.__wrapped__
 
     @patch("indy_hub.views.industry.sde_item_types_loaded", return_value=True)
     def test_registry_lists_existing_structures(self, _mock_sde_loaded) -> None:
@@ -572,6 +578,8 @@ class IndustryStructureRegistryViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Register Structure", content)
         self.assertIn("Back to Registry", content)
+        self.assertIn("Import From Structure Scan", content)
+        self.assertIn("Apply Scan", content)
         self.assertIn("Deduce Rigs", content)
         self.assertIn("Select one activity", content)
         self.assertIn("NPC Station", content)
@@ -580,6 +588,143 @@ class IndustryStructureRegistryViewTests(TestCase):
         self.assertIn('name="rigs-1-rig_type_id"', content)
         self.assertIn('name="rigs-2-rig_type_id"', content)
         self.assertNotIn('name="rigs-3-rig_type_id"', content)
+
+    @patch(
+        "indy_hub.services.industry_structure_import.structure_type_supports_rigs",
+        return_value=True,
+    )
+    @patch(
+        "indy_hub.services.industry_structure_import.is_rig_compatible_with_structure_type",
+        return_value=True,
+    )
+    @patch("indy_hub.services.industry_structure_import.get_industry_rig_catalog")
+    def test_structure_scan_resolver_extracts_services_and_rigs_from_fit_scan(
+        self,
+        mock_get_industry_rig_catalog,
+        _mock_is_rig_compatible,
+        _mock_structure_type_supports_rigs,
+    ) -> None:
+        mock_get_industry_rig_catalog.return_value = [
+            {
+                "type_id": 37170,
+                "name": "Standup L-Set Advanced Large Ship Manufacturing Efficiency I",
+                "family": "Manufacturing",
+            },
+            {
+                "type_id": 37182,
+                "name": "Standup L-Set Laboratory Optimization I",
+                "family": "Science",
+            },
+            {
+                "type_id": 37183,
+                "name": "Standup L-Set Research Cost Optimization I",
+                "family": "Science",
+            },
+        ]
+        scan_text = """High Power Slots
+Standup Heavy Energy Neutralizer I x4
+
+Medium Power Slots
+Standup Multirole Missile Launcher I x5
+
+Rig Slots
+Standup L-Set Advanced Large Ship Manufacturing Efficiency I
+Standup L-Set Laboratory Optimization I
+Standup L-Set Research Cost Optimization I
+
+Service Slots
+Standup Hyasyoda Research Lab
+Standup Cloning Center I
+"""
+
+        payload = resolve_structure_scan_loadout(scan_text, structure_type_id=35826)
+
+        self.assertTrue(payload["activity_flags"]["enable_research"])
+        self.assertTrue(payload["activity_flags"]["enable_invention"])
+        self.assertFalse(payload["activity_flags"]["enable_manufacturing"])
+        self.assertEqual(
+            [rig["type_id"] for rig in payload["rigs"]],
+            [37170, 37182, 37183],
+        )
+        warnings = " ".join(payload["warnings"])
+        self.assertIn("Standup Cloning Center I", warnings)
+        self.assertNotIn("Standup Heavy Energy Neutralizer", warnings)
+
+    @patch(
+        "indy_hub.services.industry_structure_import.structure_type_supports_rigs",
+        return_value=True,
+    )
+    @patch(
+        "indy_hub.services.industry_structure_import.is_rig_compatible_with_structure_type",
+        return_value=True,
+    )
+    @patch("indy_hub.services.industry_structure_import.get_industry_rig_catalog")
+    def test_structure_scan_resolver_supports_plain_issue_example_sections(
+        self,
+        mock_get_industry_rig_catalog,
+        _mock_is_rig_compatible,
+        _mock_structure_type_supports_rigs,
+    ) -> None:
+        mock_get_industry_rig_catalog.return_value = [
+            {
+                "type_id": 46494,
+                "name": "Standup L-Set Reactor Efficiency I",
+                "family": "Reactions",
+            },
+        ]
+
+        payload = resolve_structure_scan_loadout(
+            """Rig Slots
+Standup L-Set Reactor Efficiency I
+
+Service Slots
+Standup Biochemical Reactor I
+Standup Composite Reactor I
+""",
+            structure_type_id=35835,
+        )
+
+        self.assertTrue(payload["activity_flags"]["enable_biochemical_reactions"])
+        self.assertTrue(payload["activity_flags"]["enable_composite_reactions"])
+        self.assertFalse(payload["activity_flags"]["enable_hybrid_reactions"])
+        self.assertEqual(payload["rigs"][0]["type_id"], 46494)
+
+    @patch("indy_hub.views.industry.resolve_structure_scan_loadout")
+    def test_structure_scan_import_endpoint_returns_resolved_payload(
+        self, mock_resolve_structure_scan_loadout
+    ) -> None:
+        mock_resolve_structure_scan_loadout.return_value = {
+            "activity_flags": {"enable_research": True},
+            "services": [
+                {"name": "Standup Research Lab I", "fields": ["enable_research"]}
+            ],
+            "rigs": [
+                {"type_id": 37183, "name": "Standup L-Set Research Cost Optimization I"}
+            ],
+            "warnings": [],
+        }
+        request = self._prepare_request(
+            self.factory.post(
+                reverse("indy_hub:industry_structure_scan_import"),
+                data=json.dumps(
+                    {
+                        "raw_text": "Service Slots\nStandup Research Lab I",
+                        "structure_type_id": "35826",
+                    }
+                ),
+                content_type="application/json",
+            )
+        )
+
+        response = self._scan_import_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content.decode())
+        self.assertEqual(payload["rigs"][0]["type_id"], 37183)
+        mock_resolve_structure_scan_loadout.assert_called_once_with(
+            "Service Slots\nStandup Research Lab I",
+            structure_type_id=35826,
+        )
 
     @patch(
         "indy_hub.forms.industry_structures.sde_item_types_loaded", return_value=True

--- a/indy_hub/urls.py
+++ b/indy_hub/urls.py
@@ -59,6 +59,7 @@ from .views.industry import (
     industry_structure_existing_system_structures,
     industry_structure_registry,
     industry_structure_rig_advisor,
+    industry_structure_scan_import,
     industry_structure_solar_system_cost_indices,
     industry_structure_solar_system_search,
     personnal_bp_list,
@@ -215,6 +216,11 @@ urlpatterns = [
         "industry/structures/rig-advisor/",
         industry_structure_rig_advisor,
         name="industry_structure_rig_advisor",
+    ),
+    path(
+        "industry/structures/scan-import/",
+        industry_structure_scan_import,
+        name="industry_structure_scan_import",
     ),
     path(
         "corporation-jobs/",

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -90,7 +90,10 @@ from ..services.industry_skills import (
     build_user_character_skill_contexts,
     skill_snapshot_stale,
 )
-from ..services.industry_structure_import import import_indy_structure_paste
+from ..services.industry_structure_import import (
+    import_indy_structure_paste,
+    resolve_structure_scan_loadout,
+)
 from ..services.industry_structure_sync import get_available_structure_sync_targets
 from ..services.industry_structures import (
     COPYING_JOB_COST_BASE_PERCENT,
@@ -8050,3 +8053,31 @@ def industry_structure_rig_advisor(request):
 
     activities.sort(key=lambda entry: entry["activity_id"])
     return JsonResponse({"activities": activities})
+
+
+@indy_hub_access_required
+@login_required
+@require_http_methods(["POST"])
+def industry_structure_scan_import(request):
+    try:
+        payload = json.loads(request.body.decode("utf-8") or "{}")
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return JsonResponse({"error": "invalid_payload"}, status=400)
+
+    raw_text = str(payload.get("raw_text") or "")
+    raw_structure_type_id = payload.get("structure_type_id")
+    try:
+        structure_type_id = (
+            int(raw_structure_type_id)
+            if raw_structure_type_id not in {None, ""}
+            else None
+        )
+    except (TypeError, ValueError):
+        structure_type_id = None
+
+    return JsonResponse(
+        resolve_structure_scan_loadout(
+            raw_text,
+            structure_type_id=structure_type_id,
+        )
+    )

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -8061,7 +8061,9 @@ def industry_structure_rig_advisor(request):
 def industry_structure_scan_import(request):
     try:
         payload = json.loads(request.body.decode("utf-8") or "{}")
-    except (TypeError, ValueError, json.JSONDecodeError):
+    except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return JsonResponse({"error": "invalid_payload"}, status=400)
+    if not isinstance(payload, dict):
         return JsonResponse({"error": "invalid_payload"}, status=400)
 
     raw_text = str(payload.get("raw_text") or "")


### PR DESCRIPTION
## Summary
- Add a scan import panel to the Add/Edit Structure form for pasted EVE structure scans.
- Parse Service Slots into supported activity toggles and Rig Slots into matching compatible rig selections.
- Ignore combat fitting sections such as High/Medium/Low Power Slots and surface warnings for unsupported services or unknown/incompatible rigs.

Fixes #77

## Tests
- `/home/aadev/venv-v5/bin/python runtests.py indy_hub.tests.test_industry_structure_registry_view`
- `DJANGO_SETTINGS_MODULE=testauth.settings.local /home/aadev/venv-v5/bin/python -m django check`
- `pre-commit run --files CHANGELOG.md indy_hub/services/industry_structure_import.py indy_hub/views/industry.py indy_hub/urls.py indy_hub/templates/indy_hub/industry/structure_add.html indy_hub/static/indy_hub/css/industry_structures.css indy_hub/tests/test_industry_structure_registry_view.py`
- `tox -e py312 -q`