### PR TITLE
Prevent Indy Hub header overlap under AA themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ### Fixed
 
+- Navigation: Indy Hub pages now measure the rendered Alliance Auth top bar and offset content by its actual height, preventing Bootstrap 5 themes such as Slate/Darkly from letting wrapped module navigation overlap the page header (issue #67).
+
 - Blueprints: ESI rows with `runs=-1` are now classified as originals even when ESI also reports `quantity=-2`, character and corporation blueprint syncs persist a freshly computed `bp_type`, and a data migration repairs stale rows left behind by older releases where BPOs could remain labelled as copies after upgrade (issue #86).
 
 - Navigation: Indy Hub dropdown labels remain visible in the mobile Alliance Auth menu instead of collapsing to icon-only entries (issue #78).

--- a/indy_hub/templates/indy_hub/base.html
+++ b/indy_hub/templates/indy_hub/base.html
@@ -30,14 +30,6 @@
         text-decoration: none;
     }
 
-    /* Active state for Indy Hub nav brand */
-    .nav-link.me-auto.active {
-        color: var(--bs-primary) !important;
-        font-weight: 600;
-        border-bottom: 3px solid var(--bs-primary);
-        padding-bottom: calc(0.375rem - 3px) !important;
-    }
-
     .indy-hub-nav-badge {
         min-width: 1.55rem;
         padding: 0.25rem 0.45rem;

--- a/indy_hub/templates/indy_hub/base.html
+++ b/indy_hub/templates/indy_hub/base.html
@@ -7,6 +7,7 @@
 <style>
     :root {
         --indy-hub-header-height: 58px;
+        --aa-nav-gap: var(--indy-hub-header-height);
     }
 
     .nav-padding {
@@ -106,6 +107,7 @@
             var headerHeight = Math.ceil(navbar.getBoundingClientRect().height);
             var headerOffset = headerHeight + 'px';
             document.documentElement.style.setProperty('--indy-hub-header-height', headerOffset);
+            document.documentElement.style.setProperty('--aa-nav-gap', headerOffset);
             document.querySelectorAll('.nav-padding').forEach(function (element) {
                 element.style.setProperty('margin-top', headerOffset, 'important');
                 element.style.setProperty('max-height', 'calc(100vh - ' + headerOffset + ')', 'important');

--- a/indy_hub/templates/indy_hub/base.html
+++ b/indy_hub/templates/indy_hub/base.html
@@ -132,7 +132,7 @@
 
 {% block header_nav_brand %}
     {% block indy_hub_nav_brand %}
-        <a href="{% url 'indy_hub:index' %}" class="indy-hub-navbar-brand d-inline-flex align-items-center text-nowrap text-white text-decoration-none fw-semibold">
+        <a href="{% url 'indy_hub:index' %}" class="indy-hub-navbar-brand d-inline-flex align-items-center text-nowrap text-decoration-none fw-semibold">
             {% trans "Indy Hub" %}
         </a>
     {% endblock %}

--- a/indy_hub/templates/indy_hub/base.html
+++ b/indy_hub/templates/indy_hub/base.html
@@ -5,6 +5,30 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/dark-mode-adaptive.css' %}">
 <style>
+    :root {
+        --indy-hub-header-height: 58px;
+    }
+
+    .nav-padding {
+        margin-top: var(--indy-hub-header-height) !important;
+        max-height: calc(100vh - var(--indy-hub-header-height)) !important;
+    }
+
+    .indy-hub-navbar-brand {
+        color: var(--bs-navbar-brand-color, rgba(255, 255, 255, 0.9));
+        display: inline-flex;
+        align-items: center;
+        min-width: max-content;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .indy-hub-navbar-brand:hover,
+    .indy-hub-navbar-brand:focus {
+        color: var(--bs-navbar-brand-hover-color, #fff);
+        text-decoration: none;
+    }
+
     /* Active state for Indy Hub nav brand */
     .nav-link.me-auto.active {
         color: var(--bs-primary) !important;
@@ -70,10 +94,46 @@
     </script>
 {% endblock extra_javascript %}
 
+{% block extra_script %}
+    {{ block.super }}
+    (function () {
+        function updateIndyHubHeaderOffset() {
+            var navbar = document.querySelector('body > nav.navbar.fixed-top');
+            if (!navbar) {
+                return;
+            }
+
+            var headerHeight = Math.ceil(navbar.getBoundingClientRect().height);
+            var headerOffset = headerHeight + 'px';
+            document.documentElement.style.setProperty('--indy-hub-header-height', headerOffset);
+            document.querySelectorAll('.nav-padding').forEach(function (element) {
+                element.style.setProperty('margin-top', headerOffset, 'important');
+                element.style.setProperty('max-height', 'calc(100vh - ' + headerOffset + ')', 'important');
+            });
+        }
+
+        window.updateIndyHubHeaderOffset = updateIndyHubHeaderOffset;
+        document.addEventListener('DOMContentLoaded', updateIndyHubHeaderOffset);
+        window.addEventListener('resize', updateIndyHubHeaderOffset);
+
+        document.addEventListener('shown.bs.collapse', updateIndyHubHeaderOffset);
+        document.addEventListener('hidden.bs.collapse', updateIndyHubHeaderOffset);
+
+        if ('ResizeObserver' in window) {
+            document.addEventListener('DOMContentLoaded', function () {
+                var navbar = document.querySelector('body > nav.navbar.fixed-top');
+                if (navbar) {
+                    new ResizeObserver(updateIndyHubHeaderOffset).observe(navbar);
+                }
+            });
+        }
+    }());
+{% endblock extra_script %}
+
 {% block header_nav_brand %}
     {% block indy_hub_nav_brand %}
-        <a href="{% url 'indy_hub:index' %}" class="nav-link flex-fill align-self-center me-auto active">
-            <span class="fw-semibold">{% trans "Indy Hub" %}</span>
+        <a href="{% url 'indy_hub:index' %}" class="indy-hub-navbar-brand d-inline-flex align-items-center text-nowrap text-white text-decoration-none fw-semibold">
+            {% trans "Indy Hub" %}
         </a>
     {% endblock %}
 {% endblock header_nav_brand %}

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -3,6 +3,7 @@
 # Standard Library
 from datetime import timedelta
 from decimal import Decimal
+from html.parser import HTMLParser
 from unittest import skip
 from unittest.mock import patch
 
@@ -64,6 +65,31 @@ from indy_hub.utils.eve import get_type_name, reset_forbidden_structure_lookup_c
 from indy_hub.utils.menu_badge import compute_menu_badge_count, menu_badge_cache_key
 
 PUBLIC_STATION_ID = 60003760
+
+
+class AnchorCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.anchors: list[tuple[dict[str, str], str]] = []
+        self._active_attrs: dict[str, str] | None = None
+        self._active_text: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "a" and self._active_attrs is None:
+            self._active_attrs = {key: value or "" for key, value in attrs}
+            self._active_text = []
+
+    def handle_data(self, data: str) -> None:
+        if self._active_attrs is not None:
+            self._active_text.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "a" and self._active_attrs is not None:
+            self.anchors.append(
+                (self._active_attrs, "".join(self._active_text).strip())
+            )
+            self._active_attrs = None
+            self._active_text = []
 
 
 def ensure_base_eve_sde_loaded() -> None:
@@ -478,8 +504,19 @@ class NavbarMaterialExchangeMyOrdersTests(TestCase):
         self.assertContains(response, "--aa-nav-gap")
         self.assertContains(response, "updateIndyHubHeaderOffset")
         self.assertContains(response, "element.style.setProperty('margin-top'")
-        self.assertContains(response, "indy-hub-navbar-brand")
-        self.assertNotContains(response, "text-white text-decoration-none fw-semibold")
+
+        parser = AnchorCollector()
+        parser.feed(response.content.decode(response.charset or "utf-8"))
+        brand_classes = [
+            attrs.get("class", "")
+            for attrs, text in parser.anchors
+            if attrs.get("href") == reverse("indy_hub:index")
+            and text == "Indy Hub"
+            and "indy-hub-navbar-brand" in attrs.get("class", "").split()
+        ]
+        self.assertEqual(len(brand_classes), 1)
+        self.assertIn("indy-hub-navbar-brand", brand_classes[0].split())
+        self.assertNotIn("text-white", brand_classes[0].split())
         self.assertNotContains(
             response,
             '<a href="/indy_hub/" class="nav-link flex-fill align-self-center me-auto active">',

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -470,6 +470,19 @@ class NavbarMaterialExchangeMyOrdersTests(TestCase):
         # This URL is part of the Indy Hub navbar, not the page body.
         self.assertContains(response, reverse("indy_hub:all_bp_list"))
 
+    def test_indy_hub_navbar_offsets_content_by_rendered_height(self) -> None:
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("indy_hub:my_orders"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "--indy-hub-header-height")
+        self.assertContains(response, "updateIndyHubHeaderOffset")
+        self.assertContains(response, "element.style.setProperty('margin-top'")
+        self.assertContains(response, "indy-hub-navbar-brand")
+        self.assertNotContains(
+            response,
+            '<a href="/indy_hub/" class="nav-link flex-fill align-self-center me-auto active">',
+        )
+
     def test_my_orders_page_shows_material_hub_nav_badge_for_open_orders(self) -> None:
         settings_obj = MaterialExchangeSettings.get_solo()
         settings_obj.is_enabled = True

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -478,6 +478,7 @@ class NavbarMaterialExchangeMyOrdersTests(TestCase):
         self.assertContains(response, "updateIndyHubHeaderOffset")
         self.assertContains(response, "element.style.setProperty('margin-top'")
         self.assertContains(response, "indy-hub-navbar-brand")
+        self.assertNotContains(response, "text-white text-decoration-none fw-semibold")
         self.assertNotContains(
             response,
             '<a href="/indy_hub/" class="nav-link flex-fill align-self-center me-auto active">',

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -475,6 +475,7 @@ class NavbarMaterialExchangeMyOrdersTests(TestCase):
         response = self.client.get(reverse("indy_hub:my_orders"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "--indy-hub-header-height")
+        self.assertContains(response, "--aa-nav-gap")
         self.assertContains(response, "updateIndyHubHeaderOffset")
         self.assertContains(response, "element.style.setProperty('margin-top'")
         self.assertContains(response, "indy-hub-navbar-brand")


### PR DESCRIPTION
This updates Indy Hub's Alliance Auth header handling so Bootstrap 5 themes with taller or wrapped top navigation no longer let the fixed navbar overlap the page header.

Summary:
- replace the Indy Hub brand link's flex-filling nav-link classes with a compact non-wrapping brand link
- measure the rendered fixed navbar height at runtime and apply that value to Alliance Auth `.nav-padding` containers
- refresh the offset on resize and Bootstrap collapse show/hide events so mobile/expanded nav states stay aligned
- add a navbar rendering regression test and changelog entry

Refs #67.

Note: this intentionally does not close issue #67. We'll ask the reporters to confirm the behavior once version 1.17 is tagged.