### PR TITLE
Include Harvestable Cloud group in Material Exchange categories

### DIFF
--- a/indy_hub/views/material_exchange_config.py
+++ b/indy_hub/views/material_exchange_config.py
@@ -87,6 +87,7 @@ FORCED_INCLUDED_ITEMGROUP_IDS: set[int] = {
     448,
     14,
     12,
+    711,
     4168,
     4079,
     649,


### PR DESCRIPTION
Gas types like Fullerite-C72 sit in [ItemGroup 711 (Harvestable Cloud)](https://everef.net/groups/711) under [ItemCategory 2 (Celestial)](https://everef.net/categories/2), which is intentionally excluded from `ALLOWED_ITEMGROUP_CATEGORY_IDS`. Without an explicit override, the group was filtered out of `market_group_choices` and the search index, so the Material Exchange config page surfaced no category for those items.

Add `711` to `FORCED_INCLUDED_ITEMGROUP_IDS`, matching the existing pattern used to hand-pick the other industry-relevant Celestial groups (cargo containers, compressed gas, biomass, etc.).
