### PR TITLE
Improve craft loading and harden ESI task scheduling

### DIFF
--- a/indy_hub/services/esi_client.py
+++ b/indy_hub/services/esi_client.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 # Standard Library
 import time
 
-# Third Party
 try:
     # Celery
+    # Third Party
     from celery import current_task
 except ImportError:  # pragma: no cover - celery always available in runtime
     current_task = None
@@ -23,8 +23,8 @@ from esi.models import Token
 
 # AA Example App
 # Local
-from indy_hub.app_settings import ESI_COMPATIBILITY_DATE
 from indy_hub.app_settings import (
+    ESI_COMPATIBILITY_DATE,
     ESI_TASK_TARGET_PER_MIN_BLUEPRINTS,
     ESI_TASK_TARGET_PER_MIN_JOBS,
     ESI_TASK_TARGET_PER_MIN_ROLES,
@@ -251,7 +251,9 @@ class ESIClient:
         # Conservative fallback for authenticated endpoints not explicitly mapped.
         return int(ESI_TASK_TARGET_PER_MIN_ROLES)
 
-    def _enforce_task_scope_budget(self, scope: str | None, endpoint: str | None) -> None:
+    def _enforce_task_scope_budget(
+        self, scope: str | None, endpoint: str | None
+    ) -> None:
         if not self._is_running_in_task():
             return
 

--- a/indy_hub/services/esi_client.py
+++ b/indy_hub/services/esi_client.py
@@ -2,6 +2,19 @@
 
 from __future__ import annotations
 
+# Standard Library
+import time
+
+# Third Party
+try:
+    # Celery
+    from celery import current_task
+except ImportError:  # pragma: no cover - celery always available in runtime
+    current_task = None
+
+# Django
+from django.core.cache import cache
+
 # Alliance Auth
 from allianceauth.services.hooks import get_extension_logger
 from esi.errors import TokenError
@@ -11,6 +24,12 @@ from esi.models import Token
 # AA Example App
 # Local
 from indy_hub.app_settings import ESI_COMPATIBILITY_DATE
+from indy_hub.app_settings import (
+    ESI_TASK_TARGET_PER_MIN_BLUEPRINTS,
+    ESI_TASK_TARGET_PER_MIN_JOBS,
+    ESI_TASK_TARGET_PER_MIN_ROLES,
+    ESI_TASK_TARGET_PER_MIN_SKILLS,
+)
 
 # AA Indy Hub
 from indy_hub.services._esi_compat import HTTPError
@@ -19,6 +38,9 @@ from indy_hub.services.providers import esi_provider
 logger = get_extension_logger(__name__)
 
 DEFAULT_COMPATIBILITY_DATE = ESI_COMPATIBILITY_DATE
+
+_SCOPE_THROTTLE_PREFIX = "indy_hub:esi_task_scope_budget"
+_SCOPE_THROTTLE_TIMEOUT_SECONDS = 120
 
 
 class ESIClientError(Exception):
@@ -177,6 +199,100 @@ class ESIClient:
         self.compatibility_date = (compatibility_date or "").strip() or None
         self.provider = esi_provider
         self.client = self.provider.client
+
+    @staticmethod
+    def _is_running_in_task() -> bool:
+        if current_task is None:
+            return False
+        try:
+            request = getattr(current_task, "request", None)
+            return bool(request and getattr(request, "id", None))
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+    @staticmethod
+    def _seconds_to_next_minute() -> int:
+        return max(1, 60 - (int(time.time()) % 60))
+
+    @staticmethod
+    def _target_per_min_for_scope(scope: str | None) -> int:
+        if not scope:
+            return 0
+
+        if scope in {
+            "esi-industry.read_character_jobs.v1",
+            "esi-industry.read_corporation_jobs.v1",
+        }:
+            return int(ESI_TASK_TARGET_PER_MIN_JOBS)
+
+        if scope in {
+            "esi-characters.read_blueprints.v1",
+            "esi-corporations.read_blueprints.v1",
+        }:
+            return int(ESI_TASK_TARGET_PER_MIN_BLUEPRINTS)
+
+        if scope in {
+            "esi-skills.read_skills.v1",
+        }:
+            return int(ESI_TASK_TARGET_PER_MIN_SKILLS)
+
+        if scope in {
+            "esi-characters.read_corporation_roles.v1",
+            "esi-location.read_online.v1",
+            "esi-assets.read_assets.v1",
+            "esi-assets.read_corporation_assets.v1",
+            "esi-contracts.read_character_contracts.v1",
+            "esi-contracts.read_corporation_contracts.v1",
+            "esi-corporations.read_structures.v1",
+            "esi-universe.read_structures.v1",
+        }:
+            return int(ESI_TASK_TARGET_PER_MIN_ROLES)
+
+        # Conservative fallback for authenticated endpoints not explicitly mapped.
+        return int(ESI_TASK_TARGET_PER_MIN_ROLES)
+
+    def _enforce_task_scope_budget(self, scope: str | None, endpoint: str | None) -> None:
+        if not self._is_running_in_task():
+            return
+
+        target_per_min = self._target_per_min_for_scope(scope)
+        if target_per_min <= 0:
+            return
+
+        scope_key = (scope or "unknown").strip() or "unknown"
+        minute_bucket = int(time.time() // 60)
+        cache_key = f"{_SCOPE_THROTTLE_PREFIX}:{scope_key}:{minute_bucket}"
+
+        if cache.add(cache_key, 1, timeout=_SCOPE_THROTTLE_TIMEOUT_SECONDS):
+            return
+
+        try:
+            used = int(cache.incr(cache_key))
+        except Exception:  # pragma: no cover - cache backend edge case
+            cache.set(cache_key, 1, timeout=_SCOPE_THROTTLE_TIMEOUT_SECONDS)
+            return
+
+        if used <= target_per_min:
+            return
+
+        raise ESIRateLimitError(
+            message=(
+                "Local task ESI throttle hit for scope "
+                f"{scope_key} ({used}/{target_per_min} req/min)"
+                + (f" on {endpoint}" if endpoint else "")
+            ),
+            retry_after=self._seconds_to_next_minute(),
+            remaining=0,
+        )
+
+    def enforce_task_scope_budget(
+        self,
+        *,
+        scope: str | None,
+        endpoint: str | None = None,
+    ) -> None:
+        """Public wrapper for task-side scope throttling."""
+        self._enforce_task_scope_budget(scope, endpoint)
 
     def fetch_character_blueprints(
         self, character_id: int, *, force_refresh: bool = False
@@ -480,6 +596,7 @@ class ESIClient:
         params: dict,
         force_refresh: bool = False,
     ) -> list[dict]:
+        self._enforce_task_scope_budget(scope, endpoint)
         token_obj = self._get_token(character_id, scope)
         try:
             token_obj.valid_access_token()
@@ -801,6 +918,7 @@ class ESIClient:
     ):
         if operation is None:
             raise ESIClientError("No ESI operation provided")
+        self._enforce_task_scope_budget(scope, endpoint)
         try:
             access_token = token_obj.valid_access_token()
         except Exception as exc:

--- a/indy_hub/services/esi_client.py
+++ b/indy_hub/services/esi_client.py
@@ -270,9 +270,21 @@ class ESIClient:
 
         try:
             used = int(cache.incr(cache_key))
-        except Exception:  # pragma: no cover - cache backend edge case
-            cache.set(cache_key, 1, timeout=_SCOPE_THROTTLE_TIMEOUT_SECONDS)
-            return
+        except Exception as exc:  # pragma: no cover - cache backend edge case
+            logger.warning(
+                "Task scope throttle counter failed for scope %s on %s; applying conservative backoff: %s",
+                scope_key,
+                endpoint or "unknown-endpoint",
+                exc,
+            )
+            raise ESIRateLimitError(
+                message=(
+                    "Local task ESI throttle unavailable for scope "
+                    f"{scope_key}; backing off to avoid burst traffic"
+                ),
+                retry_after=self._seconds_to_next_minute(),
+                remaining=0,
+            ) from exc
 
         if used <= target_per_min:
             return

--- a/indy_hub/tasks/housekeeping.py
+++ b/indy_hub/tasks/housekeeping.py
@@ -37,27 +37,26 @@ from .industry import (
     SKILLS_SCOPE,
     STRUCTURE_SCOPE,
     _get_adaptive_window_minutes,
-    _queue_staggered_user_tasks,
     _refresh_online_status_for_user,
-    update_user_skill_snapshots,
+    update_character_skill_snapshot_for_character,
 )
 from .location import cache_structure_names_bulk
-from .user import CORP_ROLES_SCOPE, update_user_roles_snapshots
+from .user import CORP_ROLES_SCOPE, update_character_roles_for_character
 
 logger = get_extension_logger(__name__)
 User = get_user_model()
 
 
-def _select_users_for_stale_snapshots(
+def _select_character_targets_for_stale_snapshots(
     *,
     token_pairs: list[tuple[int, int]],
     snapshot_model,
     stale_hours: int,
     now: timezone.datetime,
-) -> set[int]:
+) -> list[tuple[int, int]]:
     character_ids = [int(cid) for _uid, cid in token_pairs if cid]
     if not character_ids:
-        return set()
+        return []
 
     rows = snapshot_model.objects.filter(character_id__in=character_ids).values_list(
         "character_id",
@@ -73,9 +72,42 @@ def _select_users_for_stale_snapshots(
     target_ids = stale_ids | missing_ids
 
     if not target_ids:
-        return set()
+        return []
 
-    return {int(uid) for uid, cid in token_pairs if int(cid) in target_ids}
+    targets = {
+        (int(uid), int(cid))
+        for uid, cid in token_pairs
+        if uid and cid and int(cid) in target_ids
+    }
+    return sorted(targets, key=lambda row: (row[0], row[1]))
+
+
+def _queue_staggered_character_tasks(
+    task,
+    targets: list[tuple[int, int]],
+    *,
+    window_minutes: int,
+    priority: int | None = None,
+) -> int:
+    if not targets:
+        return 0
+
+    total = len(targets)
+    window_seconds = max(window_minutes * 60, 0)
+    if total == 1 or window_seconds == 0:
+        for user_id, character_id in targets:
+            task.apply_async(args=(int(user_id), int(character_id)), priority=priority)
+        return total
+
+    spacing = window_seconds / total
+    for index, (user_id, character_id) in enumerate(targets):
+        countdown = int(round(index * spacing))
+        task.apply_async(
+            args=(int(user_id), int(character_id)),
+            countdown=countdown,
+            priority=priority,
+        )
+    return total
 
 
 @shared_task
@@ -85,6 +117,8 @@ def refresh_stale_snapshots() -> dict[str, int]:
     result = {
         "skills_users_queued": 0,
         "roles_users_queued": 0,
+        "skills_characters_queued": 0,
+        "roles_characters_queued": 0,
         "online_users_refreshed": 0,
         "structures_queued": 0,
     }
@@ -97,7 +131,7 @@ def refresh_stale_snapshots() -> dict[str, int]:
             .values_list("user_id", "character_id")
             .distinct()
         )
-        skill_user_ids = _select_users_for_stale_snapshots(
+        skill_targets = _select_character_targets_for_stale_snapshots(
             token_pairs=[
                 (int(uid), int(cid)) for uid, cid in skill_tokens if uid and cid
             ],
@@ -105,15 +139,16 @@ def refresh_stale_snapshots() -> dict[str, int]:
             stale_hours=SKILL_SNAPSHOT_STALE_HOURS,
             now=now,
         )
-        if skill_user_ids:
-            window_minutes = _get_adaptive_window_minutes("skills", len(skill_user_ids))
-            queued = _queue_staggered_user_tasks(
-                update_user_skill_snapshots,
-                sorted(skill_user_ids),
+        if skill_targets:
+            window_minutes = _get_adaptive_window_minutes("skills", len(skill_targets))
+            queued = _queue_staggered_character_tasks(
+                update_character_skill_snapshot_for_character,
+                skill_targets,
                 window_minutes=window_minutes,
                 priority=7,
             )
             result["skills_users_queued"] = queued
+            result["skills_characters_queued"] = queued
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("Failed stale skills refresh: %s", exc)
 
@@ -126,7 +161,7 @@ def refresh_stale_snapshots() -> dict[str, int]:
             .values_list("user_id", "character_id")
             .distinct()
         )
-        role_user_ids = _select_users_for_stale_snapshots(
+        role_targets = _select_character_targets_for_stale_snapshots(
             token_pairs=[
                 (int(uid), int(cid)) for uid, cid in role_tokens if uid and cid
             ],
@@ -134,15 +169,16 @@ def refresh_stale_snapshots() -> dict[str, int]:
             stale_hours=ROLE_SNAPSHOT_STALE_HOURS,
             now=now,
         )
-        if role_user_ids:
-            window_minutes = _get_adaptive_window_minutes("roles", len(role_user_ids))
-            queued = _queue_staggered_user_tasks(
-                update_user_roles_snapshots,
-                sorted(role_user_ids),
+        if role_targets:
+            window_minutes = _get_adaptive_window_minutes("roles", len(role_targets))
+            queued = _queue_staggered_character_tasks(
+                update_character_roles_for_character,
+                role_targets,
                 window_minutes=window_minutes,
                 priority=7,
             )
             result["roles_users_queued"] = queued
+            result["roles_characters_queued"] = queued
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("Failed stale roles refresh: %s", exc)
 
@@ -234,7 +270,8 @@ def refresh_stale_snapshots() -> dict[str, int]:
         label="completed",
         result="success",
         value=max(
-            result.get("skills_users_queued", 0) + result.get("roles_users_queued", 0),
+            result.get("skills_characters_queued", 0)
+            + result.get("roles_characters_queued", 0),
             1,
         ),
     )

--- a/indy_hub/tasks/housekeeping.py
+++ b/indy_hub/tasks/housekeeping.py
@@ -147,7 +147,9 @@ def refresh_stale_snapshots() -> dict[str, int]:
                 window_minutes=window_minutes,
                 priority=7,
             )
-            result["skills_users_queued"] = queued
+            result["skills_users_queued"] = len(
+                {int(user_id) for user_id, _character_id in skill_targets}
+            )
             result["skills_characters_queued"] = queued
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("Failed stale skills refresh: %s", exc)
@@ -177,7 +179,9 @@ def refresh_stale_snapshots() -> dict[str, int]:
                 window_minutes=window_minutes,
                 priority=7,
             )
-            result["roles_users_queued"] = queued
+            result["roles_users_queued"] = len(
+                {int(user_id) for user_id, _character_id in role_targets}
+            )
             result["roles_characters_queued"] = queued
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("Failed stale roles refresh: %s", exc)

--- a/indy_hub/tasks/industry.py
+++ b/indy_hub/tasks/industry.py
@@ -325,9 +325,10 @@ _MANUAL_REFRESH_CACHE_PREFIX = "indy_hub:manual_refresh"
 _MANUAL_REFRESH_INFLIGHT_PREFIX = "indy_hub:manual_refresh_inflight"
 _MANUAL_REFRESH_INFLIGHT_TTL_SECONDS = 15 * 60
 _BLUEPRINTS_BULK_LOCK_KEY = "indy_hub:blueprints_bulk:lock"
-_BLUEPRINTS_BULK_LOCK_TTL = 24 * 60 * 60
 _INDUSTRY_JOBS_BULK_LOCK_KEY = "indy_hub:industry_jobs_bulk:lock"
-_INDUSTRY_JOBS_BULK_LOCK_TTL = 24 * 60 * 60
+_BULK_LOCK_TTL_BUFFER_SECONDS = 15 * 60
+_BULK_LOCK_TTL_MIN_SECONDS = 30 * 60
+_BULK_LOCK_TTL_MAX_SECONDS = 18 * 60 * 60
 _DEFAULT_BULK_WINDOWS = {
     MANUAL_REFRESH_KIND_BLUEPRINTS: BLUEPRINTS_BULK_WINDOW_MINUTES,
     MANUAL_REFRESH_KIND_JOBS: INDUSTRY_JOBS_BULK_WINDOW_MINUTES,
@@ -779,6 +780,47 @@ def _get_adaptive_window_minutes(kind: str, total: int) -> int:
     return max((total + target_per_min - 1) // target_per_min, 1)
 
 
+def _get_bulk_lock_ttl_seconds(window_minutes: int) -> int:
+    window_seconds = max(int(window_minutes), 0) * 60
+    ttl = window_seconds + _BULK_LOCK_TTL_BUFFER_SECONDS
+    ttl = max(ttl, _BULK_LOCK_TTL_MIN_SECONDS)
+    return min(ttl, _BULK_LOCK_TTL_MAX_SECONDS)
+
+
+def _acquire_bulk_lock(lock_key: str, lock_token: str, *, window_minutes: int) -> bool:
+    return bool(
+        cache.add(
+            lock_key,
+            lock_token,
+            _get_bulk_lock_ttl_seconds(window_minutes),
+        )
+    )
+
+
+def _refresh_bulk_lock(lock_key: str, lock_token: str, *, window_minutes: int) -> bool:
+    if not lock_token:
+        return False
+
+    owner = cache.get(lock_key)
+    if owner != lock_token:
+        return False
+
+    ttl = _get_bulk_lock_ttl_seconds(window_minutes)
+    touch = getattr(cache, "touch", None)
+    if callable(touch):
+        try:
+            if touch(lock_key, ttl):
+                return True
+        except Exception:  # pragma: no cover - cache backend edge case
+            logger.debug("Failed to touch bulk lock key %s", lock_key, exc_info=True)
+
+    if cache.get(lock_key) != lock_token:
+        return False
+
+    cache.set(lock_key, lock_token, timeout=ttl)
+    return True
+
+
 def _manual_refresh_cache_key(kind: str, user_id: int, scope: str | None = None) -> str:
     scope_key = (scope or "").lower() or "default"
     return f"{_MANUAL_REFRESH_CACHE_PREFIX}:{kind}:{user_id}:{scope_key}"
@@ -969,28 +1011,45 @@ def _select_blueprint_sync_user_ids(
     last_user_id: int | None = None,
     batch_size: int = 500,
 ) -> list[int]:
-    character_user_ids = set(
-        Token.objects.all()
-        .require_scopes([BLUEPRINT_SCOPE])
-        .require_valid()
-        .values_list("user_id", flat=True)
-        .distinct()
+    return _select_sync_user_ids(
+        character_scope=BLUEPRINT_SCOPE,
+        corporation_scope=CORP_BLUEPRINT_SCOPE,
+        last_user_id=last_user_id,
+        batch_size=batch_size,
     )
-    corporation_user_ids = set(
-        Token.objects.all()
-        .require_scopes([CORP_BLUEPRINT_SCOPE])
-        .require_valid()
-        .values_list("user_id", flat=True)
-        .distinct()
-    )
-    user_ids = sorted(
-        int(user_id)
-        for user_id in (character_user_ids | corporation_user_ids)
-        if user_id
-    )
+
+
+def _select_sync_user_ids(
+    *,
+    character_scope: str,
+    corporation_scope: str,
+    last_user_id: int | None,
+    batch_size: int,
+) -> list[int]:
+    if batch_size <= 0:
+        return []
+
+    valid_tokens = Token.objects.all().require_valid()
     if last_user_id:
-        user_ids = [user_id for user_id in user_ids if user_id > last_user_id]
-    return user_ids[:batch_size]
+        valid_tokens = valid_tokens.filter(user_id__gt=last_user_id)
+
+    character_user_ids = (
+        valid_tokens.require_scopes([character_scope])
+        .values("user_id")
+        .order_by()
+        .distinct()
+    )
+    corporation_user_ids = (
+        valid_tokens.require_scopes([corporation_scope])
+        .values("user_id")
+        .order_by()
+        .distinct()
+    )
+
+    rows = list(
+        character_user_ids.union(corporation_user_ids).order_by("user_id")[:batch_size]
+    )
+    return [int(row["user_id"]) for row in rows if row.get("user_id")]
 
 
 def _select_character_blueprint_targets_for_users(
@@ -1034,28 +1093,12 @@ def _select_industry_job_sync_user_ids(
     last_user_id: int | None = None,
     batch_size: int = 500,
 ) -> list[int]:
-    character_user_ids = set(
-        Token.objects.all()
-        .require_scopes([JOBS_SCOPE])
-        .require_valid()
-        .values_list("user_id", flat=True)
-        .distinct()
+    return _select_sync_user_ids(
+        character_scope=JOBS_SCOPE,
+        corporation_scope=CORP_JOBS_SCOPE,
+        last_user_id=last_user_id,
+        batch_size=batch_size,
     )
-    corporation_user_ids = set(
-        Token.objects.all()
-        .require_scopes([CORP_JOBS_SCOPE])
-        .require_valid()
-        .values_list("user_id", flat=True)
-        .distinct()
-    )
-    user_ids = sorted(
-        int(user_id)
-        for user_id in (character_user_ids | corporation_user_ids)
-        if user_id
-    )
-    if last_user_id:
-        user_ids = [user_id for user_id in user_ids if user_id > last_user_id]
-    return user_ids[:batch_size]
 
 
 def _select_character_job_targets_for_users(
@@ -2453,10 +2496,14 @@ def update_all_blueprints(
         batch_size = 1
 
     release_lock = False
+    created_lock = False
+    initial_window_minutes = _get_bulk_window_minutes(MANUAL_REFRESH_KIND_BLUEPRINTS)
     if lock_token is None:
         lock_token = uuid.uuid4().hex
-        if not cache.add(
-            _BLUEPRINTS_BULK_LOCK_KEY, lock_token, _BLUEPRINTS_BULK_LOCK_TTL
+        if not _acquire_bulk_lock(
+            _BLUEPRINTS_BULK_LOCK_KEY,
+            lock_token,
+            window_minutes=initial_window_minutes,
         ):
             logger.info(
                 "Skipping bulk blueprint update: another run is already in progress"
@@ -2467,6 +2514,24 @@ def update_all_blueprints(
                 "done": True,
                 "reason": "locked",
             }
+        created_lock = True
+    elif not _refresh_bulk_lock(
+        _BLUEPRINTS_BULK_LOCK_KEY,
+        lock_token,
+        window_minutes=initial_window_minutes,
+    ):
+        logger.warning(
+            "Aborting bulk blueprint update batch: lock lost for token %s",
+            lock_token,
+        )
+        return {
+            "users_queued": 0,
+            "characters_queued": 0,
+            "corporation_users_queued": 0,
+            "batch_size": batch_size,
+            "done": True,
+            "reason": "lock_lost",
+        }
 
     try:
         logger.info(
@@ -2500,6 +2565,30 @@ def update_all_blueprints(
             _get_bulk_window_minutes(MANUAL_REFRESH_KIND_BLUEPRINTS),
             _get_adaptive_window_minutes("blueprints", total_targets),
         )
+        if created_lock:
+            cache.set(
+                _BLUEPRINTS_BULK_LOCK_KEY,
+                lock_token,
+                timeout=_get_bulk_lock_ttl_seconds(window_minutes),
+            )
+        elif not _refresh_bulk_lock(
+            _BLUEPRINTS_BULK_LOCK_KEY,
+            lock_token,
+            window_minutes=window_minutes,
+        ):
+            logger.warning(
+                "Aborting bulk blueprint update batch after lock ownership check failed for token %s",
+                lock_token,
+            )
+            return {
+                "users_queued": 0,
+                "characters_queued": 0,
+                "corporation_users_queued": 0,
+                "batch_size": batch_size,
+                "done": True,
+                "reason": "lock_lost",
+            }
+
         character_queued = _queue_staggered_blueprint_character_tasks(
             character_targets,
             window_minutes=window_minutes,
@@ -2577,10 +2666,14 @@ def update_all_industry_jobs(
         batch_size = 1
 
     release_lock = False
+    created_lock = False
+    initial_window_minutes = _get_bulk_window_minutes(MANUAL_REFRESH_KIND_JOBS)
     if lock_token is None:
         lock_token = uuid.uuid4().hex
-        if not cache.add(
-            _INDUSTRY_JOBS_BULK_LOCK_KEY, lock_token, _INDUSTRY_JOBS_BULK_LOCK_TTL
+        if not _acquire_bulk_lock(
+            _INDUSTRY_JOBS_BULK_LOCK_KEY,
+            lock_token,
+            window_minutes=initial_window_minutes,
         ):
             logger.info(
                 "Skipping bulk industry jobs update: another run is already in progress"
@@ -2591,6 +2684,24 @@ def update_all_industry_jobs(
                 "done": True,
                 "reason": "locked",
             }
+        created_lock = True
+    elif not _refresh_bulk_lock(
+        _INDUSTRY_JOBS_BULK_LOCK_KEY,
+        lock_token,
+        window_minutes=initial_window_minutes,
+    ):
+        logger.warning(
+            "Aborting bulk industry jobs update batch: lock lost for token %s",
+            lock_token,
+        )
+        return {
+            "users_queued": 0,
+            "characters_queued": 0,
+            "corporation_users_queued": 0,
+            "batch_size": batch_size,
+            "done": True,
+            "reason": "lock_lost",
+        }
 
     try:
         logger.info(
@@ -2622,6 +2733,30 @@ def update_all_industry_jobs(
             _get_bulk_window_minutes(MANUAL_REFRESH_KIND_JOBS),
             _get_adaptive_window_minutes("industry_jobs", total_targets),
         )
+        if created_lock:
+            cache.set(
+                _INDUSTRY_JOBS_BULK_LOCK_KEY,
+                lock_token,
+                timeout=_get_bulk_lock_ttl_seconds(window_minutes),
+            )
+        elif not _refresh_bulk_lock(
+            _INDUSTRY_JOBS_BULK_LOCK_KEY,
+            lock_token,
+            window_minutes=window_minutes,
+        ):
+            logger.warning(
+                "Aborting bulk industry jobs update batch after lock ownership check failed for token %s",
+                lock_token,
+            )
+            return {
+                "users_queued": 0,
+                "characters_queued": 0,
+                "corporation_users_queued": 0,
+                "batch_size": batch_size,
+                "done": True,
+                "reason": "lock_lost",
+            }
+
         character_queued = _queue_staggered_industry_job_character_tasks(
             character_targets,
             window_minutes=window_minutes,

--- a/indy_hub/tasks/industry.py
+++ b/indy_hub/tasks/industry.py
@@ -3,6 +3,7 @@
 # Place any industry-specific asynchronous tasks from tasks.py here when needed.
 
 # Standard Library
+import uuid
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 
@@ -323,6 +324,10 @@ MANUAL_REFRESH_KIND_JOBS = "jobs"
 _MANUAL_REFRESH_CACHE_PREFIX = "indy_hub:manual_refresh"
 _MANUAL_REFRESH_INFLIGHT_PREFIX = "indy_hub:manual_refresh_inflight"
 _MANUAL_REFRESH_INFLIGHT_TTL_SECONDS = 15 * 60
+_BLUEPRINTS_BULK_LOCK_KEY = "indy_hub:blueprints_bulk:lock"
+_BLUEPRINTS_BULK_LOCK_TTL = 24 * 60 * 60
+_INDUSTRY_JOBS_BULK_LOCK_KEY = "indy_hub:industry_jobs_bulk:lock"
+_INDUSTRY_JOBS_BULK_LOCK_TTL = 24 * 60 * 60
 _DEFAULT_BULK_WINDOWS = {
     MANUAL_REFRESH_KIND_BLUEPRINTS: BLUEPRINTS_BULK_WINDOW_MINUTES,
     MANUAL_REFRESH_KIND_JOBS: INDUSTRY_JOBS_BULK_WINDOW_MINUTES,
@@ -406,6 +411,11 @@ def _fetch_character_skill_levels_with_token(
     if not operation_fn:
         _SKILLS_OPERATION_UNAVAILABLE = True
         raise ESIClientError("ESI skills operation unavailable")
+
+    shared_client.enforce_task_scope_budget(
+        scope=SKILLS_SCOPE,
+        endpoint=f"/characters/{int(token_obj.character_id)}/skills/",
+    )
 
     try:
         request_kwargs = {}
@@ -822,6 +832,264 @@ def _queue_staggered_user_tasks(
     return total
 
 
+def _queue_staggered_industry_job_character_tasks(
+    targets: list[tuple[int, int]],
+    *,
+    window_minutes: int,
+    priority: int | None = None,
+) -> int:
+    if not targets:
+        return 0
+
+    total = len(targets)
+    window_seconds = max(window_minutes * 60, 0)
+
+    if total == 1 or window_seconds == 0:
+        for user_id, character_id in targets:
+            update_industry_jobs_for_user.apply_async(
+                args=(int(user_id),),
+                kwargs={"scope": "character", "character_id": int(character_id)},
+                priority=priority,
+            )
+        return total
+
+    spacing = window_seconds / total
+    for index, (user_id, character_id) in enumerate(targets):
+        countdown = int(round(index * spacing))
+        update_industry_jobs_for_user.apply_async(
+            args=(int(user_id),),
+            kwargs={"scope": "character", "character_id": int(character_id)},
+            countdown=countdown,
+            priority=priority,
+        )
+    return total
+
+
+def _queue_staggered_industry_job_corporation_tasks(
+    user_ids: list[int],
+    *,
+    window_minutes: int,
+    priority: int | None = None,
+) -> int:
+    if not user_ids:
+        return 0
+
+    total = len(user_ids)
+    window_seconds = max(window_minutes * 60, 0)
+
+    if total == 1 or window_seconds == 0:
+        for user_id in user_ids:
+            update_industry_jobs_for_user.apply_async(
+                args=(int(user_id),),
+                kwargs={"scope": "corporation"},
+                priority=priority,
+            )
+        return total
+
+    spacing = window_seconds / total
+    for index, user_id in enumerate(user_ids):
+        countdown = int(round(index * spacing))
+        update_industry_jobs_for_user.apply_async(
+            args=(int(user_id),),
+            kwargs={"scope": "corporation"},
+            countdown=countdown,
+            priority=priority,
+        )
+    return total
+
+
+def _queue_staggered_blueprint_character_tasks(
+    targets: list[tuple[int, int]],
+    *,
+    window_minutes: int,
+    priority: int | None = None,
+) -> int:
+    if not targets:
+        return 0
+
+    total = len(targets)
+    window_seconds = max(window_minutes * 60, 0)
+
+    if total == 1 or window_seconds == 0:
+        for user_id, character_id in targets:
+            update_blueprints_for_user.apply_async(
+                args=(int(user_id),),
+                kwargs={"scope": "character", "character_id": int(character_id)},
+                priority=priority,
+            )
+        return total
+
+    spacing = window_seconds / total
+    for index, (user_id, character_id) in enumerate(targets):
+        countdown = int(round(index * spacing))
+        update_blueprints_for_user.apply_async(
+            args=(int(user_id),),
+            kwargs={"scope": "character", "character_id": int(character_id)},
+            countdown=countdown,
+            priority=priority,
+        )
+    return total
+
+
+def _queue_staggered_blueprint_corporation_tasks(
+    user_ids: list[int],
+    *,
+    window_minutes: int,
+    priority: int | None = None,
+) -> int:
+    if not user_ids:
+        return 0
+
+    total = len(user_ids)
+    window_seconds = max(window_minutes * 60, 0)
+
+    if total == 1 or window_seconds == 0:
+        for user_id in user_ids:
+            update_blueprints_for_user.apply_async(
+                args=(int(user_id),),
+                kwargs={"scope": "corporation"},
+                priority=priority,
+            )
+        return total
+
+    spacing = window_seconds / total
+    for index, user_id in enumerate(user_ids):
+        countdown = int(round(index * spacing))
+        update_blueprints_for_user.apply_async(
+            args=(int(user_id),),
+            kwargs={"scope": "corporation"},
+            countdown=countdown,
+            priority=priority,
+        )
+    return total
+
+
+def _select_blueprint_sync_user_ids(
+    *,
+    last_user_id: int | None = None,
+    batch_size: int = 500,
+) -> list[int]:
+    character_user_ids = set(
+        Token.objects.all()
+        .require_scopes([BLUEPRINT_SCOPE])
+        .require_valid()
+        .values_list("user_id", flat=True)
+        .distinct()
+    )
+    corporation_user_ids = set(
+        Token.objects.all()
+        .require_scopes([CORP_BLUEPRINT_SCOPE])
+        .require_valid()
+        .values_list("user_id", flat=True)
+        .distinct()
+    )
+    user_ids = sorted(
+        int(user_id)
+        for user_id in (character_user_ids | corporation_user_ids)
+        if user_id
+    )
+    if last_user_id:
+        user_ids = [user_id for user_id in user_ids if user_id > last_user_id]
+    return user_ids[:batch_size]
+
+
+def _select_character_blueprint_targets_for_users(
+    user_ids: list[int],
+) -> list[tuple[int, int]]:
+    if not user_ids:
+        return []
+
+    return [
+        (int(user_id), int(character_id))
+        for user_id, character_id in Token.objects.all()
+        .require_scopes([BLUEPRINT_SCOPE])
+        .require_valid()
+        .filter(user_id__in=user_ids)
+        .values_list("user_id", "character_id")
+        .distinct()
+        .order_by("user_id", "character_id")
+        if user_id and character_id
+    ]
+
+
+def _select_corporation_blueprint_user_ids_for_users(user_ids: list[int]) -> list[int]:
+    if not user_ids:
+        return []
+
+    return [
+        int(user_id)
+        for user_id in Token.objects.all()
+        .require_scopes([CORP_BLUEPRINT_SCOPE])
+        .require_valid()
+        .filter(user_id__in=user_ids)
+        .values_list("user_id", flat=True)
+        .distinct()
+        .order_by("user_id")
+        if user_id
+    ]
+
+
+def _select_industry_job_sync_user_ids(
+    *,
+    last_user_id: int | None = None,
+    batch_size: int = 500,
+) -> list[int]:
+    character_user_ids = set(
+        Token.objects.all()
+        .require_scopes([JOBS_SCOPE])
+        .require_valid()
+        .values_list("user_id", flat=True)
+        .distinct()
+    )
+    corporation_user_ids = set(
+        Token.objects.all()
+        .require_scopes([CORP_JOBS_SCOPE])
+        .require_valid()
+        .values_list("user_id", flat=True)
+        .distinct()
+    )
+    user_ids = sorted(int(user_id) for user_id in (character_user_ids | corporation_user_ids) if user_id)
+    if last_user_id:
+        user_ids = [user_id for user_id in user_ids if user_id > last_user_id]
+    return user_ids[:batch_size]
+
+
+def _select_character_job_targets_for_users(
+    user_ids: list[int],
+) -> list[tuple[int, int]]:
+    if not user_ids:
+        return []
+
+    return [
+        (int(user_id), int(character_id))
+        for user_id, character_id in Token.objects.all()
+        .require_scopes([JOBS_SCOPE])
+        .require_valid()
+        .filter(user_id__in=user_ids)
+        .values_list("user_id", "character_id")
+        .distinct()
+        .order_by("user_id", "character_id")
+        if user_id and character_id
+    ]
+
+
+def _select_corporation_job_user_ids_for_users(user_ids: list[int]) -> list[int]:
+    if not user_ids:
+        return []
+
+    return [
+        int(user_id)
+        for user_id in Token.objects.all()
+        .require_scopes([CORP_JOBS_SCOPE])
+        .require_valid()
+        .filter(user_id__in=user_ids)
+        .values_list("user_id", flat=True)
+        .distinct()
+        .order_by("user_id")
+        if user_id
+    ]
+
+
 def _record_manual_refresh(kind: str, user_id: int, scope: str | None = None) -> None:
     if user_id is None:
         return
@@ -1038,6 +1306,7 @@ def update_blueprints_for_user(
         if (
             not force_refresh
             and character_id is None
+            and normalized_scope is None
             and _user_recent_blueprint_sync(user, now=now)
         ):
             logger.info(
@@ -1474,6 +1743,7 @@ def update_industry_jobs_for_user(
         if (
             not force_refresh
             and character_id is None
+            and normalized_scope is None
             and _user_recent_job_sync(user, now=now)
         ):
             logger.info(
@@ -2164,7 +2434,12 @@ def populate_location_names_async(
 
 
 @shared_task
-def update_all_blueprints(*, last_user_id: int | None = None, batch_size: int = 500):
+def update_all_blueprints(
+    *,
+    last_user_id: int | None = None,
+    batch_size: int = 500,
+    lock_token: str | None = None,
+):
     """
     Update blueprints for all users - scheduled via Celery beat.
 
@@ -2173,65 +2448,109 @@ def update_all_blueprints(*, last_user_id: int | None = None, batch_size: int = 
     if batch_size <= 0:
         batch_size = 1
 
-    logger.info(
-        "Starting bulk blueprint update batch (last_user_id=%s, batch_size=%s)",
-        last_user_id,
-        batch_size,
-    )
+    release_lock = False
+    if lock_token is None:
+        lock_token = uuid.uuid4().hex
+        if not cache.add(_BLUEPRINTS_BULK_LOCK_KEY, lock_token, _BLUEPRINTS_BULK_LOCK_TTL):
+            logger.info(
+                "Skipping bulk blueprint update: another run is already in progress"
+            )
+            return {"users_queued": 0, "characters_queued": 0, "done": True, "reason": "locked"}
 
-    user_qs = (
-        Token.objects.all()
-        .require_scopes([ONLINE_SCOPE])
-        .require_valid()
-        .values_list("user_id", flat=True)
-        .distinct()
-        .order_by("user_id")
-    )
-    if last_user_id:
-        user_qs = user_qs.filter(user_id__gt=last_user_id)
-
-    user_ids = list(user_qs[:batch_size])
-    if not user_ids:
-        logger.info("No users remaining for blueprint updates.")
-        return {"users_queued": 0, "batch_size": batch_size, "done": True}
-
-    window_minutes = _get_adaptive_window_minutes("blueprints", len(user_ids))
-    queued = _queue_staggered_user_tasks(
-        update_blueprints_for_user,
-        user_ids,
-        window_minutes=window_minutes,
-        priority=7,
-    )
-
-    if len(user_ids) == batch_size:
-        update_all_blueprints.apply_async(
-            kwargs={"last_user_id": int(user_ids[-1]), "batch_size": batch_size},
-            countdown=1,
+    try:
+        logger.info(
+            "Starting bulk blueprint update batch (last_user_id=%s, batch_size=%s)",
+            last_user_id,
+            batch_size,
         )
 
-    logger.info(
-        "Queued blueprint updates for %s users (batch_size=%s, window=%s min)",
-        queued,
-        batch_size,
-        window_minutes,
-    )
-    emit_analytics_event(
-        task="industry.update_all_blueprints",
-        label="queued",
-        result="success",
-        value=max(queued, 1),
-    )
-    return {
-        "users_queued": queued,
-        "batch_size": batch_size,
-        "window_minutes": window_minutes,
-        "last_user_id": int(user_ids[-1]),
-        "done": len(user_ids) < batch_size,
-    }
+        user_ids = _select_blueprint_sync_user_ids(
+            last_user_id=last_user_id,
+            batch_size=batch_size,
+        )
+        if not user_ids:
+            logger.info("No users remaining for blueprint updates.")
+            release_lock = True
+            return {
+                "users_queued": 0,
+                "characters_queued": 0,
+                "corporation_users_queued": 0,
+                "batch_size": batch_size,
+                "done": True,
+            }
+
+        character_targets = _select_character_blueprint_targets_for_users(user_ids)
+        corporation_user_ids = _select_corporation_blueprint_user_ids_for_users(user_ids)
+        total_targets = len(character_targets) + len(corporation_user_ids)
+
+        window_minutes = max(
+            _get_bulk_window_minutes(MANUAL_REFRESH_KIND_BLUEPRINTS),
+            _get_adaptive_window_minutes("blueprints", total_targets),
+        )
+        character_queued = _queue_staggered_blueprint_character_tasks(
+            character_targets,
+            window_minutes=window_minutes,
+            priority=7,
+        )
+        corporation_queued = 0
+        if corporation_user_ids:
+            corporation_queued = _queue_staggered_blueprint_corporation_tasks(
+                corporation_user_ids,
+                window_minutes=window_minutes,
+                priority=7,
+            )
+
+        if len(user_ids) == batch_size:
+            update_all_blueprints.apply_async(
+                kwargs={
+                    "last_user_id": int(user_ids[-1]),
+                    "batch_size": batch_size,
+                    "lock_token": lock_token,
+                },
+                countdown=max(window_minutes * 60, 1),
+            )
+        else:
+            release_lock = True
+
+        queued_total = character_queued + corporation_queued
+        logger.info(
+            "Queued blueprint updates for %s users (%s characters, %s corporation scopes, batch_size=%s, window=%s min)",
+            len(user_ids),
+            character_queued,
+            corporation_queued,
+            batch_size,
+            window_minutes,
+        )
+        emit_analytics_event(
+            task="industry.update_all_blueprints",
+            label="queued",
+            result="success",
+            value=max(queued_total, 1),
+        )
+        return {
+            "users_queued": len(user_ids),
+            "characters_queued": character_queued,
+            "corporation_users_queued": corporation_queued,
+            "batch_size": batch_size,
+            "window_minutes": window_minutes,
+            "last_user_id": int(user_ids[-1]),
+            "done": len(user_ids) < batch_size,
+        }
+    except Exception:
+        release_lock = True
+        raise
+    finally:
+        if release_lock and lock_token and cache.get(_BLUEPRINTS_BULK_LOCK_KEY) == lock_token:
+            cache.delete(_BLUEPRINTS_BULK_LOCK_KEY)
 
 
 @shared_task
-def update_all_industry_jobs(*, last_user_id: int | None = None, batch_size: int = 500):
+def update_all_industry_jobs(
+    *,
+    last_user_id: int | None = None,
+    batch_size: int = 500,
+    lock_token: str | None = None,
+):
     """
     Update industry jobs for all users - scheduled via Celery beat.
 
@@ -2240,61 +2559,100 @@ def update_all_industry_jobs(*, last_user_id: int | None = None, batch_size: int
     if batch_size <= 0:
         batch_size = 1
 
-    logger.info(
-        "Starting bulk industry jobs update batch (last_user_id=%s, batch_size=%s)",
-        last_user_id,
-        batch_size,
-    )
+    release_lock = False
+    if lock_token is None:
+        lock_token = uuid.uuid4().hex
+        if not cache.add(_INDUSTRY_JOBS_BULK_LOCK_KEY, lock_token, _INDUSTRY_JOBS_BULK_LOCK_TTL):
+            logger.info(
+                "Skipping bulk industry jobs update: another run is already in progress"
+            )
+            return {"users_queued": 0, "characters_queued": 0, "done": True, "reason": "locked"}
 
-    user_qs = (
-        Token.objects.all()
-        .require_scopes([ONLINE_SCOPE])
-        .require_valid()
-        .values_list("user_id", flat=True)
-        .distinct()
-        .order_by("user_id")
-    )
-    if last_user_id:
-        user_qs = user_qs.filter(user_id__gt=last_user_id)
-
-    user_ids = list(user_qs[:batch_size])
-    if not user_ids:
-        logger.info("No users remaining for industry job updates.")
-        return {"users_queued": 0, "batch_size": batch_size, "done": True}
-
-    window_minutes = _get_adaptive_window_minutes("industry_jobs", len(user_ids))
-    queued = _queue_staggered_user_tasks(
-        update_industry_jobs_for_user,
-        user_ids,
-        window_minutes=window_minutes,
-        priority=7,
-    )
-
-    if len(user_ids) == batch_size:
-        update_all_industry_jobs.apply_async(
-            kwargs={"last_user_id": int(user_ids[-1]), "batch_size": batch_size},
-            countdown=1,
+    try:
+        logger.info(
+            "Starting bulk industry jobs update batch (last_user_id=%s, batch_size=%s)",
+            last_user_id,
+            batch_size,
         )
 
-    logger.info(
-        "Queued industry job updates for %s users (batch_size=%s, window=%s min)",
-        queued,
-        batch_size,
-        window_minutes,
-    )
-    emit_analytics_event(
-        task="industry.update_all_industry_jobs",
-        label="queued",
-        result="success",
-        value=max(queued, 1),
-    )
-    return {
-        "users_queued": queued,
-        "batch_size": batch_size,
-        "window_minutes": window_minutes,
-        "last_user_id": int(user_ids[-1]),
-        "done": len(user_ids) < batch_size,
-    }
+        user_ids = _select_industry_job_sync_user_ids(
+            last_user_id=last_user_id,
+            batch_size=batch_size,
+        )
+        if not user_ids:
+            logger.info("No users remaining for industry job updates.")
+            release_lock = True
+            return {
+                "users_queued": 0,
+                "characters_queued": 0,
+                "corporation_users_queued": 0,
+                "batch_size": batch_size,
+                "done": True,
+            }
+
+        character_targets = _select_character_job_targets_for_users(user_ids)
+        corporation_user_ids = _select_corporation_job_user_ids_for_users(user_ids)
+        total_targets = len(character_targets) + len(corporation_user_ids)
+
+        window_minutes = max(
+            _get_bulk_window_minutes(MANUAL_REFRESH_KIND_JOBS),
+            _get_adaptive_window_minutes("industry_jobs", total_targets),
+        )
+        character_queued = _queue_staggered_industry_job_character_tasks(
+            character_targets,
+            window_minutes=window_minutes,
+            priority=7,
+        )
+        corporation_queued = 0
+        if corporation_user_ids:
+            corporation_queued = _queue_staggered_industry_job_corporation_tasks(
+                corporation_user_ids,
+                window_minutes=window_minutes,
+                priority=7,
+            )
+
+        if len(user_ids) == batch_size:
+            update_all_industry_jobs.apply_async(
+                kwargs={
+                    "last_user_id": int(user_ids[-1]),
+                    "batch_size": batch_size,
+                    "lock_token": lock_token,
+                },
+                countdown=max(window_minutes * 60, 1),
+            )
+        else:
+            release_lock = True
+
+        queued_total = character_queued + corporation_queued
+        logger.info(
+            "Queued industry job updates for %s users (%s characters, %s corporation scopes, batch_size=%s, window=%s min)",
+            len(user_ids),
+            character_queued,
+            corporation_queued,
+            batch_size,
+            window_minutes,
+        )
+        emit_analytics_event(
+            task="industry.update_all_industry_jobs",
+            label="queued",
+            result="success",
+            value=max(queued_total, 1),
+        )
+        return {
+            "users_queued": len(user_ids),
+            "characters_queued": character_queued,
+            "corporation_users_queued": corporation_queued,
+            "batch_size": batch_size,
+            "window_minutes": window_minutes,
+            "last_user_id": int(user_ids[-1]),
+            "done": len(user_ids) < batch_size,
+        }
+    except Exception:
+        release_lock = True
+        raise
+    finally:
+        if release_lock and lock_token and cache.get(_INDUSTRY_JOBS_BULK_LOCK_KEY) == lock_token:
+            cache.delete(_INDUSTRY_JOBS_BULK_LOCK_KEY)
 
 
 @shared_task

--- a/indy_hub/tasks/industry.py
+++ b/indy_hub/tasks/industry.py
@@ -1048,7 +1048,11 @@ def _select_industry_job_sync_user_ids(
         .values_list("user_id", flat=True)
         .distinct()
     )
-    user_ids = sorted(int(user_id) for user_id in (character_user_ids | corporation_user_ids) if user_id)
+    user_ids = sorted(
+        int(user_id)
+        for user_id in (character_user_ids | corporation_user_ids)
+        if user_id
+    )
     if last_user_id:
         user_ids = [user_id for user_id in user_ids if user_id > last_user_id]
     return user_ids[:batch_size]
@@ -2451,11 +2455,18 @@ def update_all_blueprints(
     release_lock = False
     if lock_token is None:
         lock_token = uuid.uuid4().hex
-        if not cache.add(_BLUEPRINTS_BULK_LOCK_KEY, lock_token, _BLUEPRINTS_BULK_LOCK_TTL):
+        if not cache.add(
+            _BLUEPRINTS_BULK_LOCK_KEY, lock_token, _BLUEPRINTS_BULK_LOCK_TTL
+        ):
             logger.info(
                 "Skipping bulk blueprint update: another run is already in progress"
             )
-            return {"users_queued": 0, "characters_queued": 0, "done": True, "reason": "locked"}
+            return {
+                "users_queued": 0,
+                "characters_queued": 0,
+                "done": True,
+                "reason": "locked",
+            }
 
     try:
         logger.info(
@@ -2480,7 +2491,9 @@ def update_all_blueprints(
             }
 
         character_targets = _select_character_blueprint_targets_for_users(user_ids)
-        corporation_user_ids = _select_corporation_blueprint_user_ids_for_users(user_ids)
+        corporation_user_ids = _select_corporation_blueprint_user_ids_for_users(
+            user_ids
+        )
         total_targets = len(character_targets) + len(corporation_user_ids)
 
         window_minutes = max(
@@ -2540,7 +2553,11 @@ def update_all_blueprints(
         release_lock = True
         raise
     finally:
-        if release_lock and lock_token and cache.get(_BLUEPRINTS_BULK_LOCK_KEY) == lock_token:
+        if (
+            release_lock
+            and lock_token
+            and cache.get(_BLUEPRINTS_BULK_LOCK_KEY) == lock_token
+        ):
             cache.delete(_BLUEPRINTS_BULK_LOCK_KEY)
 
 
@@ -2562,11 +2579,18 @@ def update_all_industry_jobs(
     release_lock = False
     if lock_token is None:
         lock_token = uuid.uuid4().hex
-        if not cache.add(_INDUSTRY_JOBS_BULK_LOCK_KEY, lock_token, _INDUSTRY_JOBS_BULK_LOCK_TTL):
+        if not cache.add(
+            _INDUSTRY_JOBS_BULK_LOCK_KEY, lock_token, _INDUSTRY_JOBS_BULK_LOCK_TTL
+        ):
             logger.info(
                 "Skipping bulk industry jobs update: another run is already in progress"
             )
-            return {"users_queued": 0, "characters_queued": 0, "done": True, "reason": "locked"}
+            return {
+                "users_queued": 0,
+                "characters_queued": 0,
+                "done": True,
+                "reason": "locked",
+            }
 
     try:
         logger.info(
@@ -2651,7 +2675,11 @@ def update_all_industry_jobs(
         release_lock = True
         raise
     finally:
-        if release_lock and lock_token and cache.get(_INDUSTRY_JOBS_BULK_LOCK_KEY) == lock_token:
+        if (
+            release_lock
+            and lock_token
+            and cache.get(_INDUSTRY_JOBS_BULK_LOCK_KEY) == lock_token
+        ):
             cache.delete(_INDUSTRY_JOBS_BULK_LOCK_KEY)
 
 

--- a/indy_hub/tasks/industry.py
+++ b/indy_hub/tasks/industry.py
@@ -821,6 +821,25 @@ def _refresh_bulk_lock(lock_key: str, lock_token: str, *, window_minutes: int) -
     return True
 
 
+def _refresh_created_bulk_lock(
+    lock_key: str,
+    lock_token: str,
+    *,
+    window_minutes: int,
+) -> bool:
+    """Refresh a lock created in the current batch while preserving ownership."""
+    owner = cache.get(lock_key)
+    if owner != lock_token:
+        return False
+
+    cache.set(
+        lock_key,
+        lock_token,
+        timeout=_get_bulk_lock_ttl_seconds(window_minutes),
+    )
+    return True
+
+
 def _manual_refresh_cache_key(kind: str, user_id: int, scope: str | None = None) -> str:
     scope_key = (scope or "").lower() or "default"
     return f"{_MANUAL_REFRESH_CACHE_PREFIX}:{kind}:{user_id}:{scope_key}"
@@ -2565,13 +2584,24 @@ def update_all_blueprints(
             _get_bulk_window_minutes(MANUAL_REFRESH_KIND_BLUEPRINTS),
             _get_adaptive_window_minutes("blueprints", total_targets),
         )
-        if created_lock:
-            cache.set(
-                _BLUEPRINTS_BULK_LOCK_KEY,
+        if created_lock and not _refresh_created_bulk_lock(
+            _BLUEPRINTS_BULK_LOCK_KEY,
+            lock_token,
+            window_minutes=window_minutes,
+        ):
+            logger.warning(
+                "Aborting bulk blueprint update batch after lock ownership check failed for token %s",
                 lock_token,
-                timeout=_get_bulk_lock_ttl_seconds(window_minutes),
             )
-        elif not _refresh_bulk_lock(
+            return {
+                "users_queued": 0,
+                "characters_queued": 0,
+                "corporation_users_queued": 0,
+                "batch_size": batch_size,
+                "done": True,
+                "reason": "lock_lost",
+            }
+        elif not created_lock and not _refresh_bulk_lock(
             _BLUEPRINTS_BULK_LOCK_KEY,
             lock_token,
             window_minutes=window_minutes,
@@ -2733,13 +2763,24 @@ def update_all_industry_jobs(
             _get_bulk_window_minutes(MANUAL_REFRESH_KIND_JOBS),
             _get_adaptive_window_minutes("industry_jobs", total_targets),
         )
-        if created_lock:
-            cache.set(
-                _INDUSTRY_JOBS_BULK_LOCK_KEY,
+        if created_lock and not _refresh_created_bulk_lock(
+            _INDUSTRY_JOBS_BULK_LOCK_KEY,
+            lock_token,
+            window_minutes=window_minutes,
+        ):
+            logger.warning(
+                "Aborting bulk industry jobs update batch after lock ownership check failed for token %s",
                 lock_token,
-                timeout=_get_bulk_lock_ttl_seconds(window_minutes),
             )
-        elif not _refresh_bulk_lock(
+            return {
+                "users_queued": 0,
+                "characters_queued": 0,
+                "corporation_users_queued": 0,
+                "batch_size": batch_size,
+                "done": True,
+                "reason": "lock_lost",
+            }
+        elif not created_lock and not _refresh_bulk_lock(
             _INDUSTRY_JOBS_BULK_LOCK_KEY,
             lock_token,
             window_minutes=window_minutes,

--- a/indy_hub/tests/test_industry_jobs_payload.py
+++ b/indy_hub/tests/test_industry_jobs_payload.py
@@ -14,7 +14,11 @@ from allianceauth.eveonline.models import EveCharacter
 
 # AA Example App
 from indy_hub.models import CharacterOnlineStatus
-from indy_hub.tasks.industry import update_industry_jobs_for_user
+from indy_hub.tasks.industry import (
+    update_all_blueprints,
+    update_all_industry_jobs,
+    update_industry_jobs_for_user,
+)
 
 
 class _FakeTokenQuerySet:
@@ -155,3 +159,151 @@ class IndustryJobsPayloadTests(TestCase):
             ),
             "Expected warning about unexpected job item type",
         )
+
+    def test_bulk_job_updates_are_staggered_per_character(self) -> None:
+        with (
+            patch(
+                "indy_hub.tasks.industry._select_industry_job_sync_user_ids",
+                return_value=[101, 202, 303],
+            ),
+            patch(
+                "indy_hub.tasks.industry._select_character_job_targets_for_users",
+                return_value=[(101, 1001), (101, 1002), (202, 2001)],
+            ),
+            patch(
+                "indy_hub.tasks.industry._select_corporation_job_user_ids_for_users",
+                return_value=[202, 303],
+            ),
+            patch("indy_hub.tasks.industry._queue_staggered_industry_job_character_tasks") as queue_characters,
+            patch("indy_hub.tasks.industry._queue_staggered_industry_job_corporation_tasks") as queue_corporations,
+            patch("indy_hub.tasks.industry.emit_analytics_event"),
+            patch("indy_hub.tasks.industry.update_all_industry_jobs.apply_async"),
+            patch("indy_hub.tasks.industry.cache.add", return_value=True),
+            patch("indy_hub.tasks.industry.cache.get", return_value=None),
+        ):
+            queue_characters.return_value = 3
+            queue_corporations.return_value = 2
+            result = update_all_industry_jobs(batch_size=100)
+
+        queue_characters.assert_called_once()
+        args, kwargs = queue_characters.call_args
+        self.assertEqual(kwargs["window_minutes"], 60)
+        self.assertEqual(kwargs["priority"], 7)
+        self.assertEqual(args[0], [(101, 1001), (101, 1002), (202, 2001)])
+        queue_corporations.assert_called_once_with(
+            [202, 303],
+            window_minutes=60,
+            priority=7,
+        )
+        self.assertEqual(result["characters_queued"], 3)
+        self.assertEqual(result["corporation_users_queued"], 2)
+
+    def test_bulk_job_updates_delay_next_batch_until_window_ends(self) -> None:
+        with (
+            patch(
+                "indy_hub.tasks.industry._select_industry_job_sync_user_ids",
+                return_value=[101, 202],
+            ),
+            patch(
+                "indy_hub.tasks.industry._select_character_job_targets_for_users",
+                return_value=[(101, 1001), (202, 2001)],
+            ),
+            patch(
+                "indy_hub.tasks.industry._select_corporation_job_user_ids_for_users",
+                return_value=[],
+            ),
+            patch(
+                "indy_hub.tasks.industry._queue_staggered_industry_job_character_tasks",
+                return_value=2,
+            ),
+            patch(
+                "indy_hub.tasks.industry._queue_staggered_industry_job_corporation_tasks",
+                return_value=0,
+            ),
+            patch("indy_hub.tasks.industry.emit_analytics_event"),
+            patch("indy_hub.tasks.industry.cache.add", return_value=True),
+            patch("indy_hub.tasks.industry.cache.get", return_value=None),
+            patch("indy_hub.tasks.industry.update_all_industry_jobs.apply_async") as requeue,
+        ):
+            update_all_industry_jobs(batch_size=2)
+
+        requeue.assert_called_once()
+        kwargs = requeue.call_args.kwargs["kwargs"]
+        self.assertEqual(kwargs["last_user_id"], 202)
+        self.assertEqual(kwargs["batch_size"], 2)
+        self.assertTrue(kwargs["lock_token"])
+        self.assertEqual(requeue.call_args.kwargs["countdown"], 3600)
+
+    def test_bulk_blueprint_updates_are_staggered_per_character(self) -> None:
+        with (
+            patch(
+                "indy_hub.tasks.industry._select_blueprint_sync_user_ids",
+                return_value=[101, 202, 303],
+            ),
+            patch(
+                "indy_hub.tasks.industry._select_character_blueprint_targets_for_users",
+                return_value=[(101, 1001), (101, 1002), (202, 2001)],
+            ),
+            patch(
+                "indy_hub.tasks.industry._select_corporation_blueprint_user_ids_for_users",
+                return_value=[202, 303],
+            ),
+            patch("indy_hub.tasks.industry._queue_staggered_blueprint_character_tasks") as queue_characters,
+            patch("indy_hub.tasks.industry._queue_staggered_blueprint_corporation_tasks") as queue_corporations,
+            patch("indy_hub.tasks.industry.emit_analytics_event"),
+            patch("indy_hub.tasks.industry.update_all_blueprints.apply_async"),
+            patch("indy_hub.tasks.industry.cache.add", return_value=True),
+            patch("indy_hub.tasks.industry.cache.get", return_value=None),
+        ):
+            queue_characters.return_value = 3
+            queue_corporations.return_value = 2
+            result = update_all_blueprints(batch_size=100)
+
+        queue_characters.assert_called_once()
+        args, kwargs = queue_characters.call_args
+        self.assertEqual(kwargs["window_minutes"], 720)
+        self.assertEqual(kwargs["priority"], 7)
+        self.assertEqual(args[0], [(101, 1001), (101, 1002), (202, 2001)])
+        queue_corporations.assert_called_once_with(
+            [202, 303],
+            window_minutes=720,
+            priority=7,
+        )
+        self.assertEqual(result["characters_queued"], 3)
+        self.assertEqual(result["corporation_users_queued"], 2)
+
+    def test_bulk_blueprint_updates_delay_next_batch_until_window_ends(self) -> None:
+        with (
+            patch(
+                "indy_hub.tasks.industry._select_blueprint_sync_user_ids",
+                return_value=[101, 202],
+            ),
+            patch(
+                "indy_hub.tasks.industry._select_character_blueprint_targets_for_users",
+                return_value=[(101, 1001), (202, 2001)],
+            ),
+            patch(
+                "indy_hub.tasks.industry._select_corporation_blueprint_user_ids_for_users",
+                return_value=[],
+            ),
+            patch(
+                "indy_hub.tasks.industry._queue_staggered_blueprint_character_tasks",
+                return_value=2,
+            ),
+            patch(
+                "indy_hub.tasks.industry._queue_staggered_blueprint_corporation_tasks",
+                return_value=0,
+            ),
+            patch("indy_hub.tasks.industry.emit_analytics_event"),
+            patch("indy_hub.tasks.industry.cache.add", return_value=True),
+            patch("indy_hub.tasks.industry.cache.get", return_value=None),
+            patch("indy_hub.tasks.industry.update_all_blueprints.apply_async") as requeue,
+        ):
+            update_all_blueprints(batch_size=2)
+
+        requeue.assert_called_once()
+        kwargs = requeue.call_args.kwargs["kwargs"]
+        self.assertEqual(kwargs["last_user_id"], 202)
+        self.assertEqual(kwargs["batch_size"], 2)
+        self.assertTrue(kwargs["lock_token"])
+        self.assertEqual(requeue.call_args.kwargs["countdown"], 43200)

--- a/indy_hub/tests/test_industry_jobs_payload.py
+++ b/indy_hub/tests/test_industry_jobs_payload.py
@@ -174,8 +174,12 @@ class IndustryJobsPayloadTests(TestCase):
                 "indy_hub.tasks.industry._select_corporation_job_user_ids_for_users",
                 return_value=[202, 303],
             ),
-            patch("indy_hub.tasks.industry._queue_staggered_industry_job_character_tasks") as queue_characters,
-            patch("indy_hub.tasks.industry._queue_staggered_industry_job_corporation_tasks") as queue_corporations,
+            patch(
+                "indy_hub.tasks.industry._queue_staggered_industry_job_character_tasks"
+            ) as queue_characters,
+            patch(
+                "indy_hub.tasks.industry._queue_staggered_industry_job_corporation_tasks"
+            ) as queue_corporations,
             patch("indy_hub.tasks.industry.emit_analytics_event"),
             patch("indy_hub.tasks.industry.update_all_industry_jobs.apply_async"),
             patch("indy_hub.tasks.industry.cache.add", return_value=True),
@@ -223,7 +227,9 @@ class IndustryJobsPayloadTests(TestCase):
             patch("indy_hub.tasks.industry.emit_analytics_event"),
             patch("indy_hub.tasks.industry.cache.add", return_value=True),
             patch("indy_hub.tasks.industry.cache.get", return_value=None),
-            patch("indy_hub.tasks.industry.update_all_industry_jobs.apply_async") as requeue,
+            patch(
+                "indy_hub.tasks.industry.update_all_industry_jobs.apply_async"
+            ) as requeue,
         ):
             update_all_industry_jobs(batch_size=2)
 
@@ -248,8 +254,12 @@ class IndustryJobsPayloadTests(TestCase):
                 "indy_hub.tasks.industry._select_corporation_blueprint_user_ids_for_users",
                 return_value=[202, 303],
             ),
-            patch("indy_hub.tasks.industry._queue_staggered_blueprint_character_tasks") as queue_characters,
-            patch("indy_hub.tasks.industry._queue_staggered_blueprint_corporation_tasks") as queue_corporations,
+            patch(
+                "indy_hub.tasks.industry._queue_staggered_blueprint_character_tasks"
+            ) as queue_characters,
+            patch(
+                "indy_hub.tasks.industry._queue_staggered_blueprint_corporation_tasks"
+            ) as queue_corporations,
             patch("indy_hub.tasks.industry.emit_analytics_event"),
             patch("indy_hub.tasks.industry.update_all_blueprints.apply_async"),
             patch("indy_hub.tasks.industry.cache.add", return_value=True),
@@ -297,7 +307,9 @@ class IndustryJobsPayloadTests(TestCase):
             patch("indy_hub.tasks.industry.emit_analytics_event"),
             patch("indy_hub.tasks.industry.cache.add", return_value=True),
             patch("indy_hub.tasks.industry.cache.get", return_value=None),
-            patch("indy_hub.tasks.industry.update_all_blueprints.apply_async") as requeue,
+            patch(
+                "indy_hub.tasks.industry.update_all_blueprints.apply_async"
+            ) as requeue,
         ):
             update_all_blueprints(batch_size=2)
 

--- a/indy_hub/tests/test_industry_jobs_payload.py
+++ b/indy_hub/tests/test_industry_jobs_payload.py
@@ -182,9 +182,12 @@ class IndustryJobsPayloadTests(TestCase):
             ) as queue_corporations,
             patch("indy_hub.tasks.industry.emit_analytics_event"),
             patch("indy_hub.tasks.industry.update_all_industry_jobs.apply_async"),
-            patch("indy_hub.tasks.industry.cache.add", return_value=True),
-            patch("indy_hub.tasks.industry.cache.get", return_value=None),
+            patch("indy_hub.tasks.industry.cache.add", return_value=True) as cache_add,
+            patch("indy_hub.tasks.industry.cache.get") as cache_get,
         ):
+            cache_get.side_effect = lambda key, _cache_add=cache_add: (
+                _cache_add.call_args.args[1] if _cache_add.call_args else None
+            )
             queue_characters.return_value = 3
             queue_corporations.return_value = 2
             result = update_all_industry_jobs(batch_size=100)
@@ -225,12 +228,15 @@ class IndustryJobsPayloadTests(TestCase):
                 return_value=0,
             ),
             patch("indy_hub.tasks.industry.emit_analytics_event"),
-            patch("indy_hub.tasks.industry.cache.add", return_value=True),
-            patch("indy_hub.tasks.industry.cache.get", return_value=None),
+            patch("indy_hub.tasks.industry.cache.add", return_value=True) as cache_add,
+            patch("indy_hub.tasks.industry.cache.get") as cache_get,
             patch(
                 "indy_hub.tasks.industry.update_all_industry_jobs.apply_async"
             ) as requeue,
         ):
+            cache_get.side_effect = lambda key, _cache_add=cache_add: (
+                _cache_add.call_args.args[1] if _cache_add.call_args else None
+            )
             update_all_industry_jobs(batch_size=2)
 
         requeue.assert_called_once()
@@ -262,9 +268,12 @@ class IndustryJobsPayloadTests(TestCase):
             ) as queue_corporations,
             patch("indy_hub.tasks.industry.emit_analytics_event"),
             patch("indy_hub.tasks.industry.update_all_blueprints.apply_async"),
-            patch("indy_hub.tasks.industry.cache.add", return_value=True),
-            patch("indy_hub.tasks.industry.cache.get", return_value=None),
+            patch("indy_hub.tasks.industry.cache.add", return_value=True) as cache_add,
+            patch("indy_hub.tasks.industry.cache.get") as cache_get,
         ):
+            cache_get.side_effect = lambda key, _cache_add=cache_add: (
+                _cache_add.call_args.args[1] if _cache_add.call_args else None
+            )
             queue_characters.return_value = 3
             queue_corporations.return_value = 2
             result = update_all_blueprints(batch_size=100)
@@ -305,12 +314,15 @@ class IndustryJobsPayloadTests(TestCase):
                 return_value=0,
             ),
             patch("indy_hub.tasks.industry.emit_analytics_event"),
-            patch("indy_hub.tasks.industry.cache.add", return_value=True),
-            patch("indy_hub.tasks.industry.cache.get", return_value=None),
+            patch("indy_hub.tasks.industry.cache.add", return_value=True) as cache_add,
+            patch("indy_hub.tasks.industry.cache.get") as cache_get,
             patch(
                 "indy_hub.tasks.industry.update_all_blueprints.apply_async"
             ) as requeue,
         ):
+            cache_get.side_effect = lambda key, _cache_add=cache_add: (
+                _cache_add.call_args.args[1] if _cache_add.call_args else None
+            )
             update_all_blueprints(batch_size=2)
 
         requeue.assert_called_once()


### PR DESCRIPTION
## Description

This PR combines the craft loading work already present on the branch with a follow-up hardening pass on Indy Hub task scheduling to reduce ESI burst pressure on both small and very large Alliance Auth instances.

On the task side, bulk refresh flows for industry jobs and blueprints now fan out by character instead of by user, keep corporation refreshes on a separate scope path, delay follow-up batches until the current stagger window ends, and use cache-backed cycle locks to avoid overlapping bulk runs. In addition, task-triggered ESI calls now share a centralized per-scope per-minute throttle in the ESI client, and stale skills/roles refreshes have been aligned to per-character orchestration as well.

This addresses the reported behavior where Indy Hub could exhaust ESI buckets by launching too many character-backed refreshes in a short time window.

Fixes #127
Fixes #138
Fixes #139

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings

## Validation

- Full test suite executed successfully: `410 tests`, `OK`, `skipped=2`
- Additional targeted runtime verification in the local Django environment confirmed:
  - industry jobs bulk scheduling fans out by character and requeues after the current 60 minute window
  - blueprint bulk scheduling fans out by character and requeues after the current 720 minute window
  - centralized task-side ESI throttling blocks the 31st `esi-industry.read_character_jobs.v1` request when the configured budget is `30/min`
