### PR TITLE
fix(perf): bound skill-context queries for high character counts (GH-110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 ### Fixed
 
 - Blueprint sharing: the "Request a copy" page no longer issues per-card eligibility and SDE-limit queries while building each card preview. Eligibility lookups for the entire page and the native `max_production_limit` are now resolved with a constant number of queries, eliminating the N+1 pattern that could push the page beyond proxy/gateway timeouts on Alliance Auth v5 instances with thousands of shared blueprints. (GH-101)
+- Character skill context loading no longer performs one `EveCharacter` lookup per linked character when building dashboard/industry skill rows. Character names are now read from the already joined ownership records (with fallback only when missing), keeping query counts bounded for users with large linked-character sets. (GH-110)
 
 ## [1.17.2] - 2026-06-01
 

--- a/indy_hub/services/industry_skills.py
+++ b/indy_hub/services/industry_skills.py
@@ -312,7 +312,8 @@ def build_user_character_skill_contexts(
         rows.append(
             {
                 "character_id": character_id,
-                "name": get_character_name(character_id),
+                "name": (char.character_name or "").strip()
+                or get_character_name(character_id),
                 "skills_missing": skills_missing,
                 "snapshot": snapshot,
                 "skill_levels": (

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -48,6 +48,7 @@ from indy_hub.models import (
 )
 from indy_hub.notifications import notify_user
 from indy_hub.services.esi_client import ESIForbiddenError
+from indy_hub.services.industry_skills import build_user_character_skill_contexts
 from indy_hub.services.location_population import (
     LocationTarget,
     _resolve_location_name_for_target,
@@ -4135,6 +4136,71 @@ class DashboardUnusedSlotsSummaryTests(TestCase):
         summary = response.context["unused_slots_summary"]
         self.assertEqual(summary["manufacturing"]["total"], 10)
         self.assertEqual(summary["manufacturing"]["available"], 10)
+
+
+class CharacterSkillContextQueryScalingTests(TestCase):
+    def _create_user_with_characters(
+        self, username: str, count: int, *, start_character_id: int
+    ) -> User:
+        user = User.objects.create_user(username, password="secret123")
+        UserProfile.objects.get_or_create(user=user)
+        for index in range(1, count + 1):
+            character_id = start_character_id + index
+            character = EveCharacter.objects.create(
+                character_id=character_id,
+                character_name=f"Pilot {character_id}",
+                corporation_id=2_000_000,
+                corporation_name="Test Corp",
+                corporation_ticker="TEST",
+            )
+            CharacterOwnership.objects.create(
+                user=user,
+                character=character,
+                owner_hash=f"hash-{user.id}-{character_id}",
+            )
+        return user
+
+    def test_skill_context_queries_do_not_scale_with_character_count(self) -> None:
+        # Django
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        small_user = self._create_user_with_characters(
+            "skills_small", 5, start_character_id=77000000
+        )
+        large_user = self._create_user_with_characters(
+            "skills_large", 40, start_character_id=88000000
+        )
+
+        eve_utils._CHAR_NAME_CACHE.clear()
+        with CaptureQueriesContext(connection) as small_queries:
+            small_rows = build_user_character_skill_contexts(
+                small_user,
+                skill_cache_ttl=timedelta(hours=1),
+            )
+
+        eve_utils._CHAR_NAME_CACHE.clear()
+        with CaptureQueriesContext(connection) as large_queries:
+            large_rows = build_user_character_skill_contexts(
+                large_user,
+                skill_cache_ttl=timedelta(hours=1),
+            )
+
+        self.assertEqual(len(small_rows), 5)
+        self.assertEqual(len(large_rows), 40)
+        self.assertTrue(all(row["name"].startswith("Pilot ") for row in large_rows))
+
+        # Query count should stay near-constant as character count increases:
+        # ownerships, snapshots, tokens, and active jobs are fetched in batches.
+        self.assertLessEqual(
+            len(large_queries.captured_queries) - len(small_queries.captured_queries),
+            3,
+            msg=(
+                "Skill context query count scaled with linked characters: "
+                f"small={len(small_queries.captured_queries)}, "
+                f"large={len(large_queries.captured_queries)}"
+            ),
+        )
 
 
 class PersonnalBlueprintViewTests(TestCase):

--- a/indy_hub/views/user.py
+++ b/indy_hub/views/user.py
@@ -2322,6 +2322,11 @@ def index(request):
             for row in character_contexts
             if int(row.get("character_id") or 0) > 0
         ]
+        character_context_by_id = {
+            int(row.get("character_id") or 0): row
+            for row in character_contexts
+            if int(row.get("character_id") or 0) > 0
+        }
         now = timezone.now()
 
         active_job_rows = (
@@ -2372,14 +2377,7 @@ def index(request):
         }
 
         for char_id in character_ids:
-            row = next(
-                (
-                    character_context
-                    for character_context in character_contexts
-                    if int(character_context.get("character_id") or 0) == char_id
-                ),
-                None,
-            )
+            row = character_context_by_id.get(char_id)
             if not row:
                 continue
 

--- a/indy_hub/views/user.py
+++ b/indy_hub/views/user.py
@@ -2317,16 +2317,14 @@ def index(request):
             request.user,
             skill_cache_ttl=timedelta(hours=1),
         )
-        character_ids = [
-            int(row.get("character_id") or 0)
-            for row in character_contexts
-            if int(row.get("character_id") or 0) > 0
-        ]
-        character_context_by_id = {
-            int(row.get("character_id") or 0): row
-            for row in character_contexts
-            if int(row.get("character_id") or 0) > 0
-        }
+        character_ids: list[int] = []
+        character_context_by_id: dict[int, dict[str, object]] = {}
+        for row in character_contexts:
+            char_id = int(row.get("character_id") or 0)
+            if char_id <= 0:
+                continue
+            character_ids.append(char_id)
+            character_context_by_id[char_id] = row
         now = timezone.now()
 
         active_job_rows = (


### PR DESCRIPTION
Closes #110.

## Problem
Users with many linked Alliance Auth characters (e.g. 40+) experienced degraded page responsiveness due to scaling issues in character-skill context and dashboard slot summary paths.

## Root cause
1. `build_user_character_skill_contexts` resolved each character name via `get_character_name(character_id)`, causing an extra DB lookup per linked character even though `EveCharacter` is already loaded via `CharacterOwnership.select_related("character")`.
2. Dashboard slot summary scanned `character_contexts` with `next(...)` inside a loop over `character_ids`, creating an O(n^2) in-memory path for larger alt counts.

## Fix
- `indy_hub/services/industry_skills.py`
  - Use `ownership.character.character_name` directly.
  - Keep fallback to `get_character_name(character_id)` only if blank/missing.
- `indy_hub/views/user.py`
  - Build `character_context_by_id` once and do O(1) lookups during aggregation.
- `indy_hub/tests/test_smoke.py`
  - Add `CharacterSkillContextQueryScalingTests.test_skill_context_queries_do_not_scale_with_character_count` (5 vs 40 linked characters, bounded query delta).
- `CHANGELOG.md`
  - Add Unreleased/Fixed note for GH-110.

## Validation
- Targeted smoke tests pass:
  - `CharacterSkillContextQueryScalingTests`
  - `DashboardUnusedSlotsSummaryTests`
- `pre-commit` passes on changed files.