### PR TITLE
Fix: keep AA ESI token on per-endpoint 403 (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ## [Unreleased]
 
+## [1.17.2] - 2026-06-01
+
 ### Fixed
 
 - ESI client: a 403 response on a single endpoint (typically a per-structure lookup) no longer deletes the underlying Alliance Auth `Token`. The token is shared with the rest of AA, so this regression caused other modules to lose character ownership until users re-authenticated. Per-endpoint forbidden responses are now only logged; token invalidation is left to Alliance Auth's own refresh flow, and the existing per-structure forbidden cooldown still prevents retry storms. (GH-107)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ## [Unreleased]
 
+### Fixed
+
+- ESI client: a 403 response on a single endpoint (typically a per-structure lookup) no longer deletes the underlying Alliance Auth `Token`. The token is shared with the rest of AA, so this regression caused other modules to lose character ownership until users re-authenticated. Per-endpoint forbidden responses are now only logged; token invalidation is left to Alliance Auth's own refresh flow, and the existing per-structure forbidden cooldown still prevents retry storms. (GH-107)
+
 ## [1.17.1] - 2026-05-24
 
 ### Changed

--- a/indy_hub/services/esi_client.py
+++ b/indy_hub/services/esi_client.py
@@ -958,6 +958,10 @@ class ESIClient:
     def _handle_forbidden_token(
         self, token: Token, *, scope: str, endpoint: str
     ) -> None:
+        # A 403 on a single endpoint (typically a per-structure lookup) is not a
+        # token invalidation: the token is shared with the rest of Alliance Auth
+        # and other modules continue to rely on it. Only AA's own refresh flow
+        # should ever delete the Token row. See GH-107.
         character_id = getattr(token, "character_id", None)
         user_repr = None
         try:
@@ -966,20 +970,13 @@ class ESIClient:
             user_repr = getattr(token, "user_id", None)
 
         logger.warning(
-            "ESI returned 403 for %s (%s) through character %s (user %s). Token will be deleted.",
+            "ESI returned 403 for %s (%s) through character %s (user %s); "
+            "token is kept (per-endpoint forbidden, not an invalid token).",
             endpoint,
             scope,
             character_id,
             user_repr,
         )
-        try:
-            token.delete()
-        except Exception:  # pragma: no cover - defensive guard
-            logger.exception(
-                "Impossible de supprimer le jeton ESI %s pour le personnage %s",
-                token.id,
-                character_id,
-            )
 
 
 # Module level singleton to avoid re-creating sessions

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -5249,3 +5249,29 @@ class OnboardingViewsTests(TestCase):
         self.assertRedirects(response, reverse("indy_hub:index"))
         progress.refresh_from_db()
         self.assertFalse(progress.dismissed)
+
+
+class EsiClientForbiddenTokenTests(TestCase):
+    """Regression coverage for GH-107: a 403 must never delete the AA token."""
+
+    def test_handle_forbidden_token_does_not_delete_token(self) -> None:
+        # Local
+        # Standard Library
+        from unittest.mock import MagicMock
+
+        # AA Example App
+        # AA Indy Hub
+        from indy_hub.services.esi_client import shared_client
+
+        token = MagicMock()
+        token.character_id = 91000001
+        token.user.username = "tester"
+        token.id = 4242
+
+        shared_client._handle_forbidden_token(
+            token,
+            scope="esi-universe.read_structures.v1",
+            endpoint="get_universe_structures_structure_id",
+        )
+
+        token.delete.assert_not_called()


### PR DESCRIPTION
Fixes #107.

## Summary
A `403 Forbidden` response on a single ESI endpoint — typically a per-structure lookup the character does not have access to — was deleting the underlying Alliance Auth `Token`. Because that token is shared with the rest of AA, the user effectively lost character ownership / token-backed functionality across every AA module that relied on the same token until they re-authenticated.

This PR makes `_handle_forbidden_token` log-only. Token invalidation is left to Alliance Auth's own OAuth refresh flow, which is the only path that can legitimately determine that a token is no longer valid.

## Changes
- `indy_hub/services/esi_client.py::_handle_forbidden_token` no longer calls `token.delete()`. It now only emits a `warning` log line. A comment documents the rationale and links the issue.
- The existing per-structure forbidden cooldown (`set_structure_forbidden_cooldown` in `indy_hub/utils/eve.py`, used by `asset_cache.py` and `resolve_location_name`) is unchanged and still prevents retry storms against structures the character cannot see.
- New regression test `EsiClientForbiddenTokenTests.test_handle_forbidden_token_does_not_delete_token` asserts that invoking the handler never calls `token.delete()`.
- `CHANGELOG.md`: `Unreleased / Fixed` entry.

## Validation
- `/home/aadev/venv-v5/bin/python runtests.py indy_hub.tests.test_smoke.EsiClientForbiddenTokenTests indy_hub.tests.test_smoke.StructureLookupForbiddenCacheTests` — 3 tests OK
- `pre-commit run --files CHANGELOG.md indy_hub/services/esi_client.py indy_hub/tests/test_smoke.py` — all hooks green

## Acceptance criteria mapping (from #107)
- [x] A 403 from any ESI endpoint never deletes the AA `Token`.
- [x] Structure-level forbidden responses still avoid hammering the same endpoint (cooldown preserved, no code path touched).
- [x] Other AA modules that depend on the same shared token continue to work (token is no longer deleted).
- [x] Regression test covers the case.