### PR TITLE
Fix Craft workspace quantity input widths (GH-105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Blueprint sharing: the "Request a copy" page no longer issues per-card eligibility and SDE-limit queries while building each card preview. Eligibility lookups for the entire page and the native `max_production_limit` are now resolved with a constant number of queries, eliminating the N+1 pattern that could push the page beyond proxy/gateway timeouts on Alliance Auth v5 instances with thousands of shared blueprints. (GH-101)
 - Character skill context loading no longer performs one `EveCharacter` lookup per linked character when building dashboard/industry skill rows. Character names are now read from the already joined ownership records (with fallback only when missing), keeping query counts bounded for users with large linked-character sets. (GH-110)
+- Crafting Projects / Workspace: quantity-oriented numeric inputs (runs, buy-tolerance override, stock allocation, and financial buy/sell override fields) now reserve enough width to display large industrial values without inner clipping, while keeping right-aligned numeric readability on desktop and mobile. (GH-105)
 
 ## [1.17.2] - 2026-06-01
 

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3253,6 +3253,59 @@ html[data-theme="darkly"] #blueprintSearchInput {
     overflow-wrap: anywhere;
 }
 
+/* Buy tab hardening: keep numeric columns visible under high zoom. */
+#buy-pane .craft-financial-table table {
+    table-layout: fixed;
+}
+
+#buy-pane .craft-financial-table .col-item {
+    width: 34%;
+}
+
+#buy-pane .craft-financial-table .col-qty {
+    width: 10%;
+}
+
+#buy-pane .craft-financial-table .col-fuzzwork,
+#buy-pane .craft-financial-table .col-real {
+    width: 14%;
+}
+
+#buy-pane .craft-financial-table .col-total {
+    width: 16%;
+}
+
+#buy-pane .craft-financial-table .col-margin {
+    width: 12%;
+}
+
+#buy-pane .craft-financial-table th,
+#buy-pane .craft-financial-table td,
+#buy-pane .craft-financial-table th.text-end,
+#buy-pane .craft-financial-table td.text-end {
+    overflow: visible;
+    white-space: normal;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+}
+
+#buy-pane .craft-financial-table input.fuzzwork-price,
+#buy-pane .craft-financial-table input.real-price,
+#buy-pane .craft-financial-table input.sale-price-unit {
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
+}
+
+#buy-pane .craft-financial-table .craft-financial-item-shell {
+    gap: 0.4rem;
+}
+
+#buy-pane .craft-financial-table .craft-planner-item-name {
+    white-space: normal;
+    line-height: 1.15;
+}
+
 @media (min-width: 1800px) {
     .craft-bp-workspace {
         max-width: 2400px;
@@ -3295,6 +3348,21 @@ html[data-theme="darkly"] #blueprintSearchInput {
         padding-inline: 0.85rem;
     }
 
+    #buy-pane .craft-financial-table .col-item {
+        width: 30%;
+    }
+
+    #buy-pane .craft-financial-table .col-qty {
+        width: 9%;
+    }
+
+    #buy-pane .craft-financial-table .col-fuzzwork,
+    #buy-pane .craft-financial-table .col-real,
+    #buy-pane .craft-financial-table .col-total,
+    #buy-pane .craft-financial-table .col-margin {
+        width: 15.25%;
+    }
+
     .craft-financial-table .col-qty,
     .craft-financial-table .col-fuzzwork,
     .craft-financial-table .col-real,
@@ -3321,6 +3389,26 @@ html[data-theme="darkly"] #blueprintSearchInput {
     .craft-stock-table-wrap,
     .craft-decision-table-wrap {
         overflow-x: clip;
+    }
+
+    #buy-pane .craft-financial-table .craft-financial-item-shell > img,
+    #buy-pane .craft-financial-table .financial-row-reset {
+        display: none !important;
+    }
+
+    #buy-pane .craft-financial-table .col-item {
+        width: 26%;
+    }
+
+    #buy-pane .craft-financial-table .col-qty {
+        width: 8%;
+    }
+
+    #buy-pane .craft-financial-table .col-fuzzwork,
+    #buy-pane .craft-financial-table .col-real,
+    #buy-pane .craft-financial-table .col-total,
+    #buy-pane .craft-financial-table .col-margin {
+        width: 16.5%;
     }
 
     .craft-financial-table th,
@@ -3365,6 +3453,19 @@ html[data-theme="darkly"] #blueprintSearchInput {
     .craft-decision-table th,
     .craft-decision-table td {
         font-size: 0.72rem;
+    }
+
+    #buy-pane .craft-financial-table table {
+        table-layout: auto;
+    }
+
+    #buy-pane .craft-financial-table .col-item,
+    #buy-pane .craft-financial-table .col-qty,
+    #buy-pane .craft-financial-table .col-fuzzwork,
+    #buy-pane .craft-financial-table .col-real,
+    #buy-pane .craft-financial-table .col-total,
+    #buy-pane .craft-financial-table .col-margin {
+        width: auto;
     }
 
     .craft-stock-table .craft-stock-allocation-input,

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3424,6 +3424,14 @@ html[data-theme="darkly"] #blueprintSearchInput {
         --craft-col-label: var(--craft-col-8);
     }
 
+    .craft-stackable-table tbody td:nth-child(9) {
+        --craft-col-label: var(--craft-col-9);
+    }
+
+    .craft-stackable-table tbody td:nth-child(10) {
+        --craft-col-label: var(--craft-col-10);
+    }
+
     .craft-stackable-table tbody tr.craft-financial-section-row td,
     .craft-stackable-table tbody tr.craft-financial-group-row td,
     .craft-stackable-table tbody tr.craft-stock-section-row td,

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3231,7 +3231,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
 
 .craft-nav-tabs {
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     align-items: stretch;
     gap: 0.5rem;
     margin-bottom: 1rem;
@@ -3239,14 +3239,12 @@ html[data-theme="darkly"] #blueprintSearchInput {
     border: 1px solid color-mix(in srgb, var(--bs-border-color) 75%, transparent);
     border-radius: 0.9rem;
     background: color-mix(in srgb, var(--bs-secondary-bg) 72%, var(--bs-body-bg));
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: thin;
-    -webkit-overflow-scrolling: touch;
+    overflow: visible !important;
 }
 
 .craft-nav-tabs .nav-item {
-    flex: 0 0 auto;
+    flex: 1 1 120px;
+    min-width: 0;
 }
 
 .craft-nav-tabs .nav-link {
@@ -3664,6 +3662,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
     .craft-nav-tabs {
         gap: 0.42rem;
         padding: 0.32rem;
+        overflow: visible !important;
     }
 
     .craft-nav-tabs .nav-link {

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3186,21 +3186,19 @@ html[data-theme="darkly"] #blueprintSearchInput {
 
 .craft-nav-tabs {
     display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    overflow-y: hidden;
+    flex-wrap: wrap;
+    overflow: visible;
     gap: 0.6rem;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: thin;
 }
 
 .craft-nav-tabs .nav-item {
-    flex: 0 0 auto;
+    flex: 1 1 160px;
 }
 
 .craft-nav-tabs .nav-link {
     min-height: 50px;
-    white-space: nowrap;
+    white-space: normal;
+    width: 100%;
 }
 
 .craft-quick-stats {
@@ -3224,17 +3222,28 @@ html[data-theme="darkly"] #blueprintSearchInput {
 }
 
 .craft-financial-table {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    overflow: visible;
 }
 
 .craft-financial-table table {
-    min-width: 960px;
+    min-width: 0;
+    table-layout: auto;
 }
 
 .craft-stock-table,
 .craft-decision-table {
-    min-width: 980px;
+    min-width: 0;
+    table-layout: auto;
+}
+
+.craft-financial-table th,
+.craft-financial-table td,
+.craft-stock-table th,
+.craft-stock-table td,
+.craft-decision-table th,
+.craft-decision-table td {
+    white-space: normal;
+    overflow-wrap: anywhere;
 }
 
 .craft-section-title,
@@ -3285,6 +3294,14 @@ html[data-theme="darkly"] #blueprintSearchInput {
     .craft-nav-tabs .nav-link {
         padding-inline: 0.85rem;
     }
+
+    .craft-financial-table .col-qty,
+    .craft-financial-table .col-fuzzwork,
+    .craft-financial-table .col-real,
+    .craft-financial-table .col-total,
+    .craft-financial-table .col-margin {
+        width: auto;
+    }
 }
 
 @media (max-width: 992px) {
@@ -3292,14 +3309,28 @@ html[data-theme="darkly"] #blueprintSearchInput {
         max-width: 100%;
     }
 
-    .craft-financial-table table,
-    .craft-stock-table,
-    .craft-decision-table {
-        min-width: 860px;
-    }
-
     .craft-quick-stats {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .craft-nav-tabs .nav-item {
+        flex: 1 1 calc(50% - 0.6rem);
+    }
+
+    .craft-financial-table,
+    .craft-stock-table-wrap,
+    .craft-decision-table-wrap {
+        overflow-x: clip;
+    }
+
+    .craft-financial-table th,
+    .craft-financial-table td,
+    .craft-stock-table th,
+    .craft-stock-table td,
+    .craft-decision-table th,
+    .craft-decision-table td {
+        padding: 0.4rem 0.28rem;
+        font-size: 0.76rem;
     }
 }
 
@@ -3323,10 +3354,23 @@ html[data-theme="darkly"] #blueprintSearchInput {
         font-size: 0.8rem;
     }
 
-    .craft-financial-table table,
-    .craft-stock-table,
-    .craft-decision-table {
-        min-width: 760px;
+    .craft-nav-tabs .nav-item {
+        flex: 1 1 100%;
+    }
+
+    .craft-financial-table th,
+    .craft-financial-table td,
+    .craft-stock-table th,
+    .craft-stock-table td,
+    .craft-decision-table th,
+    .craft-decision-table td {
+        font-size: 0.72rem;
+    }
+
+    .craft-stock-table .craft-stock-allocation-input,
+    .craft-financial-table input[type="number"] {
+        width: 100%;
+        min-width: 0;
     }
 }
 
@@ -3340,10 +3384,6 @@ html[data-theme="darkly"] #blueprintSearchInput {
         width: 100%;
     }
 
-    .craft-nav-tabs {
-        padding-bottom: 0.2rem;
-    }
-
     .craft-nav-tabs .nav-link {
         min-height: 44px;
         padding: 0.62rem 0.8rem;
@@ -3355,9 +3395,13 @@ html[data-theme="darkly"] #blueprintSearchInput {
         text-overflow: ellipsis;
     }
 
-    .craft-financial-table table,
-    .craft-stock-table,
-    .craft-decision-table {
-        min-width: 700px;
+    .craft-financial-table th,
+    .craft-financial-table td,
+    .craft-stock-table th,
+    .craft-stock-table td,
+    .craft-decision-table th,
+    .craft-decision-table td {
+        padding: 0.34rem 0.2rem;
+        font-size: 0.68rem;
     }
 }

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -1841,6 +1841,19 @@ div[id="bpTabs"] {
     height: 1.875rem;
 }
 
+/* Keep large industrial quantities readable without changing behavior. */
+.craft-bp-workspace #runsInput,
+.craft-bp-workspace #decisionBuyToleranceInput,
+.craft-bp-workspace #financialRevenueTotalOverride,
+.craft-bp-workspace .craft-stock-allocation-input,
+.craft-bp-workspace .craft-financial-table input.real-price,
+.craft-bp-workspace .craft-financial-table input.sale-price-unit {
+    min-width: 10ch;
+    width: min(16ch, 100%);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
 .craft-financial-table input.readonly {
     background-color: var(--bs-secondary-bg) !important;
     border-color: var(--bs-border-color) !important;
@@ -2586,7 +2599,7 @@ html[data-theme="darkly"] .craft-header-icon {
 }
 
 .craft-decision-tolerance {
-    width: min(220px, 100%);
+    width: min(320px, 100%);
 }
 
 .craft-decision-table-wrap {
@@ -2744,6 +2757,16 @@ html[data-theme="darkly"] .craft-header-icon {
 
     .craft-decision-tolerance {
         width: 100%;
+    }
+
+    .craft-bp-workspace #runsInput,
+    .craft-bp-workspace #decisionBuyToleranceInput,
+    .craft-bp-workspace #financialRevenueTotalOverride,
+    .craft-bp-workspace .craft-stock-allocation-input,
+    .craft-bp-workspace .craft-financial-table input.real-price,
+    .craft-bp-workspace .craft-financial-table input.sale-price-unit {
+        min-width: 9ch;
+        width: min(14ch, 100%);
     }
 
     .craft-decision-metrics {

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3255,11 +3255,6 @@ html[data-theme="darkly"] #blueprintSearchInput {
 
 /* Buy tab: container-aware layout that reflows the planner into stacked
  * cards when the pane itself becomes narrow (zoom, mobile, split-screen). */
-#buy-pane .craft-financial-table {
-    container-type: inline-size;
-    container-name: buy-planner;
-}
-
 #buy-pane .craft-financial-table table {
     table-layout: fixed;
 }
@@ -3312,21 +3307,32 @@ html[data-theme="darkly"] #blueprintSearchInput {
     line-height: 1.15;
 }
 
-/* Stacked-card mode: triggered by the pane's own width so it works for
- * every cause of narrowness (browser zoom, small windows, mobile, ...). */
-@container buy-planner (max-width: 820px) {
-    #buy-pane .craft-financial-table table,
-    #buy-pane .craft-financial-table thead,
-    #buy-pane .craft-financial-table tbody,
-    #buy-pane .craft-financial-table tfoot,
-    #buy-pane .craft-financial-table tr,
-    #buy-pane .craft-financial-table th,
-    #buy-pane .craft-financial-table td {
+/* ==========================================================================
+ * Generic stacked-card responsive pattern for Craft data tables.
+ * Any `.table-responsive.craft-stack-container > table.craft-stackable-table`
+ * automatically reflows into per-row cards when the container becomes narrow,
+ * regardless of cause (browser zoom, small viewport, split panes, ...).
+ * Column labels are supplied as `--craft-col-1..N` custom properties set on
+ * the table element (translated server-side).
+ * ========================================================================== */
+.craft-stack-container {
+    container-type: inline-size;
+    container-name: craft-stack;
+}
+
+@container craft-stack (max-width: 820px) {
+    .craft-stackable-table,
+    .craft-stackable-table thead,
+    .craft-stackable-table tbody,
+    .craft-stackable-table tfoot,
+    .craft-stackable-table tr,
+    .craft-stackable-table th,
+    .craft-stackable-table td {
         display: block;
         width: 100% !important;
     }
 
-    #buy-pane .craft-financial-table thead {
+    .craft-stackable-table thead {
         position: absolute;
         clip: rect(0 0 0 0);
         clip-path: inset(100%);
@@ -3336,7 +3342,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
         white-space: nowrap;
     }
 
-    #buy-pane .craft-financial-table tbody tr {
+    .craft-stackable-table tbody tr {
         border: 1px solid var(--bs-border-color);
         border-radius: 0.6rem;
         background: var(--bs-body-bg);
@@ -3345,13 +3351,15 @@ html[data-theme="darkly"] #blueprintSearchInput {
         box-shadow: 0 4px 14px rgb(15 23 42 / 4%);
     }
 
-    #buy-pane .craft-financial-table tbody tr.craft-financial-section-row,
-    #buy-pane .craft-financial-table tbody tr.craft-financial-group-row {
+    .craft-stackable-table tbody tr.craft-financial-section-row,
+    .craft-stackable-table tbody tr.craft-financial-group-row,
+    .craft-stackable-table tbody tr.craft-stock-section-row,
+    .craft-stackable-table tbody tr.craft-decision-section-row {
         background: var(--bs-secondary-bg);
         box-shadow: none;
     }
 
-    #buy-pane .craft-financial-table tbody td {
+    .craft-stackable-table tbody td {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -3361,7 +3369,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
         text-align: right;
     }
 
-    #buy-pane .craft-financial-table tbody td::before {
+    .craft-stackable-table tbody td::before {
         content: var(--craft-col-label, "");
         flex: 0 0 auto;
         max-width: 55%;
@@ -3373,7 +3381,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
         text-align: left;
     }
 
-    #buy-pane .craft-financial-table tbody td:nth-child(1) {
+    .craft-stackable-table tbody td:nth-child(1) {
         --craft-col-label: var(--craft-col-1);
 
         flex-direction: column;
@@ -3384,56 +3392,70 @@ html[data-theme="darkly"] #blueprintSearchInput {
         margin-bottom: 0.35rem;
     }
 
-    #buy-pane .craft-financial-table tbody td:nth-child(1)::before {
+    .craft-stackable-table tbody td:nth-child(1)::before {
         display: none;
     }
 
-    #buy-pane .craft-financial-table tbody td:nth-child(2) {
+    .craft-stackable-table tbody td:nth-child(2) {
         --craft-col-label: var(--craft-col-2);
     }
 
-    #buy-pane .craft-financial-table tbody td:nth-child(3) {
+    .craft-stackable-table tbody td:nth-child(3) {
         --craft-col-label: var(--craft-col-3);
     }
 
-    #buy-pane .craft-financial-table tbody td:nth-child(4) {
+    .craft-stackable-table tbody td:nth-child(4) {
         --craft-col-label: var(--craft-col-4);
     }
 
-    #buy-pane .craft-financial-table tbody td:nth-child(5) {
+    .craft-stackable-table tbody td:nth-child(5) {
         --craft-col-label: var(--craft-col-5);
     }
 
-    #buy-pane .craft-financial-table tbody td:nth-child(6) {
+    .craft-stackable-table tbody td:nth-child(6) {
         --craft-col-label: var(--craft-col-6);
     }
 
-    #buy-pane .craft-financial-table tbody tr.craft-financial-section-row td,
-    #buy-pane .craft-financial-table tbody tr.craft-financial-group-row td {
+    .craft-stackable-table tbody td:nth-child(7) {
+        --craft-col-label: var(--craft-col-7);
+    }
+
+    .craft-stackable-table tbody td:nth-child(8) {
+        --craft-col-label: var(--craft-col-8);
+    }
+
+    .craft-stackable-table tbody tr.craft-financial-section-row td,
+    .craft-stackable-table tbody tr.craft-financial-group-row td,
+    .craft-stackable-table tbody tr.craft-stock-section-row td,
+    .craft-stackable-table tbody tr.craft-decision-section-row td {
         display: block;
         text-align: left;
     }
 
-    #buy-pane .craft-financial-table tbody tr.craft-financial-section-row td::before,
-    #buy-pane .craft-financial-table tbody tr.craft-financial-group-row td::before {
+    .craft-stackable-table tbody tr.craft-financial-section-row td::before,
+    .craft-stackable-table tbody tr.craft-financial-group-row td::before,
+    .craft-stackable-table tbody tr.craft-stock-section-row td::before,
+    .craft-stackable-table tbody tr.craft-decision-section-row td::before {
         display: none;
     }
 
-    #buy-pane .craft-financial-table tbody td input[type="number"] {
+    .craft-stackable-table tbody td input[type="number"],
+    .craft-stackable-table tbody td input[type="text"],
+    .craft-stackable-table tbody td select {
         width: min(60%, 12rem);
         max-width: 60%;
         text-align: right;
     }
 
-    #buy-pane .craft-financial-table tbody td .badge {
+    .craft-stackable-table tbody td .badge {
         white-space: normal;
     }
 
-    #buy-pane .craft-financial-table tfoot {
+    .craft-stackable-table tfoot {
         display: block;
     }
 
-    #buy-pane .craft-financial-table tfoot tr {
+    .craft-stackable-table tfoot tr {
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
@@ -3442,23 +3464,33 @@ html[data-theme="darkly"] #blueprintSearchInput {
         padding: 0.45rem 0.2rem;
     }
 
-    #buy-pane .craft-financial-table tfoot tr.craft-revenue-mode-row {
+    .craft-stackable-table tfoot tr.craft-revenue-mode-row {
         display: block;
     }
 
-    #buy-pane .craft-financial-table tfoot tr.craft-revenue-mode-row td {
+    .craft-stackable-table tfoot tr.craft-revenue-mode-row td {
         text-align: left;
     }
 
-    #buy-pane .craft-financial-table tfoot th {
+    .craft-stackable-table tfoot th {
         display: block;
         width: auto !important;
         text-align: left;
         padding: 0.2rem 0.2rem;
     }
 
-    #buy-pane .craft-financial-table tfoot th.text-end {
+    .craft-stackable-table tfoot th.text-end {
         text-align: right;
+    }
+
+    /* Centered "empty state" cells (colspan placeholders) keep their layout. */
+    .craft-stackable-table tbody td.text-center {
+        display: block;
+        text-align: center;
+    }
+
+    .craft-stackable-table tbody td.text-center::before {
+        display: none;
     }
 }
 

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -2614,8 +2614,8 @@ html[data-theme="darkly"] .craft-header-icon {
 }
 
 .craft-decision-table {
-    min-width: 0;
-    width: 100%;
+    min-width: 880px;
+    width: auto;
 }
 
 .craft-decision-table td,
@@ -2685,8 +2685,8 @@ html[data-theme="darkly"] .craft-header-icon {
 }
 
 .craft-stock-table {
-    min-width: 0;
-    width: 100%;
+    min-width: 960px;
+    width: auto;
 }
 
 .craft-stock-table td,
@@ -3320,8 +3320,17 @@ html[data-theme="darkly"] #blueprintSearchInput {
 
 .craft-stock-table,
 .craft-decision-table {
-    min-width: 0;
     table-layout: auto;
+}
+
+/* Only remove table min-width fallback when container queries are supported,
+ * because stacked-card mode depends on that feature. */
+@supports (container-type: inline-size) {
+    .craft-stock-table,
+    .craft-decision-table {
+        min-width: 0;
+        width: 100%;
+    }
 }
 
 .craft-financial-table th,
@@ -3677,7 +3686,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
     .craft-financial-table,
     .craft-stock-table-wrap,
     .craft-decision-table-wrap {
-        overflow-x: clip;
+        overflow-x: auto;
     }
 
     .craft-financial-table th,

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3253,7 +3253,13 @@ html[data-theme="darkly"] #blueprintSearchInput {
     overflow-wrap: anywhere;
 }
 
-/* Buy tab hardening: keep numeric columns visible under high zoom. */
+/* Buy tab: container-aware layout that reflows the planner into stacked
+ * cards when the pane itself becomes narrow (zoom, mobile, split-screen). */
+#buy-pane .craft-financial-table {
+    container-type: inline-size;
+    container-name: buy-planner;
+}
+
 #buy-pane .craft-financial-table table {
     table-layout: fixed;
 }
@@ -3306,6 +3312,156 @@ html[data-theme="darkly"] #blueprintSearchInput {
     line-height: 1.15;
 }
 
+/* Stacked-card mode: triggered by the pane's own width so it works for
+ * every cause of narrowness (browser zoom, small windows, mobile, ...). */
+@container buy-planner (max-width: 820px) {
+    #buy-pane .craft-financial-table table,
+    #buy-pane .craft-financial-table thead,
+    #buy-pane .craft-financial-table tbody,
+    #buy-pane .craft-financial-table tfoot,
+    #buy-pane .craft-financial-table tr,
+    #buy-pane .craft-financial-table th,
+    #buy-pane .craft-financial-table td {
+        display: block;
+        width: 100% !important;
+    }
+
+    #buy-pane .craft-financial-table thead {
+        position: absolute;
+        clip: rect(0 0 0 0);
+        clip-path: inset(100%);
+        height: 1px;
+        width: 1px;
+        overflow: hidden;
+        white-space: nowrap;
+    }
+
+    #buy-pane .craft-financial-table tbody tr {
+        border: 1px solid var(--bs-border-color);
+        border-radius: 0.6rem;
+        background: var(--bs-body-bg);
+        padding: 0.65rem 0.85rem;
+        margin-bottom: 0.65rem;
+        box-shadow: 0 4px 14px rgb(15 23 42 / 4%);
+    }
+
+    #buy-pane .craft-financial-table tbody tr.craft-financial-section-row,
+    #buy-pane .craft-financial-table tbody tr.craft-financial-group-row {
+        background: var(--bs-secondary-bg);
+        box-shadow: none;
+    }
+
+    #buy-pane .craft-financial-table tbody td {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.4rem 0;
+        border: 0;
+        text-align: right;
+    }
+
+    #buy-pane .craft-financial-table tbody td::before {
+        content: var(--craft-col-label, "");
+        flex: 0 0 auto;
+        max-width: 55%;
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--bs-secondary-color);
+        text-align: left;
+    }
+
+    #buy-pane .craft-financial-table tbody td:nth-child(1) {
+        --craft-col-label: var(--craft-col-1);
+
+        flex-direction: column;
+        align-items: stretch;
+        text-align: left;
+        border-bottom: 1px solid var(--bs-border-color);
+        padding-bottom: 0.55rem;
+        margin-bottom: 0.35rem;
+    }
+
+    #buy-pane .craft-financial-table tbody td:nth-child(1)::before {
+        display: none;
+    }
+
+    #buy-pane .craft-financial-table tbody td:nth-child(2) {
+        --craft-col-label: var(--craft-col-2);
+    }
+
+    #buy-pane .craft-financial-table tbody td:nth-child(3) {
+        --craft-col-label: var(--craft-col-3);
+    }
+
+    #buy-pane .craft-financial-table tbody td:nth-child(4) {
+        --craft-col-label: var(--craft-col-4);
+    }
+
+    #buy-pane .craft-financial-table tbody td:nth-child(5) {
+        --craft-col-label: var(--craft-col-5);
+    }
+
+    #buy-pane .craft-financial-table tbody td:nth-child(6) {
+        --craft-col-label: var(--craft-col-6);
+    }
+
+    #buy-pane .craft-financial-table tbody tr.craft-financial-section-row td,
+    #buy-pane .craft-financial-table tbody tr.craft-financial-group-row td {
+        display: block;
+        text-align: left;
+    }
+
+    #buy-pane .craft-financial-table tbody tr.craft-financial-section-row td::before,
+    #buy-pane .craft-financial-table tbody tr.craft-financial-group-row td::before {
+        display: none;
+    }
+
+    #buy-pane .craft-financial-table tbody td input[type="number"] {
+        width: min(60%, 12rem);
+        max-width: 60%;
+        text-align: right;
+    }
+
+    #buy-pane .craft-financial-table tbody td .badge {
+        white-space: normal;
+    }
+
+    #buy-pane .craft-financial-table tfoot {
+        display: block;
+    }
+
+    #buy-pane .craft-financial-table tfoot tr {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 0.5rem;
+        border-top: 1px dashed var(--bs-border-color);
+        padding: 0.45rem 0.2rem;
+    }
+
+    #buy-pane .craft-financial-table tfoot tr.craft-revenue-mode-row {
+        display: block;
+    }
+
+    #buy-pane .craft-financial-table tfoot tr.craft-revenue-mode-row td {
+        text-align: left;
+    }
+
+    #buy-pane .craft-financial-table tfoot th {
+        display: block;
+        width: auto !important;
+        text-align: left;
+        padding: 0.2rem 0.2rem;
+    }
+
+    #buy-pane .craft-financial-table tfoot th.text-end {
+        text-align: right;
+    }
+}
+
 @media (min-width: 1800px) {
     .craft-bp-workspace {
         max-width: 2400px;
@@ -3348,21 +3504,6 @@ html[data-theme="darkly"] #blueprintSearchInput {
         padding-inline: 0.85rem;
     }
 
-    #buy-pane .craft-financial-table .col-item {
-        width: 30%;
-    }
-
-    #buy-pane .craft-financial-table .col-qty {
-        width: 9%;
-    }
-
-    #buy-pane .craft-financial-table .col-fuzzwork,
-    #buy-pane .craft-financial-table .col-real,
-    #buy-pane .craft-financial-table .col-total,
-    #buy-pane .craft-financial-table .col-margin {
-        width: 15.25%;
-    }
-
     .craft-financial-table .col-qty,
     .craft-financial-table .col-fuzzwork,
     .craft-financial-table .col-real,
@@ -3389,26 +3530,6 @@ html[data-theme="darkly"] #blueprintSearchInput {
     .craft-stock-table-wrap,
     .craft-decision-table-wrap {
         overflow-x: clip;
-    }
-
-    #buy-pane .craft-financial-table .craft-financial-item-shell > img,
-    #buy-pane .craft-financial-table .financial-row-reset {
-        display: none !important;
-    }
-
-    #buy-pane .craft-financial-table .col-item {
-        width: 26%;
-    }
-
-    #buy-pane .craft-financial-table .col-qty {
-        width: 8%;
-    }
-
-    #buy-pane .craft-financial-table .col-fuzzwork,
-    #buy-pane .craft-financial-table .col-real,
-    #buy-pane .craft-financial-table .col-total,
-    #buy-pane .craft-financial-table .col-margin {
-        width: 16.5%;
     }
 
     .craft-financial-table th,
@@ -3453,19 +3574,6 @@ html[data-theme="darkly"] #blueprintSearchInput {
     .craft-decision-table th,
     .craft-decision-table td {
         font-size: 0.72rem;
-    }
-
-    #buy-pane .craft-financial-table table {
-        table-layout: auto;
-    }
-
-    #buy-pane .craft-financial-table .col-item,
-    #buy-pane .craft-financial-table .col-qty,
-    #buy-pane .craft-financial-table .col-fuzzwork,
-    #buy-pane .craft-financial-table .col-real,
-    #buy-pane .craft-financial-table .col-total,
-    #buy-pane .craft-financial-table .col-margin {
-        width: auto;
     }
 
     .craft-stock-table .craft-stock-allocation-input,

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -1849,7 +1849,8 @@ div[id="bpTabs"] {
 .craft-bp-workspace .craft-financial-table input.real-price,
 .craft-bp-workspace .craft-financial-table input.sale-price-unit {
     min-width: 10ch;
-    width: min(16ch, 100%);
+    width: 14ch;
+    max-width: 100%;
     text-align: right;
     font-variant-numeric: tabular-nums;
 }
@@ -2766,7 +2767,8 @@ html[data-theme="darkly"] .craft-header-icon {
     .craft-bp-workspace .craft-financial-table input.real-price,
     .craft-bp-workspace .craft-financial-table input.sale-price-unit {
         min-width: 9ch;
-        width: min(14ch, 100%);
+        width: 12ch;
+        max-width: 100%;
     }
 
     .craft-decision-metrics {

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -2609,10 +2609,13 @@ html[data-theme="darkly"] .craft-header-icon {
 .craft-decision-table-wrap {
     width: 100%;
     overflow-x: auto;
+    max-width: 100%;
+    min-width: 0;
 }
 
 .craft-decision-table {
-    min-width: 880px;
+    min-width: 0;
+    width: 100%;
 }
 
 .craft-decision-table td,
@@ -2677,10 +2680,13 @@ html[data-theme="darkly"] .craft-header-icon {
 .craft-stock-table-wrap {
     width: 100%;
     overflow-x: auto;
+    max-width: 100%;
+    min-width: 0;
 }
 
 .craft-stock-table {
-    min-width: 960px;
+    min-width: 0;
+    width: 100%;
 }
 
 .craft-stock-table td,
@@ -3195,6 +3201,32 @@ html[data-theme="darkly"] #blueprintSearchInput {
 
 .craft-tab-content > .tab-pane.active {
     overflow-x: hidden;
+}
+
+/* Strict containment for tabs reported to leak overflow into AA layout. */
+#stock-pane,
+#build-pane,
+#timing-pane,
+#structure-pane,
+#run-optimized-pane {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
+    overflow-y: visible;
+}
+
+#stock-pane .craft-section,
+#build-pane .craft-section,
+#timing-pane .craft-section,
+#structure-pane .craft-section,
+#run-optimized-pane .craft-section,
+#stock-pane .table-responsive,
+#build-pane .table-responsive,
+#timing-pane .table-responsive,
+#structure-pane .table-responsive,
+#run-optimized-pane .table-responsive {
+    min-width: 0;
+    max-width: 100%;
 }
 
 .craft-nav-tabs {

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3233,6 +3233,8 @@ html[data-theme="darkly"] #blueprintSearchInput {
     display: flex;
     flex-wrap: wrap;
     align-items: stretch;
+    justify-content: flex-start;
+    align-content: flex-start;
     gap: 0.5rem;
     margin-bottom: 1rem;
     padding: 0.4rem;
@@ -3243,7 +3245,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
 }
 
 .craft-nav-tabs .nav-item {
-    flex: 1 1 120px;
+    flex: 0 0 auto;
     min-width: 0;
 }
 
@@ -3259,6 +3261,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
     white-space: nowrap;
     line-height: 1.1;
     width: auto;
+    min-width: 110px;
     color: var(--bs-body-color);
     background: transparent;
     transition: background-color 0.16s ease, border-color 0.16s ease, color 0.16s ease, transform 0.16s ease;

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3170,3 +3170,194 @@ html[data-theme="darkly"] #blueprintSearchInput {
     background: var(--bs-body-bg);
     border-color: var(--bs-border-color);
 }
+
+/* ==========================================================================
+ * Craft workspace responsive hardening (ultrawide, mobile, high zoom)
+ * ========================================================================== */
+
+.craft-bp-workspace {
+    max-width: min(100%, 2200px);
+    margin-inline: auto;
+}
+
+.craft-tab-content {
+    min-width: 0;
+}
+
+.craft-nav-tabs {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    gap: 0.6rem;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+}
+
+.craft-nav-tabs .nav-item {
+    flex: 0 0 auto;
+}
+
+.craft-nav-tabs .nav-link {
+    min-height: 50px;
+    white-space: nowrap;
+}
+
+.craft-quick-stats {
+    grid-template-columns: repeat(auto-fit, minmax(clamp(170px, 20vw, 240px), 1fr));
+}
+
+.craft-section,
+.craft-section .table-responsive,
+.craft-financial-table,
+.craft-stock-table-wrap,
+.craft-decision-table-wrap {
+    min-width: 0;
+}
+
+.craft-section-controls,
+.craft-decision-controls,
+.craft-financial-toolbar,
+.craft-financial-filters,
+.craft-bulk-actions {
+    gap: 0.6rem;
+}
+
+.craft-financial-table {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.craft-financial-table table {
+    min-width: 960px;
+}
+
+.craft-stock-table,
+.craft-decision-table {
+    min-width: 980px;
+}
+
+.craft-section-title,
+.craft-pane-title,
+.craft-stat-label,
+.craft-kpi-label {
+    overflow-wrap: anywhere;
+}
+
+@media (min-width: 1800px) {
+    .craft-bp-workspace {
+        max-width: 2400px;
+    }
+
+    .craft-tab-content {
+        padding-inline: 0.5rem;
+    }
+
+    .craft-quick-stats {
+        grid-template-columns: repeat(4, minmax(220px, 1fr));
+    }
+
+    .craft-nav-tabs .nav-link {
+        padding-inline: 1.15rem;
+    }
+}
+
+@media (max-width: 1200px) {
+    .craft-section-header-with-actions {
+        align-items: flex-start;
+    }
+
+    .craft-section-controls,
+    .craft-decision-controls,
+    .craft-financial-filters,
+    .craft-bulk-actions {
+        width: 100%;
+        flex-wrap: wrap;
+    }
+
+    .craft-financial-filters .input-group,
+    .craft-financial-filters .form-select,
+    .craft-section-controls .btn,
+    .craft-decision-controls .btn {
+        min-width: 0;
+    }
+
+    .craft-nav-tabs .nav-link {
+        padding-inline: 0.85rem;
+    }
+}
+
+@media (max-width: 992px) {
+    .craft-bp-workspace {
+        max-width: 100%;
+    }
+
+    .craft-financial-table table,
+    .craft-stock-table,
+    .craft-decision-table {
+        min-width: 860px;
+    }
+
+    .craft-quick-stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    .craft-nav-tabs .nav-link {
+        min-height: 46px;
+        padding: 0.7rem 0.95rem;
+        font-size: 0.84rem;
+        border-radius: 0.85rem;
+    }
+
+    .craft-nav-tabs .nav-link i {
+        margin-right: 0.35rem;
+    }
+
+    .craft-section {
+        padding: 0.8rem;
+    }
+
+    .craft-section-title {
+        font-size: 0.8rem;
+    }
+
+    .craft-financial-table table,
+    .craft-stock-table,
+    .craft-decision-table {
+        min-width: 760px;
+    }
+}
+
+@media (max-width: 576px) {
+    .craft-quick-stats {
+        grid-template-columns: 1fr;
+    }
+
+    .craft-section-controls .btn,
+    .craft-decision-controls .btn {
+        width: 100%;
+    }
+
+    .craft-nav-tabs {
+        padding-bottom: 0.2rem;
+    }
+
+    .craft-nav-tabs .nav-link {
+        min-height: 44px;
+        padding: 0.62rem 0.8rem;
+    }
+
+    .craft-nav-tabs .nav-link span {
+        max-width: 17ch;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .craft-financial-table table,
+    .craft-stock-table,
+    .craft-decision-table {
+        min-width: 700px;
+    }
+}

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -725,7 +725,9 @@ html[data-theme="darkly"] #financial-tab.blueprint-tab.active .tab-icon {
 }
 
 .craft-structure-table select.form-select {
-    min-width: 280px;
+    width: min(100%, 280px);
+    min-width: 0;
+    max-width: 100%;
 }
 
 .craft-structure-metric {
@@ -743,7 +745,8 @@ html[data-theme="darkly"] #financial-tab.blueprint-tab.active .tab-icon {
 
 @media (max-width: 767.98px) {
     .craft-structure-table select.form-select {
-        min-width: 220px;
+        width: min(100%, 220px);
+        min-width: 0;
     }
 }
 
@@ -2630,11 +2633,13 @@ html[data-theme="darkly"] .craft-header-icon {
 }
 
 .tree-mode-label {
-    white-space: nowrap;
+    white-space: normal;
+    overflow-wrap: anywhere;
 }
 
 .financial-stock-state {
-    white-space: nowrap;
+    white-space: normal;
+    overflow-wrap: anywhere;
 }
 
 .craft-financial-row-stock-covered {
@@ -3179,7 +3184,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
     max-width: min(100%, 2200px);
     margin-inline: auto;
     min-width: 0;
-    overflow-x: clip;
+    overflow-x: hidden;
 }
 
 .craft-tab-content,
@@ -3189,7 +3194,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
 }
 
 .craft-tab-content > .tab-pane.active {
-    overflow-x: clip;
+    overflow-x: hidden;
 }
 
 .craft-nav-tabs {
@@ -3328,7 +3333,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
     container-name: craft-stack;
     max-width: 100%;
     min-width: 0;
-    overflow-x: clip;
+    overflow-x: hidden;
     overflow-y: visible;
 }
 
@@ -3375,22 +3380,30 @@ html[data-theme="darkly"] #blueprintSearchInput {
         display: flex;
         justify-content: space-between;
         align-items: center;
+        flex-wrap: wrap;
         gap: 0.75rem;
         padding: 0.4rem 0;
         border: 0;
         text-align: right;
+        min-width: 0;
     }
 
     .craft-stackable-table tbody td::before {
         content: var(--craft-col-label, "");
         flex: 0 0 auto;
-        max-width: 55%;
+        max-width: 100%;
         font-size: 0.7rem;
         font-weight: 700;
         letter-spacing: 0.04em;
         text-transform: uppercase;
         color: var(--bs-secondary-color);
         text-align: left;
+    }
+
+    .craft-stackable-table tbody td > * {
+        min-width: 0;
+        max-width: 100%;
+        overflow-wrap: anywhere;
     }
 
     .craft-stackable-table tbody td:nth-child(1) {

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3178,10 +3178,18 @@ html[data-theme="darkly"] #blueprintSearchInput {
 .craft-bp-workspace {
     max-width: min(100%, 2200px);
     margin-inline: auto;
+    min-width: 0;
+    overflow-x: clip;
 }
 
-.craft-tab-content {
+.craft-tab-content,
+.craft-tab-content > .tab-pane {
     min-width: 0;
+    max-width: 100%;
+}
+
+.craft-tab-content > .tab-pane.active {
+    overflow-x: clip;
 }
 
 .craft-nav-tabs {
@@ -3318,6 +3326,10 @@ html[data-theme="darkly"] #blueprintSearchInput {
 .craft-stack-container {
     container-type: inline-size;
     container-name: craft-stack;
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: clip;
+    overflow-y: visible;
 }
 
 @container craft-stack (max-width: 820px) {

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3408,7 +3408,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
     container-name: craft-stack;
     max-width: 100%;
     min-width: 0;
-    overflow-x: hidden;
+    overflow-x: auto;
     overflow-y: visible;
 }
 

--- a/indy_hub/static/indy_hub/css/craft_bp.css
+++ b/indy_hub/static/indy_hub/css/craft_bp.css
@@ -3231,19 +3231,61 @@ html[data-theme="darkly"] #blueprintSearchInput {
 
 .craft-nav-tabs {
     display: flex;
-    flex-wrap: wrap;
-    overflow: visible;
-    gap: 0.6rem;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    padding: 0.4rem;
+    border: 1px solid color-mix(in srgb, var(--bs-border-color) 75%, transparent);
+    border-radius: 0.9rem;
+    background: color-mix(in srgb, var(--bs-secondary-bg) 72%, var(--bs-body-bg));
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
 }
 
 .craft-nav-tabs .nav-item {
-    flex: 1 1 160px;
+    flex: 0 0 auto;
 }
 
 .craft-nav-tabs .nav-link {
-    min-height: 50px;
-    white-space: normal;
-    width: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    min-height: 42px;
+    padding: 0.58rem 0.9rem;
+    border: 1px solid transparent;
+    border-radius: 0.72rem;
+    white-space: nowrap;
+    line-height: 1.1;
+    width: auto;
+    color: var(--bs-body-color);
+    background: transparent;
+    transition: background-color 0.16s ease, border-color 0.16s ease, color 0.16s ease, transform 0.16s ease;
+}
+
+.craft-nav-tabs .nav-link:hover {
+    background: color-mix(in srgb, var(--bs-primary-bg-subtle) 70%, transparent);
+    border-color: color-mix(in srgb, var(--bs-primary) 35%, var(--bs-border-color));
+    color: var(--bs-primary);
+}
+
+.craft-nav-tabs .nav-link.active {
+    background: color-mix(in srgb, var(--bs-primary-bg-subtle) 65%, var(--bs-body-bg));
+    border-color: color-mix(in srgb, var(--bs-primary) 55%, var(--bs-border-color));
+    color: var(--bs-primary);
+    font-weight: 700;
+}
+
+.craft-nav-tabs .nav-link:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--bs-primary) 55%, transparent);
+    outline-offset: 1px;
+}
+
+.craft-nav-tabs .nav-link i {
+    font-size: 0.9rem;
 }
 
 .craft-quick-stats {
@@ -3598,7 +3640,7 @@ html[data-theme="darkly"] #blueprintSearchInput {
     }
 
     .craft-nav-tabs .nav-link {
-        padding-inline: 0.85rem;
+        padding-inline: 0.78rem;
     }
 
     .craft-financial-table .col-qty,
@@ -3619,8 +3661,15 @@ html[data-theme="darkly"] #blueprintSearchInput {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    .craft-nav-tabs .nav-item {
-        flex: 1 1 calc(50% - 0.6rem);
+    .craft-nav-tabs {
+        gap: 0.42rem;
+        padding: 0.32rem;
+    }
+
+    .craft-nav-tabs .nav-link {
+        min-height: 40px;
+        padding: 0.52rem 0.72rem;
+        font-size: 0.84rem;
     }
 
     .craft-financial-table,
@@ -3642,14 +3691,14 @@ html[data-theme="darkly"] #blueprintSearchInput {
 
 @media (max-width: 768px) {
     .craft-nav-tabs .nav-link {
-        min-height: 46px;
-        padding: 0.7rem 0.95rem;
-        font-size: 0.84rem;
-        border-radius: 0.85rem;
+        min-height: 38px;
+        padding: 0.5rem 0.66rem;
+        font-size: 0.8rem;
+        border-radius: 0.64rem;
     }
 
     .craft-nav-tabs .nav-link i {
-        margin-right: 0.35rem;
+        margin-right: 0.12rem;
     }
 
     .craft-section {
@@ -3660,8 +3709,18 @@ html[data-theme="darkly"] #blueprintSearchInput {
         font-size: 0.8rem;
     }
 
+    .craft-nav-tabs {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        overflow: visible;
+    }
+
     .craft-nav-tabs .nav-item {
-        flex: 1 1 100%;
+        min-width: 0;
+    }
+
+    .craft-nav-tabs .nav-link {
+        width: 100%;
     }
 
     .craft-financial-table th,
@@ -3691,14 +3750,18 @@ html[data-theme="darkly"] #blueprintSearchInput {
     }
 
     .craft-nav-tabs .nav-link {
-        min-height: 44px;
-        padding: 0.62rem 0.8rem;
+        min-height: 36px;
+        padding: 0.46rem 0.54rem;
     }
 
     .craft-nav-tabs .nav-link span {
-        max-width: 17ch;
+        max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    .craft-nav-tabs .nav-link i {
+        display: none;
     }
 
     .craft-financial-table th,

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -80,6 +80,12 @@ function escapeHtml(value) {
         .replace(/'/g, '&#39;');
 }
 
+function cssCustomPropertyString(value) {
+    // JSON.stringify escapes quotes/backslashes for CSS strings.
+    // escapeHtml then keeps it safe inside a double-quoted HTML attribute.
+    return escapeHtml(JSON.stringify(String(value ?? '')));
+}
+
 function formatInteger(value) {
     const num = Number(value) || 0;
     return num.toLocaleString();
@@ -7285,7 +7291,7 @@ function updateBuildTabFromState() {
             </h3>
             <div class="table-responsive craft-cycles-table craft-stack-container craft-table-text-120">
                 <table class="table table-sm align-middle mb-0 craft-stackable-table"
-                    style="--craft-col-1: '${escapeHtml(__('Item'))}'; --craft-col-2: '${escapeHtml(__('Needed'))}'; --craft-col-3: '${escapeHtml(__('Per cycle'))}'; --craft-col-4: '${escapeHtml(__('Cycles'))}'; --craft-col-5: '${escapeHtml(__('Produced'))}'; --craft-col-6: '${escapeHtml(__('Surplus'))}';">
+                    style="--craft-col-1: ${cssCustomPropertyString(__('Item'))}; --craft-col-2: ${cssCustomPropertyString(__('Needed'))}; --craft-col-3: ${cssCustomPropertyString(__('Per cycle'))}; --craft-col-4: ${cssCustomPropertyString(__('Cycles'))}; --craft-col-5: ${cssCustomPropertyString(__('Produced'))}; --craft-col-6: ${cssCustomPropertyString(__('Surplus'))};">
                     <thead class="table-light">
                         <tr>
                             <th>${escapeHtml(__('Item'))}</th>
@@ -7709,7 +7715,7 @@ function updateCraftTimingTabFromState() {
             </h3>
             <div class="table-responsive craft-cycles-table craft-stack-container craft-table-text-120">
                 <table class="table table-sm align-middle mb-0 craft-stackable-table"
-                    style="--craft-col-1: '${escapeHtml(__('Item'))}'; --craft-col-2: 'TE'; --craft-col-3: '${escapeHtml(__('Structure bonus'))}'; --craft-col-4: '${escapeHtml(__('Skill bonus'))}'; --craft-col-5: '${escapeHtml(__('Time / cycle'))}'; --craft-col-6: '${escapeHtml(__('Cycles'))}'; --craft-col-7: '${escapeHtml(__('Jobs'))}'; --craft-col-8: '${escapeHtml(__('Elapsed'))}'; --craft-col-9: '${escapeHtml(__('Character'))}'; --craft-col-10: '${escapeHtml(__('Structure'))}';">
+                    style="--craft-col-1: ${cssCustomPropertyString(__('Item'))}; --craft-col-2: ${cssCustomPropertyString('TE')}; --craft-col-3: ${cssCustomPropertyString(__('Structure bonus'))}; --craft-col-4: ${cssCustomPropertyString(__('Skill bonus'))}; --craft-col-5: ${cssCustomPropertyString(__('Time / cycle'))}; --craft-col-6: ${cssCustomPropertyString(__('Cycles'))}; --craft-col-7: ${cssCustomPropertyString(__('Jobs'))}; --craft-col-8: ${cssCustomPropertyString(__('Elapsed'))}; --craft-col-9: ${cssCustomPropertyString(__('Character'))}; --craft-col-10: ${cssCustomPropertyString(__('Structure'))};">
                     <thead class="table-light">
                         <tr>
                             <th>${escapeHtml(__('Item'))}</th>

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -7283,8 +7283,9 @@ function updateBuildTabFromState() {
                 <i class="fas fa-sync text-info"></i> ${escapeHtml(__('Cycles'))}
                 <span class="small text-body-secondary fw-semibold ms-2">${formatInteger(finalProductRows.length + cycleEntries.length)} ${escapeHtml(__('lines'))}</span>
             </h3>
-            <div class="table-responsive craft-cycles-table craft-table-text-120">
-                <table class="table table-sm align-middle mb-0">
+            <div class="table-responsive craft-cycles-table craft-stack-container craft-table-text-120">
+                <table class="table table-sm align-middle mb-0 craft-stackable-table"
+                    style="--craft-col-1: '${escapeHtml(__('Item'))}'; --craft-col-2: '${escapeHtml(__('Needed'))}'; --craft-col-3: '${escapeHtml(__('Per cycle'))}'; --craft-col-4: '${escapeHtml(__('Cycles'))}'; --craft-col-5: '${escapeHtml(__('Produced'))}'; --craft-col-6: '${escapeHtml(__('Surplus'))}';">
                     <thead class="table-light">
                         <tr>
                             <th>${escapeHtml(__('Item'))}</th>
@@ -7706,8 +7707,9 @@ function updateCraftTimingTabFromState() {
             <h3 class="craft-section-title">
                 <i class="fas fa-clock text-primary"></i> ${escapeHtml(__('Production Times'))}
             </h3>
-            <div class="table-responsive craft-cycles-table craft-table-text-120">
-                <table class="table table-sm align-middle mb-0">
+            <div class="table-responsive craft-cycles-table craft-stack-container craft-table-text-120">
+                <table class="table table-sm align-middle mb-0 craft-stackable-table"
+                    style="--craft-col-1: '${escapeHtml(__('Item'))}'; --craft-col-2: 'TE'; --craft-col-3: '${escapeHtml(__('Structure bonus'))}'; --craft-col-4: '${escapeHtml(__('Skill bonus'))}'; --craft-col-5: '${escapeHtml(__('Time / cycle'))}'; --craft-col-6: '${escapeHtml(__('Cycles'))}'; --craft-col-7: '${escapeHtml(__('Jobs'))}'; --craft-col-8: '${escapeHtml(__('Elapsed'))}'; --craft-col-9: '${escapeHtml(__('Character'))}'; --craft-col-10: '${escapeHtml(__('Structure'))}';">
                     <thead class="table-light">
                         <tr>
                             <th>${escapeHtml(__('Item'))}</th>

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-input-widths-minclamp">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-responsive-pass">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-tab-ui-wrap-compact-v6">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-review-fixes-v7">
 {% endblock extra_css %}
 
 {% block content %}
@@ -413,7 +413,7 @@
 
                     <div class="table-responsive craft-financial-table craft-stack-container craft-table-text-120 mt-2">
                         <table class="table table-sm align-middle mb-0 craft-financial-stackable craft-stackable-table"
-                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Qty" %}'; --craft-col-3: '{% trans "Reference" %}'; --craft-col-4: '{% trans "Override" %}'; --craft-col-5: '{% trans "Line Total" %}'; --craft-col-6: '{% trans "Source" %}';">
+                            style="--craft-col-1: &quot;{% trans "Item" %}&quot;; --craft-col-2: &quot;{% trans "Qty" %}&quot;; --craft-col-3: &quot;{% trans "Reference" %}&quot;; --craft-col-4: &quot;{% trans "Override" %}&quot;; --craft-col-5: &quot;{% trans "Line Total" %}&quot;; --craft-col-6: &quot;{% trans "Source" %}&quot;;">
                             <thead class="table-light">
                                 <tr>
                                     <th class="col-item">{% trans "Item" %}</th>
@@ -619,7 +619,7 @@
 
                     <div class="table-responsive craft-needed-table craft-stack-container mt-2">
                         <table class="table table-sm align-middle mb-0 craft-stackable-table" id="needed-table"
-                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Qty" %}'; --craft-col-3: '{% trans "Unit Price" %}'; --craft-col-4: '{% trans "Total" %}';">
+                            style="--craft-col-1: &quot;{% trans "Item" %}&quot;; --craft-col-2: &quot;{% trans "Qty" %}&quot;; --craft-col-3: &quot;{% trans "Unit Price" %}&quot;; --craft-col-4: &quot;{% trans "Total" %}&quot;;">
                             <thead class="table-light">
                                 <tr>
                                     <th>{% trans "Item" %}</th>
@@ -696,7 +696,7 @@
 
                     <div class="table-responsive craft-stock-table-wrap craft-stack-container">
                         <table class="table table-sm align-middle mb-0 craft-stock-table craft-stackable-table"
-                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Required" %}'; --craft-col-3: '{% trans "In stock" %}'; --craft-col-4: '{% trans "Use" %}'; --craft-col-5: '{% trans "Still to buy" %}'; --craft-col-6: '{% trans "Value used" %}'; --craft-col-7: '{% trans "By character" %}';">
+                            style="--craft-col-1: &quot;{% trans "Item" %}&quot;; --craft-col-2: &quot;{% trans "Required" %}&quot;; --craft-col-3: &quot;{% trans "In stock" %}&quot;; --craft-col-4: &quot;{% trans "Use" %}&quot;; --craft-col-5: &quot;{% trans "Still to buy" %}&quot;; --craft-col-6: &quot;{% trans "Value used" %}&quot;; --craft-col-7: &quot;{% trans "By character" %}&quot;;">
                             <thead class="table-light">
                                 <tr>
                                     <th>{% trans "Item" %}</th>
@@ -774,7 +774,7 @@
 
                     <div class="table-responsive craft-decision-table-wrap craft-stack-container">
                         <table class="table table-sm align-middle craft-decision-table craft-stackable-table mb-0"
-                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Qty" %}'; --craft-col-3: '{% trans "Buy" %}'; --craft-col-4: '{% trans "Produce" %}'; --craft-col-5: '{% trans "Delta" %}'; --craft-col-6: '{% trans "Ratio" %}'; --craft-col-7: '{% trans "Recommended" %}'; --craft-col-8: '{% trans "Selected" %}';">
+                            style="--craft-col-1: &quot;{% trans "Item" %}&quot;; --craft-col-2: &quot;{% trans "Qty" %}&quot;; --craft-col-3: &quot;{% trans "Buy" %}&quot;; --craft-col-4: &quot;{% trans "Produce" %}&quot;; --craft-col-5: &quot;{% trans "Delta" %}&quot;; --craft-col-6: &quot;{% trans "Ratio" %}&quot;; --craft-col-7: &quot;{% trans "Recommended" %}&quot;; --craft-col-8: &quot;{% trans "Selected" %}&quot;;">
                             <thead class="table-light">
                                 <tr>
                                     <th>{% trans "Item" %}</th>
@@ -851,7 +851,7 @@
                     </div>
                     <div class="table-responsive craft-stack-container">
                         <table class="table table-sm align-middle mb-0 craft-structure-table craft-stackable-table"
-                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Recommended" %}'; --craft-col-3: '{% trans "Selected Structure" %}'; --craft-col-4: 'ME'; --craft-col-5: 'TE'; --craft-col-6: '{% trans "Job" %}'; --craft-col-7: '{% trans "Distance" %}';">
+                            style="--craft-col-1: &quot;{% trans "Item" %}&quot;; --craft-col-2: &quot;{% trans "Recommended" %}&quot;; --craft-col-3: &quot;{% trans "Selected Structure" %}&quot;; --craft-col-4: &quot;ME&quot;; --craft-col-5: &quot;TE&quot;; --craft-col-6: &quot;{% trans "Job" %}&quot;; --craft-col-7: &quot;{% trans "Distance" %}&quot;;">
                             <thead class="table-light">
                                 <tr>
                                     <th>{% trans "Item" %}</th>
@@ -1180,7 +1180,7 @@
 <script src="{% static 'indy_hub/js/craft_bp_simulation_api.js' %}?v=20260524-build-final-targets"></script>
 <script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260505-deferred-tab-init"></script>
 <script src="{% static 'indy_hub/js/craft_bp_financial_planner.js' %}?v=20260428-no-output-override"></script>
-<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260601-stackable-build-timing"></script>
+<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260601-review-fixes-v7"></script>
 <script src="{% static 'indy_hub/js/craft_bp_inline.js' %}?v=20260524-tab-change-autosave"></script>
 <script src="{% static 'indy_hub/js/craft_bp_project_rename.js' %}?v=20260523-project-rename-status"></script>
 {% endif %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-buy-zoom-columns-fix">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-buy-container-cards">
 {% endblock extra_css %}
 
 {% block content %}
@@ -412,7 +412,8 @@
                     </div>
 
                     <div class="table-responsive craft-financial-table craft-table-text-120 mt-2">
-                        <table class="table table-sm align-middle mb-0">
+                        <table class="table table-sm align-middle mb-0 craft-financial-stackable"
+                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Qty" %}'; --craft-col-3: '{% trans "Reference" %}'; --craft-col-4: '{% trans "Override" %}'; --craft-col-5: '{% trans "Line Total" %}'; --craft-col-6: '{% trans "Source" %}';">
                             <thead class="table-light">
                                 <tr>
                                     <th class="col-item">{% trans "Item" %}</th>

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-stackable-build-timing">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-stack-clip-no-overflow">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-tab-ui-refresh-v4">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-tab-ui-no-scroll-v5">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-tab-ui-no-scroll-v5">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-tab-ui-wrap-compact-v6">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260524-buy-equation-summary">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-input-widths">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-review-fixes-v7">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260602-review-fixes-v8">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-stack-clip-no-overflow">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-overflow-hardening-v2">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-responsive-pass">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-responsive-flex-pass">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-stackable-tables-all">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-stackable-build-timing">
 {% endblock extra_css %}
 
 {% block content %}
@@ -1180,7 +1180,7 @@
 <script src="{% static 'indy_hub/js/craft_bp_simulation_api.js' %}?v=20260524-build-final-targets"></script>
 <script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260505-deferred-tab-init"></script>
 <script src="{% static 'indy_hub/js/craft_bp_financial_planner.js' %}?v=20260428-no-output-override"></script>
-<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260524-zero-revenue-margin"></script>
+<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260601-stackable-build-timing"></script>
 <script src="{% static 'indy_hub/js/craft_bp_inline.js' %}?v=20260524-tab-change-autosave"></script>
 <script src="{% static 'indy_hub/js/craft_bp_project_rename.js' %}?v=20260523-project-rename-status"></script>
 {% endif %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-overflow-hardening-v2">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-tab-overflow-containment-v3">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-tab-overflow-containment-v3">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-tab-ui-refresh-v4">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-buy-container-cards">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-stackable-tables-all">
 {% endblock extra_css %}
 
 {% block content %}
@@ -411,8 +411,8 @@
                         {% trans "Grouped by the dashboard material order. Filter the planner to focus manual overrides, missing prices, buy inputs, or revenue targets." %}
                     </div>
 
-                    <div class="table-responsive craft-financial-table craft-table-text-120 mt-2">
-                        <table class="table table-sm align-middle mb-0 craft-financial-stackable"
+                    <div class="table-responsive craft-financial-table craft-stack-container craft-table-text-120 mt-2">
+                        <table class="table table-sm align-middle mb-0 craft-financial-stackable craft-stackable-table"
                             style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Qty" %}'; --craft-col-3: '{% trans "Reference" %}'; --craft-col-4: '{% trans "Override" %}'; --craft-col-5: '{% trans "Line Total" %}'; --craft-col-6: '{% trans "Source" %}';">
                             <thead class="table-light">
                                 <tr>
@@ -617,8 +617,9 @@
                         </div>
                     </div>
 
-                    <div class="table-responsive craft-needed-table mt-2">
-                        <table class="table table-sm align-middle mb-0" id="needed-table">
+                    <div class="table-responsive craft-needed-table craft-stack-container mt-2">
+                        <table class="table table-sm align-middle mb-0 craft-stackable-table" id="needed-table"
+                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Qty" %}'; --craft-col-3: '{% trans "Unit Price" %}'; --craft-col-4: '{% trans "Total" %}';">
                             <thead class="table-light">
                                 <tr>
                                     <th>{% trans "Item" %}</th>
@@ -693,8 +694,9 @@
                         {% trans "Only required items with cached stock available are shown." %}
                     </div>
 
-                    <div class="table-responsive craft-stock-table-wrap">
-                        <table class="table table-sm align-middle mb-0 craft-stock-table">
+                    <div class="table-responsive craft-stock-table-wrap craft-stack-container">
+                        <table class="table table-sm align-middle mb-0 craft-stock-table craft-stackable-table"
+                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Required" %}'; --craft-col-3: '{% trans "In stock" %}'; --craft-col-4: '{% trans "Use" %}'; --craft-col-5: '{% trans "Still to buy" %}'; --craft-col-6: '{% trans "Value used" %}'; --craft-col-7: '{% trans "By character" %}';">
                             <thead class="table-light">
                                 <tr>
                                     <th>{% trans "Item" %}</th>
@@ -770,8 +772,9 @@
 
                     <div class="small text-muted mb-3" id="decisionStrategySummary">{% trans "Open this tab to review buy / produce recommendations." %}</div>
 
-                    <div class="table-responsive craft-decision-table-wrap">
-                        <table class="table table-sm align-middle craft-decision-table mb-0">
+                    <div class="table-responsive craft-decision-table-wrap craft-stack-container">
+                        <table class="table table-sm align-middle craft-decision-table craft-stackable-table mb-0"
+                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Qty" %}'; --craft-col-3: '{% trans "Buy" %}'; --craft-col-4: '{% trans "Produce" %}'; --craft-col-5: '{% trans "Delta" %}'; --craft-col-6: '{% trans "Ratio" %}'; --craft-col-7: '{% trans "Recommended" %}'; --craft-col-8: '{% trans "Selected" %}';">
                             <thead class="table-light">
                                 <tr>
                                     <th>{% trans "Item" %}</th>
@@ -846,8 +849,9 @@
                     <div id="structurePlannerEmpty" class="alert alert-info d-none mb-0">
                         <i class="fas fa-info-circle me-2"></i>{% trans "No compatible structures are currently available for this craft plan." %}
                     </div>
-                    <div class="table-responsive">
-                        <table class="table table-sm align-middle mb-0 craft-structure-table">
+                    <div class="table-responsive craft-stack-container">
+                        <table class="table table-sm align-middle mb-0 craft-structure-table craft-stackable-table"
+                            style="--craft-col-1: '{% trans "Item" %}'; --craft-col-2: '{% trans "Recommended" %}'; --craft-col-3: '{% trans "Selected Structure" %}'; --craft-col-4: 'ME'; --craft-col-5: 'TE'; --craft-col-6: '{% trans "Job" %}'; --craft-col-7: '{% trans "Distance" %}';">
                             <thead class="table-light">
                                 <tr>
                                     <th>{% trans "Item" %}</th>

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-input-widths">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-input-widths-minclamp">
 {% endblock extra_css %}
 
 {% block content %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -8,7 +8,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'indy_hub/css/page_headers.css' %}">
 <link rel="stylesheet" href="{% static 'indy_hub/css/blueprints.css' %}">
-<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-responsive-flex-pass">
+<link rel="stylesheet" href="{% static 'indy_hub/css/craft_bp.css' %}?v=20260601-buy-zoom-columns-fix">
 {% endblock extra_css %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- fix GH-105 by widening quantity-oriented numeric fields in Craft workspace so large values stay readable
- keep numeric fields right-aligned for readability
- harden Craft workspace responsiveness across viewport/zoom ranges (including 200% zoom)
- add stackable-table behavior for key data-heavy tabs to preserve column visibility on narrow panes
- refine Craft tab bar responsive layout (no navbar scrollbar; compact wrapped rows)
- fix stacked-table fallback/escaping issues raised by Copilot review:
  - restore horizontal-scroll fallback when container queries are unsupported
  - safely quote/escape translated stacked-table CSS labels in template and JS
- bump `craft_bp.css` / `craft_bp.js` cache-busting query strings

## Scope
UI-only changes (CSS + template cache versions + JS markup/style-string generation). No backend behavior or data-model changes.

## Notes
- This PR now includes broader responsive hardening in addition to the original GH-105 input-width fix.

Closes #105.