### PR TITLE
fix(blueprints): batch eligibility/limit queries on copy request page (GH-101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ## [Unreleased]
 
+### Fixed
+
+- Blueprint sharing: the "Request a copy" page no longer issues per-card eligibility and SDE-limit queries while building each card preview. Eligibility lookups for the entire page and the native `max_production_limit` are now resolved with a constant number of queries, eliminating the N+1 pattern that could push the page beyond proxy/gateway timeouts on Alliance Auth v5 instances with thousands of shared blueprints. (GH-101)
+
 ## [1.17.2] - 2026-06-01
 
 ### Fixed

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -2735,6 +2735,55 @@ class BlueprintCopyRequestPageTests(TestCase):
         self.assertIn("max_runs_per_copy", page_entry["copy_request_preview"])
         self.assertContains(response, "bpCopyRequestModal")
 
+    def test_request_page_preview_queries_do_not_scale_with_page_size(self) -> None:
+        """GH-101: the per-entry preview must not issue N+1 eligibility queries."""
+
+        # Django
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        for index in range(1, 25):
+            Blueprint.objects.create(
+                owner_user=self.owner,
+                character_id=501,
+                item_id=9050100 + index,
+                blueprint_id=9050200 + index,
+                type_id=605001 + index,
+                location_id=PUBLIC_STATION_ID,
+                location_flag="hangar",
+                quantity=-1,
+                time_efficiency=10,
+                material_efficiency=5,
+                runs=0,
+                character_name="Supplier",
+                type_name=f"Extra Blueprint {index}",
+            )
+
+        url = reverse("indy_hub:bp_copy_request_page")
+        with CaptureQueriesContext(connection) as small_page:
+            small_response = self.client.get(url, {"per_page": 12})
+        with CaptureQueriesContext(connection) as large_page:
+            large_response = self.client.get(url, {"per_page": 96})
+
+        self.assertEqual(small_response.status_code, 200)
+        self.assertEqual(large_response.status_code, 200)
+
+        # Rendering ~8x more entries must not multiply the query count: the
+        # eligibility lookups are batched, so the delta is at most a few extra
+        # queries (template/pagination overhead).
+        self.assertLessEqual(
+            len(large_page.captured_queries) - len(small_page.captured_queries),
+            5,
+            msg=(
+                "Copy request page issued N+1 eligibility queries: "
+                f"small={len(small_page.captured_queries)}, "
+                f"large={len(large_page.captured_queries)}"
+            ),
+        )
+
+        for entry in large_response.context["page_obj"].object_list:
+            self.assertEqual(entry["copy_request_preview"]["alerted_owner_count"], 1)
+
     @patch("indy_hub.views.industry._build_copy_estimated_item_values")
     def test_request_modal_loads_estimated_copy_price_on_demand(
         self,

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -2768,9 +2768,9 @@ class BlueprintCopyRequestPageTests(TestCase):
         self.assertEqual(small_response.status_code, 200)
         self.assertEqual(large_response.status_code, 200)
 
-        # Rendering ~8x more entries must not multiply the query count: the
-        # eligibility lookups are batched, so the delta is at most a few extra
-        # queries (template/pagination overhead).
+        # Rendering a larger page (12 -> up to 25 seeded entries here) must not
+        # multiply the query count: eligibility lookups are batched, so the
+        # delta is at most a few extra queries (template/pagination overhead).
         self.assertLessEqual(
             len(large_page.captured_queries) - len(small_page.captured_queries),
             5,

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -666,7 +666,11 @@ def _eligible_owner_details_for_request(
     )
 
 
-_SENTINEL: Any = object()
+class _MissingMaxProductionLimit:
+    pass
+
+
+_SENTINEL = _MissingMaxProductionLimit()
 
 
 def _fetch_blueprint_activity_times(
@@ -762,7 +766,7 @@ def _build_copy_request_preview(
     type_name: str,
     activity_times: dict[int, dict[int, int]],
     eligible_owner_ids: set[int] | None = None,
-    max_production_limit: Any = _SENTINEL,
+    max_production_limit: int | None | _MissingMaxProductionLimit = _SENTINEL,
 ) -> dict[str, object]:
     if eligible_owner_ids is None:
         request_probe = BlueprintCopyRequest(

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -4,6 +4,7 @@
 import json
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import timedelta
 from decimal import Decimal, InvalidOperation
@@ -81,6 +82,7 @@ from ..services.corporation_blueprint_visibility import (
 )
 from ..services.craft_times import (
     compute_effective_cycle_seconds,
+    compute_max_runs_before_launch_window,
     get_max_copy_runs_per_request,
 )
 from ..services.esi_client import ESIUnmodifiedError, shared_client
@@ -664,6 +666,9 @@ def _eligible_owner_details_for_request(
     )
 
 
+_SENTINEL: Any = object()
+
+
 def _fetch_blueprint_activity_times(
     blueprint_type_ids: list[int] | set[int] | tuple[int, ...],
 ) -> dict[int, dict[int, int]]:
@@ -694,6 +699,60 @@ def _fetch_blueprint_activity_times(
     return activity_times
 
 
+def _fetch_blueprint_max_production_limits(
+    blueprint_type_ids: list[int] | set[int] | tuple[int, ...],
+) -> dict[int, int]:
+    """Batched lookup of native ``max_production_limit`` per blueprint type."""
+
+    numeric_blueprint_type_ids = sorted(
+        {
+            int(blueprint_type_id)
+            for blueprint_type_id in blueprint_type_ids
+            if blueprint_type_id
+        }
+    )
+    if not numeric_blueprint_type_ids:
+        return {}
+
+    table_names = set(connection.introspection.table_names())
+    if "eve_sde_blueprintactivity" in table_names:
+        table_name = "eve_sde_blueprintactivity"
+    elif "indy_hub_sdeblueprintactivity" in table_names:
+        table_name = "indy_hub_sdeblueprintactivity"
+    else:
+        return {}
+
+    with connection.cursor() as cursor:
+        table_description = connection.introspection.get_table_description(
+            cursor,
+            table_name,
+        )
+    available_columns = {column.name for column in table_description}
+    if "max_production_limit" not in available_columns:
+        return {}
+    if "blueprint_item_type_id" in available_columns:
+        blueprint_key_column = "blueprint_item_type_id"
+    elif "eve_type_id" in available_columns:
+        blueprint_key_column = "eve_type_id"
+    else:
+        return {}
+
+    placeholders = ", ".join(["%s"] * len(numeric_blueprint_type_ids))
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            SELECT {blueprint_key_column}, MIN(max_production_limit)
+            FROM {table_name}
+            WHERE {blueprint_key_column} IN ({placeholders})
+            AND max_production_limit IS NOT NULL
+            AND max_production_limit > 0
+            GROUP BY {blueprint_key_column}
+            """,
+            numeric_blueprint_type_ids,
+        )
+        return {int(type_id): int(limit) for type_id, limit in cursor.fetchall()}
+
+
 def _build_copy_request_preview(
     *,
     requester: User,
@@ -702,26 +761,53 @@ def _build_copy_request_preview(
     time_efficiency: int,
     type_name: str,
     activity_times: dict[int, dict[int, int]],
+    eligible_owner_ids: set[int] | None = None,
+    max_production_limit: Any = _SENTINEL,
 ) -> dict[str, object]:
-    request_probe = BlueprintCopyRequest(
-        requested_by=requester,
-        requested_by_id=requester.id,
-        type_id=type_id,
-        material_efficiency=material_efficiency,
-        time_efficiency=time_efficiency,
-        runs_requested=1,
-        copies_requested=1,
-    )
-    eligible_details = _eligible_owner_details_for_request(request_probe)
+    if eligible_owner_ids is None:
+        request_probe = BlueprintCopyRequest(
+            requested_by=requester,
+            requested_by_id=requester.id,
+            type_id=type_id,
+            material_efficiency=material_efficiency,
+            time_efficiency=time_efficiency,
+            runs_requested=1,
+            copies_requested=1,
+        )
+        eligible_owner_ids = _eligible_owner_details_for_request(
+            request_probe
+        ).owner_ids
 
     copy_base_time_seconds = (
         activity_times.get(int(type_id), {}).get(IndustryActivityMixin.ACTIVITY_COPYING)
         or 0
     )
-    max_runs_per_copy = get_max_copy_runs_per_request(
-        blueprint_type_id=type_id,
-        time_efficiency=time_efficiency,
-    )
+    if max_production_limit is _SENTINEL:
+        max_runs_per_copy = get_max_copy_runs_per_request(
+            blueprint_type_id=type_id,
+            time_efficiency=time_efficiency,
+        )
+    else:
+        manufacturing_base_time = (
+            activity_times.get(int(type_id), {}).get(
+                IndustryActivityMixin.ACTIVITY_MANUFACTURING
+            )
+            or 0
+        )
+        candidate_limits: list[int] = []
+        if max_production_limit is not None and int(max_production_limit) > 0:
+            candidate_limits.append(int(max_production_limit))
+        if manufacturing_base_time > 0:
+            effective_cycle_seconds = compute_effective_cycle_seconds(
+                base_time_seconds=manufacturing_base_time,
+                time_efficiency=time_efficiency,
+            )
+            launch_window_limit = compute_max_runs_before_launch_window(
+                effective_cycle_seconds
+            )
+            if launch_window_limit > 0:
+                candidate_limits.append(int(launch_window_limit))
+        max_runs_per_copy = min(candidate_limits) if candidate_limits else None
 
     return {
         "type_id": int(type_id),
@@ -731,11 +817,166 @@ def _build_copy_request_preview(
         "copy_base_time_seconds": int(copy_base_time_seconds or 0),
         "per_run_copy_seconds": int(copy_base_time_seconds or 0),
         "max_runs_per_copy": int(max_runs_per_copy or 0) if max_runs_per_copy else None,
-        "alerted_owner_count": int(len(eligible_details.owner_ids)),
-        "alerted_owner_ids": sorted(
-            int(owner_id) for owner_id in eligible_details.owner_ids
-        ),
+        "alerted_owner_count": int(len(eligible_owner_ids)),
+        "alerted_owner_ids": sorted(int(owner_id) for owner_id in eligible_owner_ids),
     }
+
+
+def _build_eligible_owner_ids_map(
+    requester: User,
+    blueprint_keys: Iterable[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], set[int]]:
+    """Batched equivalent of `_eligible_owner_details_for_request` for many keys.
+
+    Returns a mapping ``(type_id, ME, TE) -> set of eligible provider user ids``
+    using a constant number of DB queries regardless of the page size.
+    """
+
+    keys: set[tuple[int, int, int]] = {
+        (int(type_id), int(me), int(te)) for type_id, me, te in blueprint_keys
+    }
+    if not keys:
+        return {}
+
+    type_ids = {key[0] for key in keys}
+
+    blueprint_rows = Blueprint.objects.filter(
+        bp_type__in=[Blueprint.BPType.ORIGINAL, Blueprint.BPType.REACTION],
+        type_id__in=type_ids,
+    ).values(
+        "type_id",
+        "material_efficiency",
+        "time_efficiency",
+        "owner_kind",
+        "owner_user_id",
+        "character_id",
+        "corporation_id",
+    )
+
+    char_bps_by_key: dict[tuple[int, int, int], list[dict[str, Any]]] = defaultdict(
+        list
+    )
+    corp_ids_by_key: dict[tuple[int, int, int], set[int]] = defaultdict(set)
+    all_char_owner_user_ids: set[int] = set()
+    all_corp_ids: set[int] = set()
+
+    for row in blueprint_rows:
+        key = (
+            int(row["type_id"]),
+            int(row["material_efficiency"]),
+            int(row["time_efficiency"]),
+        )
+        if key not in keys:
+            continue
+        if row["owner_kind"] == Blueprint.OwnerKind.CHARACTER:
+            char_bps_by_key[key].append(row)
+            if row["owner_user_id"]:
+                all_char_owner_user_ids.add(row["owner_user_id"])
+        elif (
+            row["owner_kind"] == Blueprint.OwnerKind.CORPORATION
+            and row["corporation_id"]
+        ):
+            corp_ids_by_key[key].add(int(row["corporation_id"]))
+            all_corp_ids.add(int(row["corporation_id"]))
+
+    allowed_char_map: dict[int, set[int]] = defaultdict(set)
+    if all_char_owner_user_ids:
+        for setting in CharacterSettings.objects.filter(
+            user_id__in=all_char_owner_user_ids,
+            allow_copy_requests=True,
+        ).values("user_id", "character_id"):
+            allowed_char_map[setting["user_id"]].add(setting["character_id"])
+
+    corp_settings_by_corp: dict[int, list[CorporationSharingSetting]] = defaultdict(
+        list
+    )
+    if all_corp_ids:
+        for setting in CorporationSharingSetting.objects.filter(
+            corporation_id__in=all_corp_ids,
+            allow_copy_requests=True,
+            share_scope__in=[
+                CharacterSettings.SCOPE_CORPORATION,
+                CharacterSettings.SCOPE_ALLIANCE,
+                CharacterSettings.SCOPE_EVERYONE,
+            ],
+        ):
+            if setting.corporation_id:
+                corp_settings_by_corp[int(setting.corporation_id)].append(setting)
+
+    explicit_corp_manager_ids: set[int] = set()
+    corp_user_chars: dict[int, dict[int, set[int]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+    if corp_settings_by_corp:
+        explicit_corp_manager_ids = _get_explicit_corp_bp_manager_ids()
+        if explicit_corp_manager_ids:
+            for membership in CharacterOwnership.objects.filter(
+                character__corporation_id__in=set(corp_settings_by_corp.keys()),
+            ).values("user_id", "character__corporation_id", "character__character_id"):
+                corp_id = membership.get("character__corporation_id")
+                user_id = membership.get("user_id")
+                char_id = membership.get("character__character_id")
+                if corp_id and user_id:
+                    corp_user_chars[int(corp_id)][int(user_id)].add(char_id)
+
+    requester_id = requester.id
+    result: dict[tuple[int, int, int], set[int]] = {}
+    for key in keys:
+        owner_ids: set[int] = set()
+
+        for bp in char_bps_by_key.get(key, []):
+            user_id = bp.get("owner_user_id")
+            if not user_id:
+                continue
+            char_id = bp.get("character_id")
+            allowed_chars = allowed_char_map.get(user_id)
+            if not allowed_chars:
+                continue
+            if 0 in allowed_chars or char_id is None or char_id in allowed_chars:
+                owner_ids.add(int(user_id))
+
+        key_corp_ids = corp_ids_by_key.get(key, set())
+        key_corp_settings: list[CorporationSharingSetting] = []
+        corporate_owner_ids: set[int] = set()
+        for corp_id in key_corp_ids:
+            for setting in corp_settings_by_corp.get(corp_id, []):
+                owner_ids.add(int(setting.user_id))
+                corporate_owner_ids.add(int(setting.user_id))
+                key_corp_settings.append(setting)
+
+        if key_corp_settings and explicit_corp_manager_ids:
+            settings_by_corp_local: dict[int, list[CorporationSharingSetting]] = (
+                defaultdict(list)
+            )
+            for setting in key_corp_settings:
+                settings_by_corp_local[int(setting.corporation_id)].append(setting)
+            for corp_id, users in corp_user_chars.items():
+                if corp_id not in key_corp_ids:
+                    continue
+                local_settings = settings_by_corp_local.get(corp_id)
+                if not local_settings:
+                    continue
+                for user_id, char_ids in users.items():
+                    if user_id not in explicit_corp_manager_ids:
+                        continue
+                    if user_id in corporate_owner_ids:
+                        continue
+                    if user_id == requester_id:
+                        continue
+                    if any(
+                        not setting_obj.restricts_characters
+                        or any(
+                            setting_obj.is_character_authorized(char_id)
+                            for char_id in char_ids
+                        )
+                        for setting_obj in local_settings
+                    ):
+                        owner_ids.add(int(user_id))
+
+        owner_ids.discard(requester_id)
+        result[key] = owner_ids
+
+    return result
 
 
 def _build_blueprint_copy_request_notification_content(
@@ -3079,7 +3320,24 @@ def bp_copy_request_page(request):
     page_obj = paginator.get_page(page)
     page_blueprint_type_ids = [entry["type_id"] for entry in page_obj.object_list]
     activity_times = _fetch_blueprint_activity_times(page_blueprint_type_ids)
+    max_production_limits = _fetch_blueprint_max_production_limits(
+        page_blueprint_type_ids
+    )
+    page_keys = [
+        (
+            int(entry["type_id"]),
+            int(entry["material_efficiency"]),
+            int(entry["time_efficiency"]),
+        )
+        for entry in page_obj.object_list
+    ]
+    eligible_owner_ids_map = _build_eligible_owner_ids_map(request.user, page_keys)
     for entry in page_obj.object_list:
+        key = (
+            int(entry["type_id"]),
+            int(entry["material_efficiency"]),
+            int(entry["time_efficiency"]),
+        )
         entry["copy_request_preview"] = _build_copy_request_preview(
             requester=request.user,
             type_id=int(entry["type_id"]),
@@ -3087,6 +3345,8 @@ def bp_copy_request_page(request):
             time_efficiency=int(entry["time_efficiency"]),
             type_name=str(entry["type_name"]),
             activity_times=activity_times,
+            eligible_owner_ids=eligible_owner_ids_map.get(key, set()),
+            max_production_limit=max_production_limits.get(int(entry["type_id"])),
         )
     page_range = paginator.get_elided_page_range(
         number=page_obj.number, on_each_side=5, on_ends=1


### PR DESCRIPTION
Closes #101.

## Problem

On Alliance Auth v5, opening the blueprint copy request page (`bp_copy_request_page`) could take long enough to time out at the proxy/gateway layer on production instances with realistic data volumes (several thousand shared blueprints).

## Root cause

The page paginates the visible blueprints (default 24/page, up to 96), but for each card it called:

- `_eligible_owner_details_for_request` — several DB queries (`Blueprint`, `CharacterSettings`, `CorporationSharingSetting`, `CharacterOwnership`, permission resolution).
- `get_max_copy_runs_per_request` — two more SDE queries (`introspection.table_names`, `introspection.get_table_description`, then `SELECT MIN(max_production_limit)`, plus another `SDEBlueprintActivity` query for the launch-window limit).

That's a textbook N+1: query count scaled linearly with page size and, on AA5 instances with many shared blueprints, with the user's blueprint footprint reachable through the eligibility joins.

## Fix

- New `_build_eligible_owner_ids_map(user, [(type_id, ME, TE), ...])` resolves eligible provider user ids for the whole page in a constant number of queries (one per source: blueprints, character settings, corp sharing settings, optional `CharacterOwnership` join when explicit corp BP managers exist).
- New `_fetch_blueprint_max_production_limits([type_ids])` batches the SDE `max_production_limit` lookup with a single `GROUP BY` query (preserving the existing schema-introspection logic).
- The launch-window limit is now computed in Python from the already-batched `_fetch_blueprint_activity_times` result, instead of re-querying the SDE per card.
- `_build_copy_request_preview` gains optional `eligible_owner_ids` and `max_production_limit` parameters; when omitted, behavior is unchanged (legacy callers still work).

## Validation

- New regression smoke test `BlueprintCopyRequestPageTests.test_request_page_preview_queries_do_not_scale_with_page_size` seeds ~25 shared blueprints and uses `CaptureQueriesContext` to assert the query delta between `per_page=12` and `per_page=96` stays bounded (≤5 extra queries). Before the fix the delta was 116; after the fix it is well under the bound.
- Full smoke module: `runtests.py indy_hub.tests.test_smoke` — 125 tests, OK (2 skipped).
- `pre-commit run --all-files` — all hooks pass.
- `tox` — see CI.

## Acceptance criteria mapping

- ✅ Page load bounded regardless of dataset size (constant per-card DB cost).
- ✅ No regression on AA4 (logic unchanged, only batched).
- ✅ Behavior covered by a smoke regression test.