### PR TITLE
fix(sde): reuse EOFError retry logic in manual SDE commands (GH-109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Blueprint sharing: the "Request a copy" page no longer issues per-card eligibility and SDE-limit queries while building each card preview. Eligibility lookups for the entire page and the native `max_production_limit` are now resolved with a constant number of queries, eliminating the N+1 pattern that could push the page beyond proxy/gateway timeouts on Alliance Auth v5 instances with thousands of shared blueprints. (GH-101)
 - Character skill context loading no longer performs one `EveCharacter` lookup per linked character when building dashboard/industry skill rows. Character names are now read from the already joined ownership records (with fallback only when missing), keeping query counts bounded for users with large linked-character sets. (GH-110)
 - Crafting Projects / Workspace: quantity-oriented numeric inputs (runs, buy-tolerance override, stock allocation, and financial buy/sell override fields) now reserve enough width to display large industrial values without inner clipping, while keeping right-aligned numeric readability on desktop and mobile. (GH-105)
+- SDE refresh commands: manual SDE refresh paths (`sync_sde_compat` and `indy_sde`) now reuse the same retry-on-`EOFError` download/extract behavior as the Celery compatibility sync task, reducing transient ZIP truncation failures during operator-triggered refreshes. (GH-109)
 
 ## [1.17.2] - 2026-06-01
 

--- a/indy_hub/management/commands/indy_sde.py
+++ b/indy_hub/management/commands/indy_sde.py
@@ -4,6 +4,9 @@ import os
 # Django
 from django.core.management import BaseCommand, call_command
 
+# AA Example App
+from indy_hub.services.sde_sync import download_extract_sde_with_retry
+
 
 class Command(BaseCommand):
     help = "Populate Indy Hub SDE compatibility data without reloading full eve_sde by default."
@@ -48,7 +51,7 @@ class Command(BaseCommand):
 
         if not sde_folder:
             # Alliance Auth (External Libs)
-            from eve_sde.sde_tasks import SDE_FOLDER, download_extract_sde
+            from eve_sde.sde_tasks import SDE_FOLDER
 
             if os.path.isdir(SDE_FOLDER):
                 sde_folder = SDE_FOLDER
@@ -61,7 +64,7 @@ class Command(BaseCommand):
                 self.stdout.write(
                     self.style.NOTICE("[2/3] Downloading latest SDE JSONL files...")
                 )
-                download_extract_sde()
+                download_extract_sde_with_retry(max_attempts=2)
                 sde_folder = SDE_FOLDER
                 downloaded_sde = True
         else:

--- a/indy_hub/management/commands/sync_sde_compat.py
+++ b/indy_hub/management/commands/sync_sde_compat.py
@@ -10,7 +10,10 @@ from allianceauth.services.hooks import get_extension_logger
 
 # AA Example App
 from indy_hub.models import SDESyncCompatState
-from indy_hub.services.sde_sync import sync_sde_compat_tables
+from indy_hub.services.sde_sync import (
+    download_extract_sde_with_retry,
+    sync_sde_compat_tables,
+)
 
 logger = get_extension_logger(__name__)
 
@@ -52,9 +55,9 @@ class Command(BaseCommand):
             )
             try:
                 # Alliance Auth (External Libs)
-                from eve_sde.sde_tasks import SDE_FOLDER, download_extract_sde
+                from eve_sde.sde_tasks import SDE_FOLDER
 
-                download_extract_sde()
+                download_extract_sde_with_retry(max_attempts=2)
                 sde_folder = SDE_FOLDER
                 downloaded_temp_sde = True
             except Exception as ex:

--- a/indy_hub/services/sde_sync.py
+++ b/indy_hub/services/sde_sync.py
@@ -26,6 +26,31 @@ from indy_hub.models import (
 
 logger = get_extension_logger(__name__)
 
+
+def download_extract_sde_with_retry(*, max_attempts: int = 2) -> None:
+    # Alliance Auth (External Libs)
+    from eve_sde.sde_tasks import download_extract_sde
+
+    last_error: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            download_extract_sde()
+            return
+        except EOFError as exc:
+            last_error = exc
+            logger.warning(
+                "SDE archive extraction failed with EOFError on attempt %s/%s; retrying",
+                attempt,
+                max_attempts,
+                exc_info=True,
+            )
+        except Exception:
+            raise
+
+    if last_error is not None:
+        raise last_error
+
+
 _ACTIVITY_NAME_BY_ID = {
     1: "Manufacturing",
     3: "TE Research",

--- a/indy_hub/tasks/sde_sync.py
+++ b/indy_hub/tasks/sde_sync.py
@@ -18,37 +18,16 @@ from allianceauth.services.tasks import QueueOnce
 
 # AA Example App
 from indy_hub.models import SDESyncCompatState
-from indy_hub.services.sde_sync import sync_sde_compat_tables
+from indy_hub.services.sde_sync import (
+    download_extract_sde_with_retry,
+    sync_sde_compat_tables,
+)
 
 logger = get_extension_logger(__name__)
 
 _SDE_VERSION_URL = (
     "https://developers.eveonline.com/static-data/tranquility/latest.jsonl"
 )
-
-
-def _download_extract_sde_with_retry(max_attempts: int = 2) -> None:
-    # Alliance Auth (External Libs)
-    from eve_sde.sde_tasks import download_extract_sde
-
-    last_error: Exception | None = None
-    for attempt in range(1, max_attempts + 1):
-        try:
-            download_extract_sde()
-            return
-        except EOFError as exc:
-            last_error = exc
-            logger.warning(
-                "SDE archive extraction failed with EOFError on attempt %s/%s; retrying",
-                attempt,
-                max_attempts,
-                exc_info=True,
-            )
-        except Exception:
-            raise
-
-    if last_error is not None:
-        raise last_error
 
 
 def _fetch_latest_sde_source_metadata() -> tuple[int | None, datetime | None]:
@@ -113,7 +92,7 @@ def sync_sde_compatibility_data(self):
                 "SDE folder %s missing, downloading latest SDE archive for compatibility sync",
                 sde_folder,
             )
-            _download_extract_sde_with_retry(max_attempts=2)
+            download_extract_sde_with_retry(max_attempts=2)
             sde_folder = SDE_FOLDER
             downloaded_folder = True
         except Exception as exc:

--- a/indy_hub/tests/test_sde_sync_commands.py
+++ b/indy_hub/tests/test_sde_sync_commands.py
@@ -64,6 +64,50 @@ class SyncSdeCompatCommandTests(TestCase):
         mock_download.assert_called_once_with()
         mock_delete.assert_called_once_with()
 
+    @patch("indy_hub.management.commands.sync_sde_compat.sync_sde_compat_tables")
+    @patch("eve_sde.sde_tasks.delete_sde_folder")
+    @patch("eve_sde.sde_tasks.download_extract_sde")
+    @patch("eve_sde.sde_tasks.SDE_FOLDER", new="/tmp/eve-sde")
+    @patch("indy_hub.management.commands.sync_sde_compat.os.path.isdir")
+    def test_sync_retries_download_on_transient_eoferror(
+        self,
+        mock_isdir,
+        mock_download,
+        mock_delete,
+        mock_sync,
+    ):
+        mock_isdir.side_effect = [False, True]
+        mock_download.side_effect = [EOFError("truncated"), None]
+
+        call_command("sync_sde_compat", sde_folder="/tmp/missing")
+
+        self.assertEqual(mock_download.call_count, 2)
+        mock_sync.assert_called_once_with(sde_folder="/tmp/eve-sde")
+        mock_delete.assert_called_once_with()
+
+
+class IndySdeCommandTests(TestCase):
+    @patch("indy_hub.management.commands.indy_sde.call_command")
+    @patch("indy_hub.management.commands.indy_sde.download_extract_sde_with_retry")
+    @patch("eve_sde.sde_tasks.SDE_FOLDER", new="/tmp/eve-sde")
+    @patch("indy_hub.management.commands.indy_sde.os.path.isdir")
+    def test_indy_sde_uses_retrying_download_when_folder_missing(
+        self,
+        mock_isdir,
+        mock_download_with_retry,
+        mock_call_command,
+    ):
+        mock_isdir.return_value = False
+
+        call_command("indy_sde")
+
+        mock_download_with_retry.assert_called_once_with(max_attempts=2)
+        mock_call_command.assert_called_once_with(
+            "sync_sde_compat",
+            sde_folder="/tmp/eve-sde",
+            verbosity=1,
+        )
+
 
 class IndySdeCompatAliasCommandTests(TestCase):
     @patch("indy_hub.management.commands.indy_sde_compat.call_command")


### PR DESCRIPTION
## Summary
- move SDE `download_extract_sde` EOFError retry logic into a shared helper in the SDE sync service layer
- reuse that helper from both manual command paths (`sync_sde_compat`, `indy_sde`) and the existing Celery task path
- add regression tests asserting manual command download/extract retries on transient `EOFError`
- update changelog for GH-109

## Scope
UI: none
Backend: command/task resilience only

## Validation
- `python runtests.py indy_hub.tests.test_sde_sync_commands`
- pre-commit on modified files

Closes #109.