### PR TITLE
Fix MySQL retry races, synced structure setup state and tax configuration (#127, #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,118 +11,24 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ### Added
 
-- Industry Structures: added tax configuration and editing for auto-synced structures, allowing administrators to manage installation costs directly on structures synced from corporation ESI.
-- Material Exchange: added Material Hub navbar badge showing active buy/sell order counts, with status differentiation between open, completed, and cancelled transactions.
+- Industry Structures: added tax configuration and editing for auto-synced structures so administrators can manage installation costs on corporation-synced structures.
+- Material Exchange: added a Material Hub navbar badge with active buy/sell order counts and status-aware display.
 
 ### Changed
 
-- Crafting Projects / Structure planner: improved capital ship classification and structure matching so command carriers and super-carriers are detected reliably from SDE ship outputs, with the planner falling back more gracefully when lookups fail.
-
-- Crafting Projects / Project workspace: project pages now let users adjust final-output quantities directly from the Production Tree with an explicit `Update` action. Manual multi-item projects keep per-output quantity control, while EFT imports now group each detected fit under its own editable root so fit quantities scale the ship and contained items together instead of exposing every fitted line as a separate final output.
-
-- Crafting Projects / Create table modal: EFT previews now show the number of detected fits, expose per-fit initial quantities before creation, keep the summary cards and fit detection panels more compact, and only reveal `Create table` after a successful preview.
-
-- Crafting Projects / Craft payload API: blueprint product lookup now resolves against the correct product type for workspace payloads, preventing mismatches when the project blueprint context is rebuilt.
-
-- Crafting Projects / Buy: added custom fixed adjustment lines directly in the financial planner table (between Outputs and Totals). Users can add/remove any number of rows with `Name`, `Type` (Expense/Revenue), `Qty`, and `Unit Price`, with live line totals and immediate impact on project totals.
-
-- Crafting Projects / Buy: fixed-adjustment rows are now persisted in the workspace session state and restored on reload, matching other Buy-tab manual overrides.
-
-- Crafting Projects / Shopping list: improved in-client export/copy workflows for EVE-style shopping output, including clearer compute-before-copy behavior and stronger copy feedback in the Shopping header.
-
-- Crafting Projects / Workspace: quantity-oriented numeric inputs (runs, buy-tolerance override, stock allocation, and financial buy/sell override fields) now reserve enough width to display large industrial values without inner clipping, while keeping right-aligned numeric readability on desktop and mobile. (GH-105)
-
-- Crafting Projects / Workspace responsive layout: significantly improved craft table overflow handling across all tabs (Stock, Build, Timing, Structure, Decision, Buy) using container-query stacked cards for mobile viewports, minimum-width enforcement, and normalized tab pane clipping to prevent unwanted AA-level scrollbars.
-
-- Material Exchange: stock tables now show available quantity as the primary value, keep total visible, and only surface the secondary quantity when non-zero. Buy flows remain reservation-aware, and sell flows now compute reservations from active sell orders scoped to the selected character (with `character_id` persisted on sell orders) so `Reserved` and max-quantity inputs stay coherent.
-
-- Material Exchange: buy-order validation now treats explicit empty type-id filters as an empty result immediately, avoiding unnecessary database work when no stock items remain after filtering.
-
-- Material Exchange: sell page now persists sell-order character context and properly refines reserved quantity display based on active sell orders, preventing false reservation counts and keeping stock visibility aligned with actual transaction state.
-
-- SDE integration: Indy Hub now relies on the base `eve_sde` data path only, removing the legacy compatibility sync flow and related maintenance commands.
-
-- SDE / bootstrap: the SDE compatibility and startup paths were simplified to reduce duplicate state and align the app with the standard Alliance Auth installation flow. (GH-109)
-
-- Industry Structures / Sync: structure sync schedule changed from hourly to daily (06:35 UTC + AA offset) to reduce load on ESI and internal sync queues.
+- Crafting Projects: streamlined project workspace behavior (final-output quantity editing, improved EFT fit grouping/preview flow, persistent buy-tab fixed adjustments, and improved responsive table/input behavior).
+- Material Exchange: improved stock/readability and reservation flows (including sell-character context and empty-filter short-circuiting).
+- SDE integration: simplified to the base `eve_sde` path and reduced compatibility/bootstrap maintenance overhead. (GH-109)
+- Industry Structures: changed structure sync cadence from hourly to daily (06:35 UTC + AA offset) to reduce ESI and task-queue load.
 
 ### Fixed
 
-- Industry and related sync tasks now retry MySQL duplicate-key races in addition to deadlocks when performing unique-row upserts, preventing concurrent Celery workers from crashing on `IntegrityError 1062` for rows such as skill snapshots, roles, cached structure names, contracts, and blueprint sync records.
-
-- Industry Structures / Synced structures: fixed setup state tracking so auto-synced structures no longer remain stuck on "Setup needed" when taxes are edited. Taxes and rigs are now included in structure completeness checks, and partial ESI failures no longer lock the structure in an unusable state.
-
-- Industry Structures / Synced structures: fixed identity field preservation during ESI sync. Manually-entered system ID, system name, constellation/region identifiers, and category information are now reliably preserved when ESI returns incomplete or invalid data (numeric 0, negative IDs, or empty values), implementing the promised "future attempts will be skipped" behavior for 403 Forbidden structures.
-
-- Industry Structures / ESI 403 handling: the structure name resolution loop now skips structures that already have a forbidden (403) cooldown, preventing repeated ESI 403 attempts that waste rate limits. Structures marked forbidden are logged with a 15-day retry delay message.
-
-- Crafting Projects / Structure planner: fixed false `No compatible structures are currently available for this craft plan` states caused by filtering planner rows with blueprint type ids instead of produced item type ids. Planner lookup now uses produced item ids so valid structures (including Sotiyo/supercapital-capable setups) are correctly surfaced.
-
-- Crafting Projects / Structure planner: supercapital structure compatibility no longer depends on supercapital tax fields being populated; support checks now rely on explicit structure capability flags.
-
-- Crafting Projects / Structure planner: advanced component rig matching now recognizes both item category names and the `Construction Component(s)` commodity aliases used by live SDE labels, correctly applying material and time bonuses on structures with Advanced Component rigs.
-
-- Crafting Projects / Structure planner: material quantities now combine blueprint ME and selected structure/rig material bonuses before the final EVE rounding step, eliminating over-counts on T2/T3 jobs where UI rounding cascaded with structure bonus rounding.
-
-- Crafting Projects / Structure planner: ME, TE, and Job values in the assignment table now expose hover details showing component breakdown and structure role bonuses instead of a single tax column.
-
-- Crafting Projects / Structure planner: manually selected per-item structure assignments now persist across tab changes and project reloads when the workspace keeps a compact planner payload.
-
-- Crafting Projects / Build tab: final product cycle rows now use the saved project target quantity as the source of truth, preventing transient SimulationAPI or DOM quantities from displaying incorrect final run counts.
-
-- Crafting Projects / Financial planner: fixed `Total Material Cost`, `Cash Needed for Materials`, `Cash Investment Needed`, and `Total Cost` summaries reading 0 ISK when all items were toggled to Buy mode. Buy-mode items are now correctly counted as both a cost line and revenue line.
-
-- Crafting Projects / Decisions: fixed missing intermediate rows in some project trees (fuel blocks, reactions) by evaluating parent visibility across all ancestor paths instead of only the optimizer-pruned recommendation tree.
-
-- Crafting Projects / Decisions: clicking *Set everything to Buy* / *Set everything to Prod* now works even when the Decisions tab has not been opened yet, with fallback to the materials tree when the Decisions container is lazy-rendered.
-
-- Crafting Projects / Buy: margin now shows `-100%` instead of `0%` when a workspace has costs but zero configured revenue, matching the fully unprofitable state.
-
-- Crafting Projects / Workspace persistence: saved buy/produce decisions and final product prices now restore from the workspace state even when tabs are hidden or lazily hydrated, preventing default zero DOM inputs or partial price refresh responses from wiping saved decisions and allocation state.
-
-- Crafting Projects / Workspace persistence: prevented saved stock allocations from being silently destroyed on save. The persistence path now stores raw user intent (non-negative integers only) instead of display-time clamped allocations, so unrelated SDE refreshes or plan changes no longer wipe allocations not currently required.
-
-- Crafting Projects / Stock allocations: the Stock tab's `Use` inputs now accept large industrial quantities reliably, with numeric attributes using raw integers instead of thousands-separated display values, and deferred batch commits for dependent refreshes.
-
-- Crafting Projects / Blueprint planning: project workspaces now default to the best owned blueprint ME/TE when no saved override exists, so financial calculations no longer fall back to 0/0 for researched blueprints.
-
-- Crafting Projects / Build + Outputs: project renaming no longer leaks into final product item labels. The workspace now canonicalizes product names from SDE type data and never falls back to the project title for item names.
-
-- Crafting Projects / EFT import: fitting names containing square brackets (e.g. `[Retribution, [PRIME] SD 01]`) are now parsed correctly. The header regex no longer bails on inner `]` characters.
-
-- Crafting Projects / EFT import: when importing an EFT fitting without entering a project name, the modal pre-fills it as `Hull // Fit Name` (e.g. `Hurricane // s.2012 T2`) instead of just the fit name.
-
-- Crafting Projects / Tab loading: reduced browser console performance warnings by deferring heavier startup tab initialization and removing forced-layout reads that restarted animation loops.
-
-- Blueprint sharing: the "Request a copy" page no longer issues per-card eligibility and SDE-limit queries while building each card preview. Eligibility lookups for the entire page and the native `max_production_limit` are now resolved with a constant number of queries, eliminating the N+1 pattern that could push the page beyond proxy/gateway timeouts on Alliance Auth v5 instances with thousands of shared blueprints. (GH-101)
-
-- Blueprint sharing: copy-installation estimates on fulfill requests now use manufacturing material EIV, scale totals by the selected copy count, round ISK rows consistently, and keep the grand-total label aligned with the requested number of copies.
-
-- Blueprint sharing: a finished contract that was already linked to a previous buy order is no longer eligible to auto-validate a new identical buy order, preventing false "wrong contract reference" anomaly overrides when users repeat the same request pattern. (GH-119)
-
-- Character skill context loading no longer performs one `EveCharacter` lookup per linked character when building dashboard/industry skill rows. Character names are now read from the already joined ownership records (with fallback only when missing), keeping query counts bounded for users with large linked-character sets. (GH-110)
-
-- Material Exchange / Buy validation: contract structure or item-name resolution edge cases are now handled more robustly, and duplicate transaction processing is prevented.
-
-- Material Exchange / Sell page: clicking a stale Discord link to a completed, cancelled, or deleted order now lands on a friendly "order no longer available" page (HTTP 404) instead of Django's raw debug message.
-
-- Material Exchange / Sell paste import: now renders catalog as a JSON array, guards against malformed payloads, and falls back to normalized visible row names when matching pasted lines. Items like `Core Probe Launcher I\t7` or `tritanium 2500` are now matched instead of reported as unknown.
-
-- Material Exchange / Sell paste import: item names missing from the local page catalog are now resolved against the SDE database before classification, so items are only shown as unknown when the name cannot be found in the DB.
-
-- SDE compatibility sync: when the temporary SDE archive extraction fails with a transient `EOFError` (truncated ZIP stream), the Celery sync task now retries the download+extract step before failing, reducing one-off sync crashes. (GH-109)
-
-- Tests and maintenance: cleaned up brittle or redundant regression coverage, removed dead placeholder tests, and tightened the Material Exchange, craft timing, industry jobs, and structure lookup tests around the actual runtime behavior.
-
-- Performance: reduced repeated location and skill lookups, reused skill and slot snapshots more broadly, and improved query optimization for linked character sets with large inventories.
-
-- Navigation: Indy Hub pages now measure the rendered Alliance Auth top bar and offset content by its actual height, preventing Bootstrap 5 themes (Slate/Darkly) from letting wrapped module navigation overlap the page header.
-
-- Navigation: Indy Hub dropdown labels remain visible in the mobile Alliance Auth menu instead of collapsing to icon-only entries.
-
-- Admin: Blueprint changelist now displays blueprint type, ownership scope, real owner entity, and corporation ID, with matching filters and search fields, so corporation blueprints are no longer easy to confuse with personal character blueprints.
-
-- Notifications: fixed typo in SHORT_LINK_LABEL for transaction notifications.
+- Industry sync tasks: fixed MySQL duplicate-key race handling (`IntegrityError 1062`) by extending retry behavior alongside deadlock retries.
+- Industry Structures: fixed synced-structure setup state, preserved manually-entered identity fields when ESI returns incomplete/invalid values, and enforced 403 forbidden cooldown skipping to avoid repeated rate-limit waste.
+- Crafting Projects: fixed multiple planner and financial regressions (structure compatibility resolution, rig bonus application/rounding, all-buy totals, decision persistence, stock allocation persistence, and lazy-tab action reliability).
+- Blueprint Sharing: fixed request-page performance (N+1 eligibility/limit lookups), copy-install cost consistency, and repeated-contract validation edge cases. (GH-101, GH-119)
+- Material Exchange: fixed duplicate-processing and name-resolution edge cases, improved stale-order link handling, and hardened sell paste-import matching/classification.
+- Platform and UX: improved large-account performance (linked-character query scaling), stabilized navigation header/mobile label behavior, and corrected admin/notification polish issues.
 
 ## [1.17.2] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ## [Unreleased]
 
+### Added
+
+- Industry Structures: added tax configuration and editing for auto-synced structures, allowing administrators to manage installation costs directly on structures synced from corporation ESI.
+- Material Exchange: added Material Hub navbar badge showing active buy/sell order counts, with status differentiation between open, completed, and cancelled transactions.
+
 ### Changed
 
 - Crafting Projects / Structure planner: improved capital ship classification and structure matching so command carriers and super-carriers are detected reliably from SDE ship outputs, with the planner falling back more gracefully when lookups fail.
@@ -19,43 +24,105 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 - Crafting Projects / Craft payload API: blueprint product lookup now resolves against the correct product type for workspace payloads, preventing mismatches when the project blueprint context is rebuilt.
 
+- Crafting Projects / Buy: added custom fixed adjustment lines directly in the financial planner table (between Outputs and Totals). Users can add/remove any number of rows with `Name`, `Type` (Expense/Revenue), `Qty`, and `Unit Price`, with live line totals and immediate impact on project totals.
+
+- Crafting Projects / Buy: fixed-adjustment rows are now persisted in the workspace session state and restored on reload, matching other Buy-tab manual overrides.
+
+- Crafting Projects / Shopping list: improved in-client export/copy workflows for EVE-style shopping output, including clearer compute-before-copy behavior and stronger copy feedback in the Shopping header.
+
+- Crafting Projects / Workspace: quantity-oriented numeric inputs (runs, buy-tolerance override, stock allocation, and financial buy/sell override fields) now reserve enough width to display large industrial values without inner clipping, while keeping right-aligned numeric readability on desktop and mobile. (GH-105)
+
+- Crafting Projects / Workspace responsive layout: significantly improved craft table overflow handling across all tabs (Stock, Build, Timing, Structure, Decision, Buy) using container-query stacked cards for mobile viewports, minimum-width enforcement, and normalized tab pane clipping to prevent unwanted AA-level scrollbars.
+
 - Material Exchange: stock tables now show available quantity as the primary value, keep total visible, and only surface the secondary quantity when non-zero. Buy flows remain reservation-aware, and sell flows now compute reservations from active sell orders scoped to the selected character (with `character_id` persisted on sell orders) so `Reserved` and max-quantity inputs stay coherent.
 
 - Material Exchange: buy-order validation now treats explicit empty type-id filters as an empty result immediately, avoiding unnecessary database work when no stock items remain after filtering.
+
+- Material Exchange: sell page now persists sell-order character context and properly refines reserved quantity display based on active sell orders, preventing false reservation counts and keeping stock visibility aligned with actual transaction state.
+
+- SDE integration: Indy Hub now relies on the base `eve_sde` data path only, removing the legacy compatibility sync flow and related maintenance commands.
+
+- SDE / bootstrap: the SDE compatibility and startup paths were simplified to reduce duplicate state and align the app with the standard Alliance Auth installation flow. (GH-109)
+
+- Industry Structures / Sync: structure sync schedule changed from hourly to daily (06:35 UTC + AA offset) to reduce load on ESI and internal sync queues.
 
 ### Fixed
 
 - Industry and related sync tasks now retry MySQL duplicate-key races in addition to deadlocks when performing unique-row upserts, preventing concurrent Celery workers from crashing on `IntegrityError 1062` for rows such as skill snapshots, roles, cached structure names, contracts, and blueprint sync records.
 
-- SDE integration: Indy Hub now relies on the base `eve_sde` data path only, removing the legacy compatibility sync flow and related maintenance commands.
+- Industry Structures / Synced structures: fixed setup state tracking so auto-synced structures no longer remain stuck on "Setup needed" when taxes are edited. Taxes and rigs are now included in structure completeness checks, and partial ESI failures no longer lock the structure in an unusable state.
 
-- SDE / bootstrap: the SDE compatibility and startup paths were simplified to reduce duplicate state and align the app with the standard Alliance Auth installation flow.
+- Industry Structures / Synced structures: fixed identity field preservation during ESI sync. Manually-entered system ID, system name, constellation/region identifiers, and category information are now reliably preserved when ESI returns incomplete or invalid data (numeric 0, negative IDs, or empty values), implementing the promised "future attempts will be skipped" behavior for 403 Forbidden structures.
 
-- Tests and maintenance: cleaned up brittle or redundant regression coverage, removed a dead placeholder test, and tightened the Material Exchange, craft timing, industry jobs, and structure lookup tests around the actual runtime behavior.
-
-## [1.18.0] - 2026-06-06
-
-### Changed
-
-- Crafting Projects / Buy: added custom fixed adjustment lines directly in the financial planner table (between Outputs and Totals). Users can add/remove any number of rows with `Name`, `Type` (Expense/Revenue), `Qty`, and `Unit Price`, with live line totals and immediate impact on project totals.
-- Crafting Projects / Buy: fixed-adjustment rows are now persisted in the workspace session state and restored on reload, matching other Buy-tab manual overrides.
-- Crafting Projects / Shopping list: improved in-client export/copy workflows for EVE-style shopping output, including clearer compute-before-copy behavior and stronger copy feedback in the Shopping header.
-
-### Fixed
+- Industry Structures / ESI 403 handling: the structure name resolution loop now skips structures that already have a forbidden (403) cooldown, preventing repeated ESI 403 attempts that waste rate limits. Structures marked forbidden are logged with a 15-day retry delay message.
 
 - Crafting Projects / Structure planner: fixed false `No compatible structures are currently available for this craft plan` states caused by filtering planner rows with blueprint type ids instead of produced item type ids. Planner lookup now uses produced item ids so valid structures (including Sotiyo/supercapital-capable setups) are correctly surfaced.
 
 - Crafting Projects / Structure planner: supercapital structure compatibility no longer depends on supercapital tax fields being populated; support checks now rely on explicit structure capability flags.
 
+- Crafting Projects / Structure planner: advanced component rig matching now recognizes both item category names and the `Construction Component(s)` commodity aliases used by live SDE labels, correctly applying material and time bonuses on structures with Advanced Component rigs.
+
+- Crafting Projects / Structure planner: material quantities now combine blueprint ME and selected structure/rig material bonuses before the final EVE rounding step, eliminating over-counts on T2/T3 jobs where UI rounding cascaded with structure bonus rounding.
+
+- Crafting Projects / Structure planner: ME, TE, and Job values in the assignment table now expose hover details showing component breakdown and structure role bonuses instead of a single tax column.
+
+- Crafting Projects / Structure planner: manually selected per-item structure assignments now persist across tab changes and project reloads when the workspace keeps a compact planner payload.
+
+- Crafting Projects / Build tab: final product cycle rows now use the saved project target quantity as the source of truth, preventing transient SimulationAPI or DOM quantities from displaying incorrect final run counts.
+
+- Crafting Projects / Financial planner: fixed `Total Material Cost`, `Cash Needed for Materials`, `Cash Investment Needed`, and `Total Cost` summaries reading 0 ISK when all items were toggled to Buy mode. Buy-mode items are now correctly counted as both a cost line and revenue line.
+
+- Crafting Projects / Decisions: fixed missing intermediate rows in some project trees (fuel blocks, reactions) by evaluating parent visibility across all ancestor paths instead of only the optimizer-pruned recommendation tree.
+
+- Crafting Projects / Decisions: clicking *Set everything to Buy* / *Set everything to Prod* now works even when the Decisions tab has not been opened yet, with fallback to the materials tree when the Decisions container is lazy-rendered.
+
+- Crafting Projects / Buy: margin now shows `-100%` instead of `0%` when a workspace has costs but zero configured revenue, matching the fully unprofitable state.
+
+- Crafting Projects / Workspace persistence: saved buy/produce decisions and final product prices now restore from the workspace state even when tabs are hidden or lazily hydrated, preventing default zero DOM inputs or partial price refresh responses from wiping saved decisions and allocation state.
+
+- Crafting Projects / Workspace persistence: prevented saved stock allocations from being silently destroyed on save. The persistence path now stores raw user intent (non-negative integers only) instead of display-time clamped allocations, so unrelated SDE refreshes or plan changes no longer wipe allocations not currently required.
+
+- Crafting Projects / Stock allocations: the Stock tab's `Use` inputs now accept large industrial quantities reliably, with numeric attributes using raw integers instead of thousands-separated display values, and deferred batch commits for dependent refreshes.
+
+- Crafting Projects / Blueprint planning: project workspaces now default to the best owned blueprint ME/TE when no saved override exists, so financial calculations no longer fall back to 0/0 for researched blueprints.
+
+- Crafting Projects / Build + Outputs: project renaming no longer leaks into final product item labels. The workspace now canonicalizes product names from SDE type data and never falls back to the project title for item names.
+
+- Crafting Projects / EFT import: fitting names containing square brackets (e.g. `[Retribution, [PRIME] SD 01]`) are now parsed correctly. The header regex no longer bails on inner `]` characters.
+
+- Crafting Projects / EFT import: when importing an EFT fitting without entering a project name, the modal pre-fills it as `Hull // Fit Name` (e.g. `Hurricane // s.2012 T2`) instead of just the fit name.
+
+- Crafting Projects / Tab loading: reduced browser console performance warnings by deferring heavier startup tab initialization and removing forced-layout reads that restarted animation loops.
+
 - Blueprint sharing: the "Request a copy" page no longer issues per-card eligibility and SDE-limit queries while building each card preview. Eligibility lookups for the entire page and the native `max_production_limit` are now resolved with a constant number of queries, eliminating the N+1 pattern that could push the page beyond proxy/gateway timeouts on Alliance Auth v5 instances with thousands of shared blueprints. (GH-101)
+
+- Blueprint sharing: copy-installation estimates on fulfill requests now use manufacturing material EIV, scale totals by the selected copy count, round ISK rows consistently, and keep the grand-total label aligned with the requested number of copies.
+
+- Blueprint sharing: a finished contract that was already linked to a previous buy order is no longer eligible to auto-validate a new identical buy order, preventing false "wrong contract reference" anomaly overrides when users repeat the same request pattern. (GH-119)
 
 - Character skill context loading no longer performs one `EveCharacter` lookup per linked character when building dashboard/industry skill rows. Character names are now read from the already joined ownership records (with fallback only when missing), keeping query counts bounded for users with large linked-character sets. (GH-110)
 
-- Crafting Projects / Workspace: quantity-oriented numeric inputs (runs, buy-tolerance override, stock allocation, and financial buy/sell override fields) now reserve enough width to display large industrial values without inner clipping, while keeping right-aligned numeric readability on desktop and mobile. (GH-105)
+- Material Exchange / Buy validation: contract structure or item-name resolution edge cases are now handled more robustly, and duplicate transaction processing is prevented.
 
-- SDE loading now uses the base `eve_sde` data directly. Indy Hub no longer maintains a parallel compatibility cache or `sync_sde_compat`/`indy_sde_compat` refresh flow, and operator guidance now relies on the standard `eve_sde` setup process. (GH-109)
+- Material Exchange / Sell page: clicking a stale Discord link to a completed, cancelled, or deleted order now lands on a friendly "order no longer available" page (HTTP 404) instead of Django's raw debug message.
 
-- Material Exchange / Buy validation: a finished contract that was already linked to a previous buy order is no longer eligible to auto-validate a new identical buy order, preventing false "wrong contract reference" anomaly overrides when users repeat the same request pattern. (GH-119)
+- Material Exchange / Sell paste import: now renders catalog as a JSON array, guards against malformed payloads, and falls back to normalized visible row names when matching pasted lines. Items like `Core Probe Launcher I\t7` or `tritanium 2500` are now matched instead of reported as unknown.
+
+- Material Exchange / Sell paste import: item names missing from the local page catalog are now resolved against the SDE database before classification, so items are only shown as unknown when the name cannot be found in the DB.
+
+- SDE compatibility sync: when the temporary SDE archive extraction fails with a transient `EOFError` (truncated ZIP stream), the Celery sync task now retries the download+extract step before failing, reducing one-off sync crashes. (GH-109)
+
+- Tests and maintenance: cleaned up brittle or redundant regression coverage, removed dead placeholder tests, and tightened the Material Exchange, craft timing, industry jobs, and structure lookup tests around the actual runtime behavior.
+
+- Performance: reduced repeated location and skill lookups, reused skill and slot snapshots more broadly, and improved query optimization for linked character sets with large inventories.
+
+- Navigation: Indy Hub pages now measure the rendered Alliance Auth top bar and offset content by its actual height, preventing Bootstrap 5 themes (Slate/Darkly) from letting wrapped module navigation overlap the page header.
+
+- Navigation: Indy Hub dropdown labels remain visible in the mobile Alliance Auth menu instead of collapsing to icon-only entries.
+
+- Admin: Blueprint changelist now displays blueprint type, ownership scope, real owner entity, and corporation ID, with matching filters and search fields, so corporation blueprints are no longer easy to confuse with personal character blueprints.
+
+- Notifications: fixed typo in SHORT_LINK_LABEL for transaction notifications.
 
 ## [1.17.2] - 2026-06-01
 

--- a/indy_hub/migrations/0106_update_periodic_tasks.py
+++ b/indy_hub/migrations/0106_update_periodic_tasks.py
@@ -1,0 +1,32 @@
+# Django
+from django.db import migrations
+
+
+def update_periodic_tasks(apps, schema_editor):
+    """Re-apply IndyHub periodic task schedules after schedule changes."""
+    try:
+        # AA Example App
+        from indy_hub.tasks import setup_periodic_tasks as _setup_periodic_tasks
+
+        _setup_periodic_tasks()
+    except Exception:
+        # Standard Library
+        import logging
+
+        logging.getLogger(__name__).exception(
+            "Failed to update IndyHub periodic tasks during migration."
+        )
+
+
+def noop(apps, schema_editor):
+    return None
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("indy_hub", "0105_remove_project_item_unique_type_category"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_periodic_tasks, noop),
+    ]

--- a/indy_hub/migrations/0106_update_periodic_tasks.py
+++ b/indy_hub/migrations/0106_update_periodic_tasks.py
@@ -9,13 +9,14 @@ def update_periodic_tasks(apps, schema_editor):
         from indy_hub.tasks import setup_periodic_tasks as _setup_periodic_tasks
 
         _setup_periodic_tasks()
-    except ImportError:
+    except Exception:
         # Standard Library
         import logging
 
-        logging.getLogger(__name__).warning(
-            "IndyHub tasks module not available during migration; periodic tasks not updated. "
-            "Run 'python manage.py shell' and call setup_periodic_tasks() manually if needed."
+        logging.getLogger(__name__).exception(
+            "Failed to re-apply IndyHub periodic tasks during migration 0106. "
+            "Upgrade continues; periodic tasks can be re-applied manually by calling "
+            "setup_periodic_tasks() from a Django shell."
         )
 
 

--- a/indy_hub/migrations/0106_update_periodic_tasks.py
+++ b/indy_hub/migrations/0106_update_periodic_tasks.py
@@ -9,12 +9,13 @@ def update_periodic_tasks(apps, schema_editor):
         from indy_hub.tasks import setup_periodic_tasks as _setup_periodic_tasks
 
         _setup_periodic_tasks()
-    except Exception:
+    except ImportError:
         # Standard Library
         import logging
 
-        logging.getLogger(__name__).exception(
-            "Failed to update IndyHub periodic tasks during migration."
+        logging.getLogger(__name__).warning(
+            "IndyHub tasks module not available during migration; periodic tasks not updated. "
+            "Run 'python manage.py shell' and call setup_periodic_tasks() manually if needed."
         )
 
 

--- a/indy_hub/models.py
+++ b/indy_hub/models.py
@@ -3361,7 +3361,6 @@ class IndustryStructure(models.Model):
 
     def get_missing_profile_sections(self) -> list[str]:
         missing_sections: list[str] = []
-        is_synced = self.is_synced_structure()
 
         if not self.structure_type_id or not self.solar_system_id:
             missing_sections.append("Identity")
@@ -3384,17 +3383,12 @@ class IndustryStructure(models.Model):
         ):
             missing_sections.append("Rigs")
 
-        # Synced structures keep tax fields read-only in the UI because they are
-        # governed by the corporation ESI sync flow. Requiring non-zero tax values
-        # on those entries would keep them stuck in "Setup needed" with no manual
-        # path to resolve the warning.
-        if not is_synced:
-            has_non_zero_tax = any(
-                (tax_percent or Decimal("0")) > 0
-                for _label, tax_percent in self.get_activity_tax_rows()
-            )
-            if not has_non_zero_tax:
-                missing_sections.append("Taxes")
+        has_non_zero_tax = any(
+            (tax_percent or Decimal("0")) > 0
+            for _label, tax_percent in self.get_activity_tax_rows()
+        )
+        if not has_non_zero_tax:
+            missing_sections.append("Taxes")
 
         return missing_sections
 

--- a/indy_hub/models.py
+++ b/indy_hub/models.py
@@ -3361,6 +3361,7 @@ class IndustryStructure(models.Model):
 
     def get_missing_profile_sections(self) -> list[str]:
         missing_sections: list[str] = []
+        is_synced = self.is_synced_structure()
 
         if not self.structure_type_id or not self.solar_system_id:
             missing_sections.append("Identity")
@@ -3383,12 +3384,17 @@ class IndustryStructure(models.Model):
         ):
             missing_sections.append("Rigs")
 
-        has_non_zero_tax = any(
-            (tax_percent or Decimal("0")) > 0
-            for _label, tax_percent in self.get_activity_tax_rows()
-        )
-        if not has_non_zero_tax:
-            missing_sections.append("Taxes")
+        # Synced structures keep tax fields read-only in the UI because they are
+        # governed by the corporation ESI sync flow. Requiring non-zero tax values
+        # on those entries would keep them stuck in "Setup needed" with no manual
+        # path to resolve the warning.
+        if not is_synced:
+            has_non_zero_tax = any(
+                (tax_percent or Decimal("0")) > 0
+                for _label, tax_percent in self.get_activity_tax_rows()
+            )
+            if not has_non_zero_tax:
+                missing_sections.append("Taxes")
 
         return missing_sections
 

--- a/indy_hub/schedules.py
+++ b/indy_hub/schedules.py
@@ -28,7 +28,7 @@ INDY_HUB_BEAT_SCHEDULE = {
     },
     "indy-hub-sync-persisted-structures": {
         "task": "indy_hub.tasks.industry_structure_sync.sync_persisted_industry_structure_registry",
-        "schedule": crontab(minute=35, hour="*"),  # Hourly
+        "schedule": crontab(minute=35, hour=6),  # Daily at 06:35
         "options": {"priority": 7},
         "apply_offset": True,
     },

--- a/indy_hub/services/asset_cache.py
+++ b/indy_hub/services/asset_cache.py
@@ -979,6 +979,12 @@ def resolve_structure_names(
             except Exception as exc:
                 logger.debug("Failed to update task progress: %s", exc)
 
+        # Skip structures that already have a forbidden cooldown to prevent
+        # repeated 403 attempts that waste rate limits
+        if has_structure_forbidden_cooldown(structure_id):
+            forbidden_structure_ids.add(int(structure_id))
+            continue
+
         if do_sync_esi and sync_lookup_budget > 0:
             resolved = False
             structure_forbidden = False
@@ -1039,6 +1045,10 @@ def resolve_structure_names(
             elif structure_forbidden:
                 forbidden_structure_ids.add(int(structure_id))
                 set_structure_forbidden_cooldown(int(structure_id))
+                logger.info(
+                    "Structure %s is forbidden and will be skipped for 15 days (ESI 403)",
+                    structure_id,
+                )
 
     if total_to_resolve and (
         forbidden_attempts

--- a/indy_hub/services/industry_structure_sync.py
+++ b/indy_hub/services/industry_structure_sync.py
@@ -420,9 +420,7 @@ def sync_corporation_structure_targets(
                 structure_type_name = (
                     structure_type_reference[1]
                     if structure_type_reference is not None
-                    else (
-                        get_type_name(structure_type_id) if structure_type_id else None
-                    )
+                    else (get_type_name(structure_type_id) if structure_type_id else "")
                 )
 
                 solar_system_reference = (
@@ -433,7 +431,7 @@ def sync_corporation_structure_targets(
                 solar_system_name = (
                     solar_system_reference[1]
                     if solar_system_reference is not None
-                    else None  # Use None, not "", so merge preserves manual values
+                    else ""
                 )
                 system_security_band = (
                     solar_system_reference[2]
@@ -475,7 +473,7 @@ def sync_corporation_structure_targets(
                         constellation_name=(
                             str(solar_system_location_reference["constellation_name"])
                             if solar_system_location_reference is not None
-                            else None
+                            else ""
                         ),
                         region_id=(
                             solar_system_location_reference["region_id"]
@@ -485,7 +483,7 @@ def sync_corporation_structure_targets(
                         region_name=(
                             str(solar_system_location_reference["region_name"])
                             if solar_system_location_reference is not None
-                            else None
+                            else ""
                         ),
                         system_security_band=system_security_band,
                         external_structure_id=structure_id,
@@ -530,7 +528,7 @@ def sync_corporation_structure_targets(
                         (
                             str(solar_system_location_reference["constellation_name"])
                             if solar_system_location_reference is not None
-                            else None
+                            else ""
                         ),
                     ),
                     "region_id": _merge_synced_identity_value(
@@ -546,7 +544,7 @@ def sync_corporation_structure_targets(
                         (
                             str(solar_system_location_reference["region_name"])
                             if solar_system_location_reference is not None
-                            else None
+                            else ""
                         ),
                     ),
                     "system_security_band": _merge_synced_identity_value(

--- a/indy_hub/services/industry_structure_sync.py
+++ b/indy_hub/services/industry_structure_sync.py
@@ -232,7 +232,7 @@ def _get_online_industry_activity_flags(payload: dict[str, object]) -> dict[str,
 
 def _merge_synced_identity_value(current_value, incoming_value):
     """Keep existing identity data when ESI payload omits that field.
-    
+
     Preserves manually-entered values when ESI:
     - Omits the field (incoming_value is None)
     - Returns empty/whitespace string
@@ -240,19 +240,19 @@ def _merge_synced_identity_value(current_value, incoming_value):
     """
     if incoming_value is None:
         return current_value
-    
+
     # For string fields: preserve existing when incoming is empty/whitespace
     if isinstance(incoming_value, str):
         if not incoming_value.strip():
             return current_value
         return incoming_value
-    
+
     # For numeric fields (IDs): preserve existing when incoming is 0 or negative
     if isinstance(incoming_value, int):
         if incoming_value <= 0:
             return current_value
         return incoming_value
-    
+
     # For other types, use incoming value
     return incoming_value
 
@@ -420,7 +420,9 @@ def sync_corporation_structure_targets(
                 structure_type_name = (
                     structure_type_reference[1]
                     if structure_type_reference is not None
-                    else (get_type_name(structure_type_id) if structure_type_id else None)
+                    else (
+                        get_type_name(structure_type_id) if structure_type_id else None
+                    )
                 )
 
                 solar_system_reference = (

--- a/indy_hub/services/industry_structure_sync.py
+++ b/indy_hub/services/industry_structure_sync.py
@@ -231,11 +231,29 @@ def _get_online_industry_activity_flags(payload: dict[str, object]) -> dict[str,
 
 
 def _merge_synced_identity_value(current_value, incoming_value):
-    """Keep existing identity data when ESI payload omits that field."""
+    """Keep existing identity data when ESI payload omits that field.
+    
+    Preserves manually-entered values when ESI:
+    - Omits the field (incoming_value is None)
+    - Returns empty/whitespace string
+    - Returns invalid numeric value (0 or negative) for IDs
+    """
     if incoming_value is None:
         return current_value
-    if isinstance(incoming_value, str) and not incoming_value.strip():
-        return current_value
+    
+    # For string fields: preserve existing when incoming is empty/whitespace
+    if isinstance(incoming_value, str):
+        if not incoming_value.strip():
+            return current_value
+        return incoming_value
+    
+    # For numeric fields (IDs): preserve existing when incoming is 0 or negative
+    if isinstance(incoming_value, int):
+        if incoming_value <= 0:
+            return current_value
+        return incoming_value
+    
+    # For other types, use incoming value
     return incoming_value
 
 
@@ -402,8 +420,8 @@ def sync_corporation_structure_targets(
                 structure_type_name = (
                     structure_type_reference[1]
                     if structure_type_reference is not None
-                    else (get_type_name(structure_type_id) if structure_type_id else "")
-                ) or ""
+                    else (get_type_name(structure_type_id) if structure_type_id else None)
+                )
 
                 solar_system_reference = (
                     resolve_solar_system_reference(solar_system_id=solar_system_id)
@@ -413,7 +431,7 @@ def sync_corporation_structure_targets(
                 solar_system_name = (
                     solar_system_reference[1]
                     if solar_system_reference is not None
-                    else ""
+                    else None  # Use None, not "", so merge preserves manual values
                 )
                 system_security_band = (
                     solar_system_reference[2]
@@ -455,7 +473,7 @@ def sync_corporation_structure_targets(
                         constellation_name=(
                             str(solar_system_location_reference["constellation_name"])
                             if solar_system_location_reference is not None
-                            else ""
+                            else None
                         ),
                         region_id=(
                             solar_system_location_reference["region_id"]
@@ -465,7 +483,7 @@ def sync_corporation_structure_targets(
                         region_name=(
                             str(solar_system_location_reference["region_name"])
                             if solar_system_location_reference is not None
-                            else ""
+                            else None
                         ),
                         system_security_band=system_security_band,
                         external_structure_id=structure_id,
@@ -510,7 +528,7 @@ def sync_corporation_structure_targets(
                         (
                             str(solar_system_location_reference["constellation_name"])
                             if solar_system_location_reference is not None
-                            else ""
+                            else None
                         ),
                     ),
                     "region_id": _merge_synced_identity_value(
@@ -526,7 +544,7 @@ def sync_corporation_structure_targets(
                         (
                             str(solar_system_location_reference["region_name"])
                             if solar_system_location_reference is not None
-                            else ""
+                            else None
                         ),
                     ),
                     "system_security_band": _merge_synced_identity_value(

--- a/indy_hub/services/industry_structure_sync.py
+++ b/indy_hub/services/industry_structure_sync.py
@@ -230,6 +230,15 @@ def _get_online_industry_activity_flags(payload: dict[str, object]) -> dict[str,
     return enabled_flags
 
 
+def _merge_synced_identity_value(current_value, incoming_value):
+    """Keep existing identity data when ESI payload omits that field."""
+    if incoming_value is None:
+        return current_value
+    if isinstance(incoming_value, str) and not incoming_value.strip():
+        return current_value
+    return incoming_value
+
+
 def _has_online_industry_service(payload: dict[str, object]) -> bool:
     return any(_get_online_industry_activity_flags(payload).values())
 
@@ -472,34 +481,64 @@ def sync_corporation_structure_targets(
                 changed_fields: list[str] = []
                 synced_field_values = {
                     "name": synced_name,
-                    "structure_type_id": structure_type_id,
-                    "structure_type_name": structure_type_name,
-                    "solar_system_id": solar_system_id,
-                    "solar_system_name": solar_system_name,
-                    "constellation_id": (
-                        solar_system_location_reference["constellation_id"]
-                        if solar_system_location_reference is not None
-                        else None
+                    "structure_type_id": _merge_synced_identity_value(
+                        existing_structure.structure_type_id,
+                        structure_type_id,
                     ),
-                    "constellation_name": (
-                        str(solar_system_location_reference["constellation_name"])
-                        if solar_system_location_reference is not None
-                        else ""
+                    "structure_type_name": _merge_synced_identity_value(
+                        existing_structure.structure_type_name,
+                        structure_type_name,
                     ),
-                    "region_id": (
-                        solar_system_location_reference["region_id"]
-                        if solar_system_location_reference is not None
-                        else None
+                    "solar_system_id": _merge_synced_identity_value(
+                        existing_structure.solar_system_id,
+                        solar_system_id,
                     ),
-                    "region_name": (
-                        str(solar_system_location_reference["region_name"])
-                        if solar_system_location_reference is not None
-                        else ""
+                    "solar_system_name": _merge_synced_identity_value(
+                        existing_structure.solar_system_name,
+                        solar_system_name,
                     ),
-                    "system_security_band": system_security_band,
+                    "constellation_id": _merge_synced_identity_value(
+                        existing_structure.constellation_id,
+                        (
+                            solar_system_location_reference["constellation_id"]
+                            if solar_system_location_reference is not None
+                            else None
+                        ),
+                    ),
+                    "constellation_name": _merge_synced_identity_value(
+                        existing_structure.constellation_name,
+                        (
+                            str(solar_system_location_reference["constellation_name"])
+                            if solar_system_location_reference is not None
+                            else ""
+                        ),
+                    ),
+                    "region_id": _merge_synced_identity_value(
+                        existing_structure.region_id,
+                        (
+                            solar_system_location_reference["region_id"]
+                            if solar_system_location_reference is not None
+                            else None
+                        ),
+                    ),
+                    "region_name": _merge_synced_identity_value(
+                        existing_structure.region_name,
+                        (
+                            str(solar_system_location_reference["region_name"])
+                            if solar_system_location_reference is not None
+                            else ""
+                        ),
+                    ),
+                    "system_security_band": _merge_synced_identity_value(
+                        existing_structure.system_security_band,
+                        system_security_band,
+                    ),
                     "external_structure_id": structure_id,
                     "owner_corporation_id": corporation_id,
-                    "owner_corporation_name": corporation_name,
+                    "owner_corporation_name": _merge_synced_identity_value(
+                        existing_structure.owner_corporation_name,
+                        corporation_name,
+                    ),
                     "sync_source": IndustryStructure.SyncSource.ESI_CORPORATION,
                     "last_synced_at": now,
                     **enabled_activity_flags,

--- a/indy_hub/templates/indy_hub/industry/structure_add.html
+++ b/indy_hub/templates/indy_hub/industry/structure_add.html
@@ -33,7 +33,7 @@
 
                             {% if is_synced_structure_locked %}
                                 <div class="alert alert-info m-3 mb-0">
-                                    {% trans "This structure is synchronized automatically from corporation ESI. Identity, activities and taxes are locked here; only rigs can be adjusted." %}
+                                    {% trans "This structure is synchronized automatically from corporation ESI. Identity and activities are locked here; taxes and rigs can still be adjusted." %}
                                 </div>
                             {% endif %}
 
@@ -49,7 +49,7 @@
                                     </div>
                                     <p class="structure-command-card__meta mb-0">
                                         {% if is_synced_structure_locked %}
-                                            {% trans "Identity and taxes are controlled by ESI sync." %}
+                                            {% trans "Identity comes from ESI sync. Taxes and rigs remain locally configurable." %}
                                         {% else %}
                                             {% trans "You control identity, services, taxes and rigs from this screen." %}
                                         {% endif %}
@@ -76,7 +76,6 @@
                                 </section>
                             </div>
 
-                            {% if is_synced_structure_locked %}<fieldset disabled>{% endif %}
                             <section class="border-bottom structure-zone structure-zone--identity">
                                 <div class="card-header bg-body-tertiary border-0 py-3 px-4 structure-zone__header">
                                     <div>
@@ -259,8 +258,6 @@
                                     </div>
                                 </div>
                             </section>
-
-                            {% if is_synced_structure_locked %}</fieldset>{% endif %}
 
                             <section class="structure-zone structure-zone--rigs" id="structure-rig-section">
                                 <div class="card-header bg-body-tertiary border-0 py-3 px-4 structure-zone__header">

--- a/indy_hub/tests/test_industry_structure_registry_view.py
+++ b/indy_hub/tests/test_industry_structure_registry_view.py
@@ -972,6 +972,26 @@ Standup Composite Reactor I
         self.assertNotIn("Rigs", missing)
         self.assertFalse(structure.is_profile_incomplete(), missing)
 
+    def test_synced_structure_does_not_report_missing_taxes(self) -> None:
+        """Synced structures lock tax editing and should not stay stuck on taxes."""
+
+        structure = IndustryStructure.objects.create(
+            name="Iralaja IX - Synced NPC",
+            structure_type_id=NPC_STATION_STRUCTURE_TYPE_ID,
+            structure_type_name="NPC Station",
+            solar_system_id=30002780,
+            solar_system_name="Iralaja",
+            visibility_scope=IndustryStructure.VisibilityScope.PUBLIC,
+            sync_source=IndustryStructure.SyncSource.ESI_CORPORATION,
+            external_structure_id=1020000000009,
+            enable_manufacturing=True,
+            manufacturing_tax_percent=Decimal("0"),
+        )
+
+        missing = structure.get_missing_profile_sections()
+        self.assertNotIn("Taxes", missing)
+        self.assertFalse(structure.is_profile_incomplete(), missing)
+
     @patch(
         "indy_hub.forms.industry_structures.sde_item_types_loaded", return_value=True
     )

--- a/indy_hub/tests/test_industry_structure_registry_view.py
+++ b/indy_hub/tests/test_industry_structure_registry_view.py
@@ -972,8 +972,8 @@ Standup Composite Reactor I
         self.assertNotIn("Rigs", missing)
         self.assertFalse(structure.is_profile_incomplete(), missing)
 
-    def test_synced_structure_does_not_report_missing_taxes(self) -> None:
-        """Synced structures lock tax editing and should not stay stuck on taxes."""
+    def test_synced_structure_reports_missing_taxes_when_all_zero(self) -> None:
+        """Synced structures should report missing taxes when all enabled taxes are zero."""
 
         structure = IndustryStructure.objects.create(
             name="Iralaja IX - Synced NPC",
@@ -989,8 +989,8 @@ Standup Composite Reactor I
         )
 
         missing = structure.get_missing_profile_sections()
-        self.assertNotIn("Taxes", missing)
-        self.assertFalse(structure.is_profile_incomplete(), missing)
+        self.assertIn("Taxes", missing)
+        self.assertTrue(structure.is_profile_incomplete())
 
     @patch(
         "indy_hub.forms.industry_structures.sde_item_types_loaded", return_value=True
@@ -1711,12 +1711,16 @@ Standup Composite Reactor I
     @patch(
         "indy_hub.forms.industry_structures.sde_item_types_loaded", return_value=True
     )
+    @patch("indy_hub.forms.industry_structures.resolve_solar_system_location_reference")
+    @patch("indy_hub.forms.industry_structures.resolve_solar_system_reference")
     @patch("indy_hub.forms.industry_structures.resolve_item_type_reference")
     @patch("indy_hub.forms.industry_structures.is_rig_compatible_with_structure_type")
-    def test_edit_view_for_synced_structure_only_updates_rigs(
+    def test_edit_view_for_synced_structure_updates_taxes_and_rigs_only(
         self,
         mock_is_rig_compatible,
         mock_resolve_item_type_reference,
+        mock_resolve_solar_system_reference,
+        mock_resolve_solar_system_location_reference,
         _mock_form_sde_loaded,
     ) -> None:
         structure = IndustryStructure.objects.create(
@@ -1744,9 +1748,24 @@ Standup Composite Reactor I
         mock_is_rig_compatible.return_value = True
         mock_resolve_item_type_reference.side_effect = (
             lambda *, item_type_id=None, item_type_name=None: {
+                35826: (35826, "Azbel"),
                 43879: (43879, "Standup M-Set Invention Cost Optimization I"),
             }.get(item_type_id)
         )
+        mock_resolve_solar_system_reference.return_value = (
+            30000142,
+            "Jita",
+            IndustryStructure.SecurityBand.HIGHSEC,
+        )
+        mock_resolve_solar_system_location_reference.return_value = {
+            "solar_system_id": 30000142,
+            "solar_system_name": "Jita",
+            "system_security_band": IndustryStructure.SecurityBand.HIGHSEC,
+            "constellation_id": 20000020,
+            "constellation_name": "Kimotoro",
+            "region_id": 10000002,
+            "region_name": "The Forge",
+        }
 
         request = self._prepare_request(
             self.factory.post(
@@ -1757,6 +1776,13 @@ Standup Composite Reactor I
                     "solar_system_name": "Perimeter",
                     "enable_invention": "1",
                     "manufacturing_tax_percent": "9.999",
+                    "manufacturing_capitals_tax_percent": "0.000",
+                    "manufacturing_super_capitals_tax_percent": "0.000",
+                    "research_tax_percent": "0.000",
+                    "invention_tax_percent": "2.500",
+                    "biochemical_reactions_tax_percent": "0.000",
+                    "hybrid_reactions_tax_percent": "0.000",
+                    "composite_reactions_tax_percent": "0.000",
                     "rigs-TOTAL_FORMS": "3",
                     "rigs-INITIAL_FORMS": "3",
                     "rigs-MIN_NUM_FORMS": "0",
@@ -1783,7 +1809,8 @@ Standup Composite Reactor I
         self.assertEqual(structure.structure_type_id, 35826)
         self.assertEqual(structure.solar_system_name, "Jita")
         self.assertFalse(structure.enable_invention)
-        self.assertEqual(structure.manufacturing_tax_percent, Decimal("0.500"))
+        self.assertEqual(structure.manufacturing_tax_percent, Decimal("9.999"))
+        self.assertEqual(structure.invention_tax_percent, Decimal("2.500"))
         self.assertEqual(structure.rigs.count(), 1)
         self.assertEqual(structure.rigs.get(slot_index=2).rig_type_id, 43879)
 

--- a/indy_hub/tests/test_industry_structure_sync_service.py
+++ b/indy_hub/tests/test_industry_structure_sync_service.py
@@ -116,3 +116,64 @@ class IndustryStructureSyncServiceTests(TestCase):
         self.assertFalse(structure.enable_biochemical_reactions)
         self.assertFalse(structure.enable_hybrid_reactions)
         self.assertTrue(structure.enable_composite_reactions)
+
+    @patch(
+        "indy_hub.services.industry_structure_sync.resolve_solar_system_location_reference"
+    )
+    @patch("indy_hub.services.industry_structure_sync.resolve_solar_system_reference")
+    @patch("indy_hub.services.industry_structure_sync.resolve_item_type_reference")
+    @patch(
+        "indy_hub.services.industry_structure_sync.shared_client.fetch_corporation_structures"
+    )
+    def test_sync_does_not_wipe_identity_when_payload_omits_solar_system(
+        self,
+        mock_fetch_corporation_structures,
+        mock_resolve_item_type_reference,
+        mock_resolve_solar_system_reference,
+        mock_resolve_solar_system_location_reference,
+    ) -> None:
+        mock_fetch_corporation_structures.return_value = [
+            {
+                "structure_id": 1020000000002,
+                "name": "Azbel ESI",
+                "type_id": 35826,
+                "solar_system_id": None,
+                "services": [
+                    {"name": "Manufacturing (Standard)", "state": "online"},
+                ],
+            }
+        ]
+        mock_resolve_item_type_reference.return_value = (35826, "Azbel")
+        mock_resolve_solar_system_reference.return_value = None
+        mock_resolve_solar_system_location_reference.return_value = None
+
+        structure = IndustryStructure.objects.create(
+            name="Azbel ESI [Acme Corp #1020000000002]",
+            structure_type_id=35826,
+            structure_type_name="Azbel",
+            solar_system_id=30000142,
+            solar_system_name="Jita",
+            constellation_id=20000020,
+            constellation_name="Kimotoro",
+            region_id=10000002,
+            region_name="The Forge",
+            system_security_band=IndustryStructure.SecurityBand.HIGHSEC,
+            external_structure_id=1020000000002,
+            owner_corporation_id=98134807,
+            owner_corporation_name="Acme Corp",
+            sync_source=IndustryStructure.SyncSource.ESI_CORPORATION,
+            visibility_scope=IndustryStructure.VisibilityScope.PUBLIC,
+            enable_manufacturing=True,
+        )
+
+        summary = sync_corporation_structure_targets(
+            [{"id": 98134807, "name": "Acme Corp", "character_id": 2112625428}],
+            force_refresh=True,
+        )
+
+        self.assertEqual(summary["errors"], [])
+        structure.refresh_from_db()
+        self.assertEqual(structure.solar_system_id, 30000142)
+        self.assertEqual(structure.solar_system_name, "Jita")
+        self.assertEqual(structure.constellation_id, 20000020)
+        self.assertEqual(structure.region_id, 10000002)

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -7610,8 +7610,17 @@ def _build_structure_rig_formset(
     )
 
 
-def _set_structure_form_read_only(structure_form) -> None:
-    for field in structure_form.fields.values():
+def _set_structure_form_read_only(
+    structure_form,
+    *,
+    editable_field_names: set[str] | None = None,
+) -> None:
+    editable_fields = editable_field_names or set()
+    for field_name, field in structure_form.fields.items():
+        if field_name in editable_fields:
+            field.disabled = False
+            field.widget.attrs.pop("disabled", None)
+            continue
         field.disabled = True
         field.widget.attrs["disabled"] = "disabled"
 
@@ -7746,7 +7755,7 @@ def _build_structure_edit_page_context(request, structure, structure_form, rig_f
             ),
             "page_subtitle": (
                 _(
-                    "Automatically synchronized structures keep their identity, activities and taxes locked. Only installed rigs can be edited here."
+                    "Automatically synchronized structures keep identity and activities locked. Taxes and installed rigs can be edited here."
                 )
                 if is_synced_structure_locked
                 else _(
@@ -7949,6 +7958,9 @@ def industry_structure_edit(request, structure_id):
         )
 
     is_synced_structure_locked = structure.is_synced_structure()
+    synced_editable_tax_fields = {
+        field_name for field_name, _label in IndustryStructure.TAX_FIELD_LABELS
+    }
     emit_view_analytics_event(
         view_name="industry.structure_edit",
         request=request,
@@ -7959,19 +7971,21 @@ def industry_structure_edit(request, structure_id):
             structure=structure, data=request.POST
         )
         if is_synced_structure_locked:
-            structure_form = IndustryStructureRegistryForm(instance=structure)
-            _set_structure_form_read_only(structure_form)
+            structure_form = IndustryStructureRegistryForm(
+                request.POST, instance=structure
+            )
+            _set_structure_form_read_only(
+                structure_form,
+                editable_field_names=synced_editable_tax_fields,
+            )
         else:
             structure_form = IndustryStructureRegistryForm(
                 request.POST, instance=structure
             )
 
-        if rig_formset.is_valid() and (
-            is_synced_structure_locked or structure_form.is_valid()
-        ):
-            if not is_synced_structure_locked:
-                structure = structure_form.save(commit=False)
-                structure.save()
+        if rig_formset.is_valid() and structure_form.is_valid():
+            structure = structure_form.save(commit=False)
+            structure.save()
             saved_rig_count = _save_structure_rigs(structure, rig_formset)
             messages.success(
                 request,
@@ -7990,7 +8004,10 @@ def industry_structure_edit(request, structure_id):
     else:
         structure_form = IndustryStructureRegistryForm(instance=structure)
         if is_synced_structure_locked:
-            _set_structure_form_read_only(structure_form)
+            _set_structure_form_read_only(
+                structure_form,
+                editable_field_names=synced_editable_tax_fields,
+            )
         rig_formset = _build_structure_rig_formset(structure=structure)
 
     context = _build_structure_edit_page_context(

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -8013,7 +8013,9 @@ def industry_structure_edit(request, structure_id):
             if editable_fields_data:
                 for field_name, value in editable_fields_data.items():
                     setattr(structure, field_name, value)
-                structure.save(update_fields=list(editable_fields_data.keys()))
+                structure.save(
+                    update_fields=[*editable_fields_data.keys(), "updated_at"]
+                )
                 saved_rig_count = _save_structure_rigs(structure, rig_formset)
                 messages.success(
                     request,

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -8003,11 +8003,7 @@ def industry_structure_edit(request, structure_id):
 
         # For synced structures, allow partial save: persist editable fields (taxes) + rigs
         # even if non-editable identity fields fail validation (e.g., ESI lookup failed).
-        if (
-            is_synced_structure_locked
-            and rig_formset.is_valid()
-            and not form_is_valid
-        ):
+        if is_synced_structure_locked and rig_formset.is_valid() and not form_is_valid:
             # Try to save only the editable tax fields and rigs, skipping identity validation
             editable_fields_data = {
                 field_name: structure_form.cleaned_data.get(field_name)
@@ -8017,9 +8013,7 @@ def industry_structure_edit(request, structure_id):
             if editable_fields_data:
                 for field_name, value in editable_fields_data.items():
                     setattr(structure, field_name, value)
-                structure.save(
-                    update_fields=list(editable_fields_data.keys())
-                )
+                structure.save(update_fields=list(editable_fields_data.keys()))
                 saved_rig_count = _save_structure_rigs(structure, rig_formset)
                 messages.success(
                     request,

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -7983,7 +7983,8 @@ def industry_structure_edit(request, structure_id):
                 request.POST, instance=structure
             )
 
-        if rig_formset.is_valid() and structure_form.is_valid():
+        form_is_valid = structure_form.is_valid()
+        if rig_formset.is_valid() and form_is_valid:
             structure = structure_form.save(commit=False)
             structure.save()
             saved_rig_count = _save_structure_rigs(structure, rig_formset)
@@ -7999,6 +8000,36 @@ def industry_structure_edit(request, structure_id):
                 % {"count": saved_rig_count},
             )
             return redirect("indy_hub:industry_structure_registry")
+
+        # For synced structures, allow partial save: persist editable fields (taxes) + rigs
+        # even if non-editable identity fields fail validation (e.g., ESI lookup failed).
+        if (
+            is_synced_structure_locked
+            and rig_formset.is_valid()
+            and not form_is_valid
+        ):
+            # Try to save only the editable tax fields and rigs, skipping identity validation
+            editable_fields_data = {
+                field_name: structure_form.cleaned_data.get(field_name)
+                for field_name in synced_editable_tax_fields
+                if field_name in structure_form.cleaned_data
+            }
+            if editable_fields_data:
+                for field_name, value in editable_fields_data.items():
+                    setattr(structure, field_name, value)
+                structure.save(
+                    update_fields=list(editable_fields_data.keys())
+                )
+                saved_rig_count = _save_structure_rigs(structure, rig_formset)
+                messages.success(
+                    request,
+                    _(
+                        "Taxes and rigs updated successfully. Rigs saved: %(count)s. "
+                        "(Identity fields could not be updated due to ESI lookup issues.)"
+                    )
+                    % {"count": saved_rig_count},
+                )
+                return redirect("indy_hub:industry_structure_registry")
 
         _emit_structure_form_errors(request, structure_form, rig_formset)
     else:

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -7983,8 +7983,9 @@ def industry_structure_edit(request, structure_id):
                 request.POST, instance=structure
             )
 
+        rig_formset_is_valid = rig_formset.is_valid()
         form_is_valid = structure_form.is_valid()
-        if rig_formset.is_valid() and form_is_valid:
+        if rig_formset_is_valid and form_is_valid:
             structure = structure_form.save(commit=False)
             structure.save()
             saved_rig_count = _save_structure_rigs(structure, rig_formset)
@@ -8003,7 +8004,7 @@ def industry_structure_edit(request, structure_id):
 
         # For synced structures, allow partial save: persist editable fields (taxes) + rigs
         # even if non-editable identity fields fail validation (e.g., ESI lookup failed).
-        if is_synced_structure_locked and rig_formset.is_valid() and not form_is_valid:
+        if is_synced_structure_locked and rig_formset_is_valid and not form_is_valid:
             # Try to save only the editable tax fields and rigs, skipping identity validation
             editable_fields_data = {
                 field_name: structure_form.cleaned_data.get(field_name)
@@ -8011,6 +8012,15 @@ def industry_structure_edit(request, structure_id):
                 if field_name in structure_form.cleaned_data
             }
             if editable_fields_data:
+                # Form clean may exit early when identity lookups fail; normalize
+                # any missing tax values before persisting to non-null DecimalFields.
+                for field_name in synced_editable_tax_fields:
+                    if not field_name.endswith("_tax_percent"):
+                        continue
+                    value = editable_fields_data.get(field_name)
+                    if value in (None, ""):
+                        editable_fields_data[field_name] = Decimal("0")
+
                 for field_name, value in editable_fields_data.items():
                     setattr(structure, field_name, value)
                 structure.save(


### PR DESCRIPTION
## Summary

This PR fixes two reported issues and adds related hardening/UX improvements across the ESI scheduling and industry structure registry.

Closes #127
Closes #137

---

## Issue #127 — MySQL duplicate-key races in sync tasks

**Problem:** `update_user_skill_snapshots` intermittently raised `IntegrityError 1062` under concurrent execution, causing task failures with no retry.

**Fix:**
- Extended `_update_or_create_with_deadlock_retry` to catch MySQL error 1062 in addition to deadlocks.
- On collision, re-reads the existing row and applies the update inside a transaction with bounded jittered backoff.
- Existing deadlock retry behaviour unchanged.

---

## Issue #137 — Auto-synced structures stuck on "Setup needed" + identity overwritten

**Problem:** Corporation structures discovered via ESI director token remained stuck on `Setup needed` (showing `Identity`, `Rigs`, `Taxes` badges) with no path to resolve them. Manual admin edits to Identity fields were silently overwritten by the next sync cycle.

**Fixes:**
- **Identity overwrite:** Sync service now uses `_merge_synced_identity_value` — blank/null ESI values never overwrite existing populated identity fields.
- **Taxes editable on auto-sync structures:** Previously taxes were locked read-only on synced entries (and excluded from the completeness check), leaving them stuck. Taxes are now fully editable via the edit page while identity and activity flags remain ESI-controlled.
- **UI copy updated:** The edit page for synced structures now clearly states that identity/activities are controlled by ESI sync, while taxes and rigs can be adjusted locally.
- **Completeness check restored:** Synced structures are now subject to the same tax non-zero requirement as manual structures, since taxes are editable.

---

## Additional hardening (ESI scheduling / throttle)

- Throttle and stagger ESI task scheduling to respect rate limits.
- Hardened bulk lock ownership checks across the batch lifecycle (dynamic TTL, lock-loss abort).
- Fixed bulk scheduling counter: distinct users vs character task counts reported separately.
- Conservative throttle fallback: fail-closed with warning + `ESIRateLimitError` on cache `incr` failures.

---

## Structure sync schedule

- Reduced `indy-hub-sync-persisted-structures` from **hourly** to **once per day at 06:35** (+ AllianceAuth offset). Structures change at most once per day (rename, unanchor).
- Migration `0106` re-applies the updated schedule on existing installations via `manage.py migrate`.

---

## Tests

- 412 tests, all passing (skipped 2), py310 + py312.
- New regression tests for:
  - Synced structure completeness reporting missing taxes when all-zero.
  - Synced structure edit saving taxes and rigs while preserving identity/activity fields.
  - Lock ownership and TTL race scenarios.
  - MySQL duplicate-key retry helper.
