### PR TITLE
Optimize Indy Hub render path: force-refresh ESI and cache structure bonus resolution

### DIFF
--- a/indy_hub/migrations/0107_industrystructure_resolved_bonus_cache.py
+++ b/indy_hub/migrations/0107_industrystructure_resolved_bonus_cache.py
@@ -1,3 +1,4 @@
+# Django
 from django.db import migrations, models
 
 

--- a/indy_hub/migrations/0107_industrystructure_resolved_bonus_cache.py
+++ b/indy_hub/migrations/0107_industrystructure_resolved_bonus_cache.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("indy_hub", "0106_update_periodic_tasks"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="industrystructure",
+            name="resolved_bonuses_cache",
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name="industrystructure",
+            name="resolved_bonuses_cache_signature",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name="industrystructure",
+            name="resolved_bonuses_cache_updated_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/indy_hub/models.py
+++ b/indy_hub/models.py
@@ -3011,6 +3011,9 @@ class IndustryStructure(models.Model):
             MaxValueValidator(Decimal("100")),
         ],
     )
+    resolved_bonuses_cache = models.JSONField(default=list, blank=True)
+    resolved_bonuses_cache_signature = models.CharField(max_length=255, blank=True)
+    resolved_bonuses_cache_updated_at = models.DateTimeField(blank=True, null=True)
     last_synced_at = models.DateTimeField(blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -3198,9 +3201,111 @@ class IndustryStructure(models.Model):
 
     def get_resolved_bonuses(self):
         # AA Example App
-        from indy_hub.services.industry_structures import resolve_structure_bonuses
+        from indy_hub.services.industry_structures import (
+            IndustryStructureResolvedBonus,
+            resolve_structure_bonuses,
+        )
 
-        return resolve_structure_bonuses(self)
+        def _serialize_bonus_rows(
+            rows: list[IndustryStructureResolvedBonus],
+        ) -> list[dict[str, object]]:
+            payload: list[dict[str, object]] = []
+            for row in rows:
+                payload.append(
+                    {
+                        "source": row.source,
+                        "label": row.label,
+                        "activity_id": int(row.activity_id),
+                        "supported_types_label": row.supported_types_label,
+                        "supported_type_names": list(row.supported_type_names or ()),
+                        "material_efficiency_percent": str(
+                            row.material_efficiency_percent or Decimal("0")
+                        ),
+                        "time_efficiency_percent": str(
+                            row.time_efficiency_percent or Decimal("0")
+                        ),
+                        "job_cost_percent": str(row.job_cost_percent or Decimal("0")),
+                    }
+                )
+            return payload
+
+        def _deserialize_bonus_rows(
+            payload: object,
+        ) -> list[IndustryStructureResolvedBonus] | None:
+            if not isinstance(payload, list):
+                return None
+            rows: list[IndustryStructureResolvedBonus] = []
+            try:
+                for item in payload:
+                    if not isinstance(item, dict):
+                        return None
+                    rows.append(
+                        IndustryStructureResolvedBonus(
+                            source=str(item.get("source") or ""),
+                            label=str(item.get("label") or ""),
+                            activity_id=int(item.get("activity_id") or 0),
+                            supported_types_label=str(
+                                item.get("supported_types_label") or ""
+                            ),
+                            supported_type_names=tuple(
+                                str(name)
+                                for name in (item.get("supported_type_names") or [])
+                                if name
+                            ),
+                            material_efficiency_percent=Decimal(
+                                str(item.get("material_efficiency_percent") or "0")
+                            ),
+                            time_efficiency_percent=Decimal(
+                                str(item.get("time_efficiency_percent") or "0")
+                            ),
+                            job_cost_percent=Decimal(
+                                str(item.get("job_cost_percent") or "0")
+                            ),
+                        )
+                    )
+            except Exception:
+                return None
+            return rows
+
+        rig_rows = list(self.rigs.all())
+        rig_rows.sort(
+            key=lambda rig: (
+                int(getattr(rig, "slot_index", 0) or 0),
+                int(getattr(rig, "rig_type_id", 0) or 0),
+            )
+        )
+        signature = "|".join(
+            [
+                str(int(self.structure_type_id or 0)),
+                str(self.system_security_band or ""),
+                ",".join(
+                    f"{int(getattr(rig, 'slot_index', 0) or 0)}:{int(getattr(rig, 'rig_type_id', 0) or 0)}"
+                    for rig in rig_rows
+                ),
+            ]
+        )
+
+        cached_rows = _deserialize_bonus_rows(self.resolved_bonuses_cache)
+        if (
+            signature
+            and self.resolved_bonuses_cache_signature == signature
+            and cached_rows is not None
+        ):
+            return cached_rows
+
+        resolved_rows = resolve_structure_bonuses(self)
+        serialized_rows = _serialize_bonus_rows(resolved_rows)
+        cache_updated_at = timezone.now()
+        self.resolved_bonuses_cache = serialized_rows
+        self.resolved_bonuses_cache_signature = signature
+        self.resolved_bonuses_cache_updated_at = cache_updated_at
+        if self.pk:
+            IndustryStructure.objects.filter(pk=self.pk).update(
+                resolved_bonuses_cache=serialized_rows,
+                resolved_bonuses_cache_signature=signature,
+                resolved_bonuses_cache_updated_at=cache_updated_at,
+            )
+        return resolved_rows
 
     def get_bonus_multiplier(self, activity_id: int, bonus_field: str) -> Decimal:
         multiplier = Decimal("1")
@@ -3437,6 +3542,33 @@ class IndustryStructure(models.Model):
             raise ValidationError(validation_errors)
 
     def save(self, *args, **kwargs):
+        update_fields = kwargs.get("update_fields")
+        invalidate_bonus_cache = not bool(self.pk)
+        if self.pk:
+            watched_fields = {"structure_type_id", "system_security_band"}
+            if update_fields is None or watched_fields.intersection(set(update_fields)):
+                previous = (
+                    IndustryStructure.objects.filter(pk=self.pk)
+                    .values("structure_type_id", "system_security_band")
+                    .first()
+                )
+                if previous is not None and (
+                    previous.get("structure_type_id") != self.structure_type_id
+                    or previous.get("system_security_band") != self.system_security_band
+                ):
+                    invalidate_bonus_cache = True
+
+        if invalidate_bonus_cache:
+            self.resolved_bonuses_cache = []
+            self.resolved_bonuses_cache_signature = ""
+            self.resolved_bonuses_cache_updated_at = None
+            if update_fields is not None:
+                kwargs["update_fields"] = set(update_fields) | {
+                    "resolved_bonuses_cache",
+                    "resolved_bonuses_cache_signature",
+                    "resolved_bonuses_cache_updated_at",
+                }
+
         if not kwargs.get("raw", False):
             self.full_clean()
         super().save(*args, **kwargs)
@@ -3470,3 +3602,26 @@ class IndustryStructureRig(models.Model):
     def __str__(self) -> str:
         label = self.rig_type_name or self.rig_type_id
         return f"{self.structure.name} - Slot {self.slot_index}: {label}"
+
+    def _invalidate_structure_bonus_cache(self) -> None:
+        if not self.structure_id:
+            return
+        IndustryStructure.objects.filter(pk=self.structure_id).update(
+            resolved_bonuses_cache=[],
+            resolved_bonuses_cache_signature="",
+            resolved_bonuses_cache_updated_at=None,
+        )
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self._invalidate_structure_bonus_cache()
+
+    def delete(self, *args, **kwargs):
+        structure_id = self.structure_id
+        super().delete(*args, **kwargs)
+        if structure_id:
+            IndustryStructure.objects.filter(pk=structure_id).update(
+                resolved_bonuses_cache=[],
+                resolved_bonuses_cache_signature="",
+                resolved_bonuses_cache_updated_at=None,
+            )

--- a/indy_hub/models.py
+++ b/indy_hub/models.py
@@ -3613,7 +3613,38 @@ class IndustryStructureRig(models.Model):
         )
 
     def save(self, *args, **kwargs):
+        update_fields = kwargs.get("update_fields")
+        invalidate_bonus_cache = not bool(self.pk)
+        previous_structure_id = None
+
+        if self.pk:
+            watched_fields = {"structure_id", "slot_index", "rig_type_id"}
+            if update_fields is None or watched_fields.intersection(set(update_fields)):
+                previous = (
+                    IndustryStructureRig.objects.filter(pk=self.pk)
+                    .values("structure_id", "slot_index", "rig_type_id")
+                    .first()
+                )
+                if previous is not None:
+                    previous_structure_id = previous.get("structure_id")
+                    if (
+                        previous.get("structure_id") != self.structure_id
+                        or previous.get("slot_index") != self.slot_index
+                        or previous.get("rig_type_id") != self.rig_type_id
+                    ):
+                        invalidate_bonus_cache = True
+
         super().save(*args, **kwargs)
+        if not invalidate_bonus_cache:
+            return
+
+        if previous_structure_id and previous_structure_id != self.structure_id:
+            IndustryStructure.objects.filter(pk=previous_structure_id).update(
+                resolved_bonuses_cache=[],
+                resolved_bonuses_cache_signature="",
+                resolved_bonuses_cache_updated_at=None,
+            )
+
         self._invalidate_structure_bonus_cache()
 
     def delete(self, *args, **kwargs):

--- a/indy_hub/services/industry_skills.py
+++ b/indy_hub/services/industry_skills.py
@@ -207,6 +207,8 @@ def build_user_character_skill_contexts(
     fetch_character_skill_levels=None,
     update_skill_snapshot=None,
     skill_cache_ttl,
+    allow_live_fetch: bool = True,
+    force_refresh: bool = False,
 ) -> list[dict[str, object]]:
     ownerships = CharacterOwnership.objects.filter(user=user).select_related(
         "character"
@@ -282,9 +284,14 @@ def build_user_character_skill_contexts(
         has_skill_token = character_id in skill_token_ids
         skills_missing = not has_skill_token
 
-        if has_skill_token and fetch_character_skill_levels and update_skill_snapshot:
+        if (
+            has_skill_token
+            and fetch_character_skill_levels
+            and update_skill_snapshot
+            and allow_live_fetch
+        ):
             try:
-                if snapshot is None:
+                if force_refresh or snapshot is None:
                     levels = fetch_character_skill_levels(
                         character_id, force_refresh=True
                     )

--- a/indy_hub/services/industry_structures.py
+++ b/indy_hub/services/industry_structures.py
@@ -1522,7 +1522,9 @@ def resolve_structure_bonuses(
         structure.structure_type_id,
         structure_type_name=structure.structure_type_name,
     )
-    for rig in structure.rigs.all().order_by("slot_index"):
+    rig_rows = list(structure.rigs.all())
+    rig_rows.sort(key=lambda rig: int(getattr(rig, "slot_index", 0) or 0))
+    for rig in rig_rows:
         bonuses.extend(
             resolve_rig_type_bonuses(
                 rig.rig_type_id,

--- a/indy_hub/static/indy_hub/js/personal_job_list.js
+++ b/indy_hub/static/indy_hub/js/personal_job_list.js
@@ -13,6 +13,7 @@ function refreshJobs() {
 
     const url = new URL(window.location.href);
     url.searchParams.set('refresh', '1');
+    url.searchParams.set('force_refresh', '1');
     window.location.href = url.toString();
 }
 

--- a/indy_hub/tasks/industry.py
+++ b/indy_hub/tasks/industry.py
@@ -914,7 +914,7 @@ def _queue_staggered_industry_job_corporation_tasks(
         for user_id in user_ids:
             update_industry_jobs_for_user.apply_async(
                 args=(int(user_id),),
-                kwargs={"scope": "corporation"},
+                kwargs={"scope": "corporation", "character_id": 0},
                 priority=priority,
             )
         return total
@@ -924,7 +924,7 @@ def _queue_staggered_industry_job_corporation_tasks(
         countdown = int(round(index * spacing))
         update_industry_jobs_for_user.apply_async(
             args=(int(user_id),),
-            kwargs={"scope": "corporation"},
+            kwargs={"scope": "corporation", "character_id": 0},
             countdown=countdown,
             priority=priority,
         )
@@ -1202,8 +1202,9 @@ def queue_industry_job_update_for_user(
     countdown: int = 0,
     priority: int | None = None,
     scope: str | None = None,
+    character_id: int | None = None,
 ) -> None:
-    kwargs = {}
+    kwargs = {"character_id": int(character_id) if character_id else 0}
     if scope:
         kwargs["scope"] = scope
     update_industry_jobs_for_user.apply_async(

--- a/indy_hub/templates/indy_hub/industry/Personnal_Job_list.html
+++ b/indy_hub/templates/indy_hub/industry/Personnal_Job_list.html
@@ -21,13 +21,20 @@
                     {{ scope_title }}
                 </h2>
                 <p class="description">{{ scope_description }}</p>
+                <p class="description small mb-0 mt-2">
+                    {% if last_data_refresh_at %}
+                        {% blocktrans with last_refresh=last_data_refresh_at|date:"Y-m-d H:i" %}Last update: {{ last_refresh }}{% endblocktrans %}
+                    {% else %}
+                        {% trans "Last update: not available yet" %}
+                    {% endif %}
+                </p>
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2">
                 <a href="{{ back_to_overview_url }}" class="btn btn-outline-light">
                     <i class="fas fa-arrow-left me-1"></i>{% trans "Back to Overview" %}
                 </a>
                 <button type="button" class="btn btn-light text-primary" data-refresh-jobs onclick="refreshJobs()">
-                    <i class="fas fa-sync-alt me-1"></i>{% trans "Refresh Data" %}
+                    <i class="fas fa-sync-alt me-1"></i>{% trans "Force Refresh" %}
                 </button>
             </div>
         </div>

--- a/indy_hub/views/hubs.py
+++ b/indy_hub/views/hubs.py
@@ -12,14 +12,13 @@ from allianceauth.services.hooks import get_extension_logger
 
 # Local
 from ..decorators import indy_hub_permission_required
-from ..models import MaterialExchangeConfig, MaterialExchangeSettings
 from ..services.corporation_blueprint_visibility import (
     can_view_corporation_blueprints,
     can_view_corporation_jobs,
 )
 from ..utils.analytics import emit_view_analytics_event
 from .navigation import build_nav_context
-from .user import _build_dashboard_context
+from .user import _build_settings_hub_context
 
 logger = get_extension_logger(__name__)
 
@@ -40,7 +39,7 @@ def settings_hub(request):
         can_manage_material_hub,
     )
 
-    context = _build_dashboard_context(request)
+    context = _build_settings_hub_context(request)
     context.update(
         {
             "can_manage_material_hub": can_manage_material_hub,
@@ -48,18 +47,6 @@ def settings_hub(request):
             "can_view_corporation_blueprints": can_view_corporation_bp,
             "can_view_corporation_jobs": can_view_corporation_jobs_flag,
         }
-    )
-
-    # Material Exchange counters
-    context["material_exchange_config_total"] = MaterialExchangeConfig.objects.count()
-    context["material_exchange_enabled"] = (
-        MaterialExchangeSettings.get_solo().is_enabled
-    )
-    context["material_exchange_config_active"] = (
-        1
-        if context["material_exchange_enabled"]
-        and context["material_exchange_config_total"]
-        else 0
     )
 
     logger.debug(

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -2728,7 +2728,7 @@ def personnal_job_list(request, scope="character"):
             .aggregate(last_updated=Max("last_updated"))
             .get("last_updated")
         )
-        latest_jobs_refresh_at = jobs_qs.aggregate(
+        latest_jobs_refresh_at = base_jobs_qs.aggregate(
             last_updated=Max("last_updated")
         ).get("last_updated")
         last_data_refresh_at = latest_skill_snapshot_at or latest_jobs_refresh_at

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -21,7 +21,7 @@ from django.core.cache import cache
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.core.paginator import Paginator
 from django.db import connection
-from django.db.models import Case, Count, Prefetch, Q, When
+from django.db.models import Case, Count, Max, Prefetch, Q, When
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -335,12 +335,19 @@ def _skill_snapshot_stale(snapshot: IndustrySkillSnapshot | None) -> bool:
     return skill_snapshot_stale(snapshot, SKILL_CACHE_TTL)
 
 
-def _build_slot_overview_rows(user: User) -> list[dict[str, object]]:
+def _build_slot_overview_rows(
+    user: User,
+    *,
+    allow_live_fetch: bool = False,
+    force_refresh: bool = False,
+) -> list[dict[str, object]]:
     return build_user_character_skill_contexts(
         user,
         fetch_character_skill_levels=_fetch_character_skill_levels,
         update_skill_snapshot=_update_skill_snapshot,
         skill_cache_ttl=SKILL_CACHE_TTL,
+        allow_live_fetch=allow_live_fetch,
+        force_refresh=force_refresh,
     )
 
 
@@ -2290,6 +2297,7 @@ def personnal_job_list(request, scope="character"):
         )
     try:
         force_update = request.GET.get("refresh") == "1"
+        force_skill_refresh = request.GET.get("force_refresh") == "1" or force_update
         if force_update:
             logger.info(
                 f"User {request.user.username} requested jobs refresh; enqueuing Celery task"
@@ -2710,7 +2718,22 @@ def personnal_job_list(request, scope="character"):
             if grouped_jobs.get(meta["key"])
         ]
 
-        slot_overview_rows = _build_slot_overview_rows(request.user)
+        slot_overview_rows = _build_slot_overview_rows(
+            request.user,
+            allow_live_fetch=force_skill_refresh,
+            force_refresh=force_skill_refresh,
+        )
+        latest_skill_snapshot_at = (
+            IndustrySkillSnapshot.objects.filter(owner_user=request.user)
+            .aggregate(last_updated=Max("last_updated"))
+            .get("last_updated")
+        )
+        latest_jobs_refresh_at = jobs_qs.aggregate(
+            last_updated=Max("last_updated")
+        ).get("last_updated")
+        last_data_refresh_at = latest_skill_snapshot_at or latest_jobs_refresh_at
+        if latest_skill_snapshot_at and latest_jobs_refresh_at:
+            last_data_refresh_at = max(latest_skill_snapshot_at, latest_jobs_refresh_at)
         context = {
             "jobs": jobs_page,
             "statistics": statistics,
@@ -2752,6 +2775,7 @@ def personnal_job_list(request, scope="character"):
             "slot_overview_rows": slot_overview_rows,
             "slot_overview_summary": _build_slot_overview_summary(slot_overview_rows),
             "skills_scope": SKILLS_SCOPE,
+            "last_data_refresh_at": last_data_refresh_at,
         }
         context.update(
             build_nav_context(

--- a/indy_hub/views/user.py
+++ b/indy_hub/views/user.py
@@ -47,7 +47,12 @@ from esi.views import sso_redirect
 from eve_sde.models import EveSDE
 
 # AA Example App
-from indy_hub.models import CharacterSettings, CorporationSharingSetting
+from indy_hub.models import (
+    CharacterSettings,
+    CorporationSharingSetting,
+    MaterialExchangeConfig,
+    MaterialExchangeSettings,
+)
 
 from ..app_settings import ROLE_SNAPSHOT_STALE_HOURS
 from ..decorators import indy_hub_access_required, tokens_required
@@ -499,6 +504,7 @@ def _collect_corporation_scope_status(
     *,
     include_warnings: bool = False,
     allow_live_role_fetch: bool = True,
+    validate_tokens: bool = True,
 ) -> list[dict[str, Any]] | tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     if not user.has_perm("indy_hub.can_manage_corp_bp_requests"):
         empty: list[dict[str, Any]] = []
@@ -527,6 +533,11 @@ def _collect_corporation_scope_status(
     corp_role_state: dict[int, dict[str, bool]] = {}
     warnings: list[dict[str, Any]] = [] if include_warnings else []
 
+    def _apply_token_validity_filter(token_queryset):
+        if not validate_tokens:
+            return token_queryset
+        return token_queryset.require_valid()
+
     def _revoke_corporation_tokens(
         token_queryset,
         character_id: int,
@@ -546,9 +557,9 @@ def _collect_corporation_scope_status(
         token_ids: set[int] = set()
         for scope in normalized_scopes:
             token_ids.update(
-                token_queryset.require_scopes([scope])
-                .require_valid()
-                .values_list("pk", flat=True)
+                _apply_token_validity_filter(
+                    token_queryset.require_scopes([scope])
+                ).values_list("pk", flat=True)
             )
 
         if not token_ids:
@@ -579,7 +590,9 @@ def _collect_corporation_scope_status(
             if normalized in seen:
                 continue
             seen.add(normalized)
-            candidate = token_qs.require_scopes(scope_list).require_valid()
+            candidate = _apply_token_validity_filter(
+                token_qs.require_scopes(scope_list)
+            )
             token = candidate.order_by("-created").first()
             if token:
                 return token
@@ -628,8 +641,7 @@ def _collect_corporation_scope_status(
         blueprint_token = _select_corporation_token(token_qs, CORP_BLUEPRINT_SCOPE)
         jobs_token = _select_corporation_token(token_qs, CORP_JOBS_SCOPE)
         roles_token = (
-            token_qs.require_scopes([CORP_ROLES_SCOPE])
-            .require_valid()
+            _apply_token_validity_filter(token_qs.require_scopes([CORP_ROLES_SCOPE]))
             .order_by("-created")
             .first()
         )
@@ -798,7 +810,7 @@ def _collect_corporation_scope_status(
         present_scopes = {
             scope
             for scope in required_corporation_scopes
-            if token_qs.require_scopes([scope]).require_valid().exists()
+            if _apply_token_validity_filter(token_qs.require_scopes([scope])).exists()
         }
         if present_scopes:
             corp_available_scopes.setdefault(corp_id, set()).update(present_scopes)
@@ -873,8 +885,9 @@ def _collect_corporation_scope_status(
             }
 
         material_exchange_token = (
-            token_qs.require_scopes(MATERIAL_EXCHANGE_SCOPE_SET)
-            .require_valid()
+            _apply_token_validity_filter(
+                token_qs.require_scopes(MATERIAL_EXCHANGE_SCOPE_SET)
+            )
             .order_by("-created")
             .first()
         )
@@ -887,8 +900,9 @@ def _collect_corporation_scope_status(
             }
 
         material_exchange_token = (
-            token_qs.require_scopes(MATERIAL_EXCHANGE_SCOPE_SET)
-            .require_valid()
+            _apply_token_validity_filter(
+                token_qs.require_scopes(MATERIAL_EXCHANGE_SCOPE_SET)
+            )
             .order_by("-created")
             .first()
         )
@@ -953,6 +967,7 @@ def build_corporation_sharing_context(
     user,
     *,
     allow_live_role_fetch: bool = True,
+    validate_tokens: bool = True,
 ) -> dict[str, Any] | None:
     if not user.has_perm("indy_hub.can_manage_corp_bp_requests"):
         return None
@@ -974,6 +989,7 @@ def build_corporation_sharing_context(
     corp_scope_status = _collect_corporation_scope_status(
         user,
         allow_live_role_fetch=allow_live_role_fetch,
+        validate_tokens=validate_tokens,
     )
     settings_map = {
         setting.corporation_id: setting
@@ -1628,14 +1644,12 @@ def _build_dashboard_context(request):
             blueprint_char_ids = list(
                 Token.objects.filter(user=request.user)
                 .require_scopes(BLUEPRINT_SCOPE_SET)
-                .require_valid()
                 .values_list("character_id", flat=True)
                 .distinct()
             )
             jobs_char_ids = list(
                 Token.objects.filter(user=request.user)
                 .require_scopes(JOBS_SCOPE_SET)
-                .require_valid()
                 .values_list("character_id", flat=True)
                 .distinct()
             )
@@ -1994,6 +2008,7 @@ def _build_dashboard_context(request):
             corp_scope_status = _collect_corporation_scope_status(
                 request.user,
                 allow_live_role_fetch=False,
+                validate_tokens=False,
             )
             cache.set(corp_scope_status_cache_key, corp_scope_status, timeout=300)
     else:
@@ -2103,6 +2118,7 @@ def _build_dashboard_context(request):
         build_corporation_sharing_context(
             request.user,
             allow_live_role_fetch=False,
+            validate_tokens=False,
         )
         if can_manage_corp
         else None
@@ -2191,6 +2207,234 @@ def _build_dashboard_context(request):
         "show_corporation_tab": can_manage_corp,
     }
     return context
+
+
+def _build_settings_hub_context(request) -> dict[str, Any]:
+    """Collect only the data required by the settings hub view."""
+
+    settings_obj, _created = CharacterSettings.objects.get_or_create(
+        user=request.user, character_id=0
+    )
+
+    pending_updates: list[str] = []
+    if not settings_obj.jobs_notify_frequency:
+        default_frequency = (
+            CharacterSettings.NOTIFY_IMMEDIATE
+            if settings_obj.jobs_notify_completed
+            else CharacterSettings.NOTIFY_DISABLED
+        )
+        settings_obj.jobs_notify_frequency = default_frequency
+        pending_updates.append("jobs_notify_frequency")
+
+    if (
+        not settings_obj.jobs_notify_custom_days
+        or settings_obj.jobs_notify_custom_days < 1
+    ):
+        settings_obj.jobs_notify_custom_days = 3
+        pending_updates.append("jobs_notify_custom_days")
+
+    if (
+        not getattr(settings_obj, "jobs_notify_custom_hours", None)
+        or settings_obj.jobs_notify_custom_hours < 1
+    ):
+        settings_obj.jobs_notify_custom_hours = 6
+        pending_updates.append("jobs_notify_custom_hours")
+
+    if pending_updates:
+        settings_obj.save(update_fields=pending_updates)
+
+    jobs_notify_frequency = settings_obj.jobs_notify_frequency
+    valid_frequencies = dict(CharacterSettings.JOB_NOTIFICATION_FREQUENCY_CHOICES)
+    if jobs_notify_frequency not in valid_frequencies:
+        jobs_notify_frequency = CharacterSettings.NOTIFY_DISABLED
+        if settings_obj.jobs_notify_frequency != jobs_notify_frequency:
+            settings_obj.jobs_notify_frequency = jobs_notify_frequency
+            settings_obj.save(update_fields=["jobs_notify_frequency"])
+
+    jobs_notify_completed = jobs_notify_frequency != CharacterSettings.NOTIFY_DISABLED
+    if settings_obj.jobs_notify_completed != jobs_notify_completed:
+        settings_obj.jobs_notify_completed = jobs_notify_completed
+        settings_obj.save(update_fields=["jobs_notify_completed"])
+
+    job_notification_custom_days = max(1, settings_obj.jobs_notify_custom_days or 1)
+    if job_notification_custom_days != settings_obj.jobs_notify_custom_days:
+        settings_obj.jobs_notify_custom_days = job_notification_custom_days
+        settings_obj.save(update_fields=["jobs_notify_custom_days"])
+
+    job_notification_custom_hours = max(
+        1, getattr(settings_obj, "jobs_notify_custom_hours", 1) or 1
+    )
+    if job_notification_custom_hours != settings_obj.jobs_notify_custom_hours:
+        settings_obj.jobs_notify_custom_hours = job_notification_custom_hours
+        settings_obj.save(update_fields=["jobs_notify_custom_hours"])
+
+    job_notification_hint = _describe_job_notification_hint(
+        jobs_notify_frequency,
+        job_notification_custom_days,
+        job_notification_custom_hours,
+    )
+
+    copy_sharing_scope = settings_obj.copy_sharing_scope
+    if copy_sharing_scope not in dict(CharacterSettings.COPY_SHARING_SCOPE_CHOICES):
+        copy_sharing_scope = CharacterSettings.SCOPE_NONE
+
+    copy_sharing_states = get_copy_sharing_states()
+    copy_sharing_states_with_scope = {
+        key: {**value, "scope": key} for key, value in copy_sharing_states.items()
+    }
+    sharing_state = copy_sharing_states.get(
+        copy_sharing_scope, copy_sharing_states[CharacterSettings.SCOPE_NONE]
+    )
+
+    allow_copy_requests = sharing_state["enabled"]
+    if allow_copy_requests != settings_obj.allow_copy_requests:
+        settings_obj.allow_copy_requests = allow_copy_requests
+        settings_obj.save(update_fields=["allow_copy_requests"])
+
+    can_manage_corp = request.user.has_perm("indy_hub.can_manage_corp_bp_requests")
+    can_manage_material_hub = request.user.has_perm("indy_hub.can_manage_material_hub")
+    can_view_corporation_bp = can_view_corporation_blueprints(request.user)
+    can_view_corporation_jobs_flag = can_view_corporation_jobs(request.user)
+
+    if can_manage_corp:
+        corp_scope_status_cache_key = (
+            f"indy_hub:corp_scope_status:settings:{int(request.user.id)}"
+        )
+        corp_scope_status = cache.get(corp_scope_status_cache_key)
+        if corp_scope_status is None:
+            corp_scope_status = _collect_corporation_scope_status(
+                request.user,
+                allow_live_role_fetch=False,
+                validate_tokens=False,
+            )
+            cache.set(corp_scope_status_cache_key, corp_scope_status, timeout=300)
+    else:
+        corp_scope_status = []
+
+    corporation_share_controls, corporation_share_summary = (
+        _build_corporation_share_controls(request.user, corp_scope_status)
+    )
+
+    corp_job_notification_controls: list[dict[str, Any]] = []
+    if can_manage_corp and corporation_share_controls:
+        for corp_ctrl in corporation_share_controls:
+            corp_id = corp_ctrl["corporation_id"]
+            corp_name = corp_ctrl["corporation_name"]
+            corp_setting, _created = CorporationSharingSetting.objects.get_or_create(
+                user=request.user,
+                corporation_id=corp_id,
+                defaults={
+                    "corporation_name": corp_name,
+                    "corp_jobs_notify_frequency": CharacterSettings.NOTIFY_DISABLED,
+                    "corp_jobs_notify_custom_days": 3,
+                    "corp_jobs_notify_custom_hours": 6,
+                },
+            )
+
+            freq = (
+                corp_setting.corp_jobs_notify_frequency
+                or CharacterSettings.NOTIFY_DISABLED
+            )
+            if freq not in valid_frequencies:
+                freq = CharacterSettings.NOTIFY_DISABLED
+                if corp_setting.corp_jobs_notify_frequency != freq:
+                    corp_setting.corp_jobs_notify_frequency = freq
+                    corp_setting.save(update_fields=["corp_jobs_notify_frequency"])
+
+            custom_days = max(1, corp_setting.corp_jobs_notify_custom_days or 1)
+            if custom_days != corp_setting.corp_jobs_notify_custom_days:
+                corp_setting.corp_jobs_notify_custom_days = custom_days
+                corp_setting.save(update_fields=["corp_jobs_notify_custom_days"])
+
+            custom_hours = max(1, corp_setting.corp_jobs_notify_custom_hours or 1)
+            if custom_hours != corp_setting.corp_jobs_notify_custom_hours:
+                corp_setting.corp_jobs_notify_custom_hours = custom_hours
+                corp_setting.save(update_fields=["corp_jobs_notify_custom_hours"])
+
+            hint = _describe_job_notification_hint(freq, custom_days, custom_hours)
+            corp_job_notification_controls.append(
+                {
+                    "corporation_id": corp_id,
+                    "corporation_name": corp_name,
+                    "frequency": freq,
+                    "custom_days": custom_days,
+                    "custom_hours": custom_hours,
+                    "hint": hint,
+                }
+            )
+
+    corporation_settings_controls: list[dict[str, object]] = []
+    if can_manage_corp and corporation_share_controls:
+        job_by_corp_id = {
+            int(entry.get("corporation_id")): entry
+            for entry in corp_job_notification_controls
+            if isinstance(entry, dict) and entry.get("corporation_id") is not None
+        }
+        for corp_ctrl in corporation_share_controls:
+            corp_id = int(corp_ctrl["corporation_id"])
+            job_ctrl = job_by_corp_id.get(corp_id, {})
+            corporation_settings_controls.append(
+                {
+                    "corporation_id": corp_id,
+                    "corporation_name": corp_ctrl.get("corporation_name"),
+                    "has_blueprint_scope": corp_ctrl.get("has_blueprint_scope"),
+                    "share_scope": corp_ctrl.get("share_scope"),
+                    "blueprint_catalog_scope": corp_ctrl.get("blueprint_catalog_scope"),
+                    "job_catalog_scope": corp_ctrl.get("job_catalog_scope"),
+                    "status_label": corp_ctrl.get("status_label"),
+                    "status_hint": corp_ctrl.get("status_hint"),
+                    "badge_class": corp_ctrl.get("badge_class"),
+                    "catalog_status_label": corp_ctrl.get("catalog_status_label"),
+                    "catalog_status_hint": corp_ctrl.get("catalog_status_hint"),
+                    "catalog_badge_class": corp_ctrl.get("catalog_badge_class"),
+                    "job_catalog_status_label": corp_ctrl.get(
+                        "job_catalog_status_label"
+                    ),
+                    "job_catalog_status_hint": corp_ctrl.get("job_catalog_status_hint"),
+                    "job_catalog_badge_class": corp_ctrl.get("job_catalog_badge_class"),
+                    "jobs_frequency": job_ctrl.get(
+                        "frequency", CharacterSettings.NOTIFY_DISABLED
+                    ),
+                    "jobs_custom_days": job_ctrl.get("custom_days", 3),
+                    "jobs_custom_hours": job_ctrl.get("custom_hours", 6),
+                    "jobs_hint": job_ctrl.get("hint", ""),
+                }
+            )
+
+    material_exchange_config_total = MaterialExchangeConfig.objects.count()
+    material_exchange_enabled = MaterialExchangeSettings.get_solo().is_enabled
+    material_exchange_config_active = (
+        1 if material_exchange_enabled and material_exchange_config_total else 0
+    )
+
+    return {
+        "job_notification_frequency": jobs_notify_frequency,
+        "job_notification_custom_days": job_notification_custom_days,
+        "job_notification_custom_hours": job_notification_custom_hours,
+        "job_notification_hint": job_notification_hint,
+        "copy_sharing_scope": copy_sharing_scope,
+        "copy_sharing_state": sharing_state,
+        "copy_sharing_states": copy_sharing_states_with_scope,
+        "copy_sharing_states_json": json.dumps(copy_sharing_states_with_scope),
+        "blueprint_catalog_states_json": json.dumps(get_blueprint_catalog_states()),
+        "job_catalog_states_json": json.dumps(get_job_catalog_states()),
+        "can_manage_corp_bp_requests": can_manage_corp,
+        "can_manage_material_hub": can_manage_material_hub,
+        "can_view_corporation_blueprints": can_view_corporation_bp,
+        "can_view_corporation_jobs": can_view_corporation_jobs_flag,
+        "corporation_share_controls": corporation_share_controls,
+        "corporation_share_controls_json": json.dumps(corporation_share_controls),
+        "corporation_share_summary": corporation_share_summary,
+        "corp_job_notification_controls": corp_job_notification_controls,
+        "corp_job_notification_controls_json": json.dumps(
+            corp_job_notification_controls
+        ),
+        "corporation_settings_controls": corporation_settings_controls,
+        "corporation_settings_controls_json": json.dumps(corporation_settings_controls),
+        "material_exchange_enabled": material_exchange_enabled,
+        "material_exchange_config_total": material_exchange_config_total,
+        "material_exchange_config_active": material_exchange_config_active,
+    }
 
 
 def _is_base_eve_sde_loaded() -> bool:
@@ -2417,6 +2661,7 @@ def token_management(request):
                 request.user,
                 include_warnings=True,
                 allow_live_role_fetch=False,
+                validate_tokens=False,
             )
             corp_scope_status = [
                 status
@@ -2429,6 +2674,7 @@ def token_management(request):
             corporation_sharing = build_corporation_sharing_context(
                 request.user,
                 allow_live_role_fetch=False,
+                validate_tokens=False,
             )
             token_management_live_hash = _token_management_payload_hash(
                 corporations=corp_scope_status,
@@ -2442,20 +2688,14 @@ def token_management(request):
         corporation_sharing = None
     if Token:
         try:
-            blueprint_tokens = (
-                Token.objects.filter(user=request.user)
-                .require_scopes(BLUEPRINT_SCOPE_SET)
-                .require_valid()
+            blueprint_tokens = Token.objects.filter(user=request.user).require_scopes(
+                BLUEPRINT_SCOPE_SET
             )
-            jobs_tokens = (
-                Token.objects.filter(user=request.user)
-                .require_scopes(JOBS_SCOPE_SET)
-                .require_valid()
+            jobs_tokens = Token.objects.filter(user=request.user).require_scopes(
+                JOBS_SCOPE_SET
             )
-            assets_tokens = (
-                Token.objects.filter(user=request.user)
-                .require_scopes(ASSETS_SCOPE_SET)
-                .require_valid()
+            assets_tokens = Token.objects.filter(user=request.user).require_scopes(
+                ASSETS_SCOPE_SET
             )
             # Deduplicate by character_id
             blueprint_char_ids = (
@@ -2539,9 +2779,7 @@ def token_management(request):
 
         missing_scopes: list[str] = []
         if Token:
-            char_tokens = Token.objects.filter(
-                user=request.user, character_id=cid
-            ).require_valid()
+            char_tokens = Token.objects.filter(user=request.user, character_id=cid)
             for scope in character_required_scopes:
                 if not char_tokens.require_scopes([scope]).exists():
                     missing_scopes.append(scope)

--- a/indy_hub/views/user.py
+++ b/indy_hub/views/user.py
@@ -38,6 +38,7 @@ from django.views.decorators.http import require_POST
 from allianceauth.authentication.models import CharacterOwnership
 from allianceauth.eveonline.models import EveCharacter
 from allianceauth.services.hooks import get_extension_logger
+from esi import app_settings as esi_app_settings
 from esi.errors import TokenError
 from esi.exceptions import HTTPClientError, HTTPNotModified, HTTPServerError
 from esi.models import CallbackRedirect, Token
@@ -98,6 +99,18 @@ logger = get_extension_logger(__name__)
 _HTTP_ERROR_TYPES = (HTTPClientError, HTTPServerError)
 
 _TOKEN_MANAGEMENT_LIVE_CACHE_TTL_SECONDS = 300
+
+
+def _apply_token_validity_filter(token_queryset, *, validate_tokens: bool):
+    """Filter tokens by validity while optionally avoiding live refresh side effects."""
+
+    if validate_tokens:
+        return token_queryset.require_valid()
+
+    max_age = timezone.now() - timedelta(
+        seconds=esi_app_settings.ESI_TOKEN_VALID_DURATION
+    )
+    return token_queryset.filter(created__gt=max_age)
 
 
 def _token_management_live_cache_key(user_id: int) -> str:
@@ -533,11 +546,6 @@ def _collect_corporation_scope_status(
     corp_role_state: dict[int, dict[str, bool]] = {}
     warnings: list[dict[str, Any]] = [] if include_warnings else []
 
-    def _apply_token_validity_filter(token_queryset):
-        if not validate_tokens:
-            return token_queryset
-        return token_queryset.require_valid()
-
     def _revoke_corporation_tokens(
         token_queryset,
         character_id: int,
@@ -558,7 +566,8 @@ def _collect_corporation_scope_status(
         for scope in normalized_scopes:
             token_ids.update(
                 _apply_token_validity_filter(
-                    token_queryset.require_scopes([scope])
+                    token_queryset.require_scopes([scope]),
+                    validate_tokens=validate_tokens,
                 ).values_list("pk", flat=True)
             )
 
@@ -591,7 +600,8 @@ def _collect_corporation_scope_status(
                 continue
             seen.add(normalized)
             candidate = _apply_token_validity_filter(
-                token_qs.require_scopes(scope_list)
+                token_qs.require_scopes(scope_list),
+                validate_tokens=validate_tokens,
             )
             token = candidate.order_by("-created").first()
             if token:
@@ -641,7 +651,10 @@ def _collect_corporation_scope_status(
         blueprint_token = _select_corporation_token(token_qs, CORP_BLUEPRINT_SCOPE)
         jobs_token = _select_corporation_token(token_qs, CORP_JOBS_SCOPE)
         roles_token = (
-            _apply_token_validity_filter(token_qs.require_scopes([CORP_ROLES_SCOPE]))
+            _apply_token_validity_filter(
+                token_qs.require_scopes([CORP_ROLES_SCOPE]),
+                validate_tokens=validate_tokens,
+            )
             .order_by("-created")
             .first()
         )
@@ -810,7 +823,10 @@ def _collect_corporation_scope_status(
         present_scopes = {
             scope
             for scope in required_corporation_scopes
-            if _apply_token_validity_filter(token_qs.require_scopes([scope])).exists()
+            if _apply_token_validity_filter(
+                token_qs.require_scopes([scope]),
+                validate_tokens=validate_tokens,
+            ).exists()
         }
         if present_scopes:
             corp_available_scopes.setdefault(corp_id, set()).update(present_scopes)
@@ -886,7 +902,8 @@ def _collect_corporation_scope_status(
 
         material_exchange_token = (
             _apply_token_validity_filter(
-                token_qs.require_scopes(MATERIAL_EXCHANGE_SCOPE_SET)
+                token_qs.require_scopes(MATERIAL_EXCHANGE_SCOPE_SET),
+                validate_tokens=validate_tokens,
             )
             .order_by("-created")
             .first()
@@ -901,7 +918,8 @@ def _collect_corporation_scope_status(
 
         material_exchange_token = (
             _apply_token_validity_filter(
-                token_qs.require_scopes(MATERIAL_EXCHANGE_SCOPE_SET)
+                token_qs.require_scopes(MATERIAL_EXCHANGE_SCOPE_SET),
+                validate_tokens=validate_tokens,
             )
             .order_by("-created")
             .first()
@@ -2688,14 +2706,21 @@ def token_management(request):
         corporation_sharing = None
     if Token:
         try:
-            blueprint_tokens = Token.objects.filter(user=request.user).require_scopes(
-                BLUEPRINT_SCOPE_SET
+            blueprint_tokens = _apply_token_validity_filter(
+                Token.objects.filter(user=request.user).require_scopes(
+                    BLUEPRINT_SCOPE_SET
+                ),
+                validate_tokens=False,
             )
-            jobs_tokens = Token.objects.filter(user=request.user).require_scopes(
-                JOBS_SCOPE_SET
+            jobs_tokens = _apply_token_validity_filter(
+                Token.objects.filter(user=request.user).require_scopes(JOBS_SCOPE_SET),
+                validate_tokens=False,
             )
-            assets_tokens = Token.objects.filter(user=request.user).require_scopes(
-                ASSETS_SCOPE_SET
+            assets_tokens = _apply_token_validity_filter(
+                Token.objects.filter(user=request.user).require_scopes(
+                    ASSETS_SCOPE_SET
+                ),
+                validate_tokens=False,
             )
             # Deduplicate by character_id
             blueprint_char_ids = (
@@ -2779,7 +2804,10 @@ def token_management(request):
 
         missing_scopes: list[str] = []
         if Token:
-            char_tokens = Token.objects.filter(user=request.user, character_id=cid)
+            char_tokens = _apply_token_validity_filter(
+                Token.objects.filter(user=request.user, character_id=cid),
+                validate_tokens=False,
+            )
             for scope in character_required_scopes:
                 if not char_tokens.require_scopes([scope]).exists():
                     missing_scopes.append(scope)


### PR DESCRIPTION
## Description

This PR improves Indy Hub runtime performance by moving expensive live ESI work off default page renders and by caching structure bonus resolution in the database.

Key changes:
- Jobs page: live ESI skill fetch now happens only on explicit user action (`Force Refresh`).
- Jobs page header now shows a `Last update` timestamp.
- User/settings render paths no longer trigger live token validity refresh during page rendering.
- Settings hub now uses a lightweight context builder instead of full dashboard context.
- Structures: added persistent cache for resolved structure bonuses with signature-based reuse.
- Structures: automatic cache invalidation when structure identity/security band or rigs change.
- Added migration for new `IndustryStructure` cache fields.

Validation performed:
- `pre-commit run --all-files`
- `tox -q`

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
