### PR TITLE
Reduce structure sync log noise and defer on local rate limit

### DIFF
--- a/indy_hub/services/industry_structure_sync.py
+++ b/indy_hub/services/industry_structure_sync.py
@@ -14,6 +14,8 @@ from esi.models import Token
 # AA Example App
 from indy_hub.models import IndustryStructure
 from indy_hub.services.esi_client import (
+    ESIForbiddenError,
+    ESIRateLimitError,
     ESITokenError,
     ESIUnmodifiedError,
     shared_client,
@@ -55,6 +57,8 @@ DEFAULT_DISABLED_ACTIVITY_FLAGS = {
     "enable_hybrid_reactions": False,
     "enable_composite_reactions": False,
 }
+
+SYNC_ERROR_SAMPLE_LIMIT = 5
 
 
 def _truncate_structure_sync_name(value: str) -> str:
@@ -357,11 +361,18 @@ def sync_corporation_structure_targets(
         "unchanged": 0,
         "skipped_unsupported": 0,
         "deleted": 0,
+        "skipped_forbidden": 0,
+        "skipped_missing_token": 0,
+        "rate_limited": 0,
+        "deferred_due_to_rate_limit": 0,
         "errors": [],
+        "forbidden_samples": [],
+        "missing_token_samples": [],
+        "rate_limit_samples": [],
     }
     now = timezone.now()
 
-    for corporation in sync_targets:
+    for index, corporation in enumerate(sync_targets):
         corporation_id = int(corporation["id"])
         corporation_name = str(corporation.get("name") or corporation_id)
         character_id = int(corporation["character_id"])
@@ -377,6 +388,41 @@ def sync_corporation_structure_targets(
                 corporation_id,
             )
             continue
+        except ESIForbiddenError as exc:
+            summary["skipped_forbidden"] += 1
+            forbidden_samples = summary["forbidden_samples"]
+            if len(forbidden_samples) < SYNC_ERROR_SAMPLE_LIMIT:
+                forbidden_samples.append(f"{corporation_name}: {exc}")
+            logger.info(
+                "Skipping corporation %s structure sync after ESI 403",
+                corporation_id,
+            )
+            continue
+        except ESITokenError as exc:
+            summary["skipped_missing_token"] += 1
+            missing_token_samples = summary["missing_token_samples"]
+            if len(missing_token_samples) < SYNC_ERROR_SAMPLE_LIMIT:
+                missing_token_samples.append(f"{corporation_name}: {exc}")
+            logger.info(
+                "Skipping corporation %s structure sync because no usable token/scope is available",
+                corporation_id,
+            )
+            continue
+        except ESIRateLimitError as exc:
+            summary["rate_limited"] += 1
+            rate_limit_samples = summary["rate_limit_samples"]
+            if len(rate_limit_samples) < SYNC_ERROR_SAMPLE_LIMIT:
+                rate_limit_samples.append(f"{corporation_name}: {exc}")
+
+            remaining_targets = max(len(sync_targets) - index - 1, 0)
+            if remaining_targets:
+                summary["deferred_due_to_rate_limit"] += int(remaining_targets)
+            logger.info(
+                "Stopping structure sync early after local ESI throttle for corporation %s; deferred=%s",
+                corporation_id,
+                remaining_targets,
+            )
+            break
         except Exception as exc:
             logger.warning(
                 "Unable to sync structures for corporation %s: %s",

--- a/indy_hub/services/industry_structure_sync.py
+++ b/indy_hub/services/industry_structure_sync.py
@@ -362,12 +362,12 @@ def sync_corporation_structure_targets(
         "skipped_unsupported": 0,
         "deleted": 0,
         "skipped_forbidden": 0,
-        "skipped_missing_token": 0,
+        "skipped_unusable_token": 0,
         "rate_limited": 0,
         "deferred_due_to_rate_limit": 0,
         "errors": [],
         "forbidden_samples": [],
-        "missing_token_samples": [],
+        "unusable_token_samples": [],
         "rate_limit_samples": [],
     }
     now = timezone.now()
@@ -399,10 +399,10 @@ def sync_corporation_structure_targets(
             )
             continue
         except ESITokenError as exc:
-            summary["skipped_missing_token"] += 1
-            missing_token_samples = summary["missing_token_samples"]
-            if len(missing_token_samples) < SYNC_ERROR_SAMPLE_LIMIT:
-                missing_token_samples.append(f"{corporation_name}: {exc}")
+            summary["skipped_unusable_token"] += 1
+            unusable_token_samples = summary["unusable_token_samples"]
+            if len(unusable_token_samples) < SYNC_ERROR_SAMPLE_LIMIT:
+                unusable_token_samples.append(f"{corporation_name}: {exc}")
             logger.info(
                 "Skipping corporation %s structure sync because no usable token/scope is available",
                 corporation_id,

--- a/indy_hub/tasks/industry_structure_sync.py
+++ b/indy_hub/tasks/industry_structure_sync.py
@@ -20,14 +20,34 @@ def sync_persisted_industry_structure_registry(
     force_refresh: bool = True,
 ) -> dict[str, int | str | list[str]]:
     summary = sync_persisted_industry_structures(force_refresh=force_refresh)
-    logger.info(
-        "Automatic industry structure sync complete: corporations=%s created=%s updated=%s unchanged=%s deleted=%s skipped_unsupported=%s errors=%s",
+    error_count = len(summary["errors"])
+    logger_method = logger.warning if error_count else logger.info
+    logger_method(
+        "Automatic industry structure sync complete: corporations=%s created=%s updated=%s unchanged=%s deleted=%s skipped_unsupported=%s skipped_forbidden=%s skipped_missing_token=%s rate_limited=%s deferred=%s errors=%s",
         summary["corporations"],
         summary["created"],
         summary["updated"],
         summary["unchanged"],
         summary.get("deleted", 0),
         summary.get("skipped_unsupported", 0),
-        len(summary["errors"]),
+        summary.get("skipped_forbidden", 0),
+        summary.get("skipped_missing_token", 0),
+        summary.get("rate_limited", 0),
+        summary.get("deferred_due_to_rate_limit", 0),
+        error_count,
     )
+    if summary.get("forbidden_samples"):
+        logger.info(
+            "Structure sync 403 sample: %s", " | ".join(summary["forbidden_samples"])
+        )
+    if summary.get("missing_token_samples"):
+        logger.info(
+            "Structure sync missing-token sample: %s",
+            " | ".join(summary["missing_token_samples"]),
+        )
+    if summary.get("rate_limit_samples"):
+        logger.info(
+            "Structure sync rate-limit sample: %s",
+            " | ".join(summary["rate_limit_samples"]),
+        )
     return {"status": "ok", **summary}

--- a/indy_hub/tasks/industry_structure_sync.py
+++ b/indy_hub/tasks/industry_structure_sync.py
@@ -23,7 +23,7 @@ def sync_persisted_industry_structure_registry(
     error_count = len(summary["errors"])
     logger_method = logger.warning if error_count else logger.info
     logger_method(
-        "Automatic industry structure sync complete: corporations=%s created=%s updated=%s unchanged=%s deleted=%s skipped_unsupported=%s skipped_forbidden=%s skipped_missing_token=%s rate_limited=%s deferred=%s errors=%s",
+        "Automatic industry structure sync complete: corporations=%s created=%s updated=%s unchanged=%s deleted=%s skipped_unsupported=%s skipped_forbidden=%s skipped_unusable_token=%s rate_limited=%s deferred=%s errors=%s",
         summary["corporations"],
         summary["created"],
         summary["updated"],
@@ -31,7 +31,7 @@ def sync_persisted_industry_structure_registry(
         summary.get("deleted", 0),
         summary.get("skipped_unsupported", 0),
         summary.get("skipped_forbidden", 0),
-        summary.get("skipped_missing_token", 0),
+        summary.get("skipped_unusable_token", 0),
         summary.get("rate_limited", 0),
         summary.get("deferred_due_to_rate_limit", 0),
         error_count,
@@ -40,10 +40,10 @@ def sync_persisted_industry_structure_registry(
         logger.info(
             "Structure sync 403 sample: %s", " | ".join(summary["forbidden_samples"])
         )
-    if summary.get("missing_token_samples"):
+    if summary.get("unusable_token_samples"):
         logger.info(
-            "Structure sync missing-token sample: %s",
-            " | ".join(summary["missing_token_samples"]),
+            "Structure sync unusable-token sample: %s",
+            " | ".join(summary["unusable_token_samples"]),
         )
     if summary.get("rate_limit_samples"):
         logger.info(

--- a/indy_hub/tests/test_industry_structure_sync_service.py
+++ b/indy_hub/tests/test_industry_structure_sync_service.py
@@ -10,6 +10,7 @@ from django.test import TestCase
 
 # AA Example App
 from indy_hub.models import IndustryStructure
+from indy_hub.services.esi_client import ESIForbiddenError, ESIRateLimitError
 from indy_hub.services.industry_structure_sync import (
     _get_online_industry_activity_flags,
     sync_corporation_structure_targets,
@@ -177,3 +178,49 @@ class IndustryStructureSyncServiceTests(TestCase):
         self.assertEqual(structure.solar_system_name, "Jita")
         self.assertEqual(structure.constellation_id, 20000020)
         self.assertEqual(structure.region_id, 10000002)
+
+    @patch(
+        "indy_hub.services.industry_structure_sync.shared_client.fetch_corporation_structures"
+    )
+    def test_sync_aggregates_forbidden_errors_without_marking_as_failure(
+        self,
+        mock_fetch_corporation_structures,
+    ) -> None:
+        mock_fetch_corporation_structures.side_effect = ESIForbiddenError(
+            "ESI returned 403 for /corporations/98134807/structures/"
+        )
+
+        summary = sync_corporation_structure_targets(
+            [{"id": 98134807, "name": "Acme Corp", "character_id": 2112625428}],
+            force_refresh=True,
+        )
+
+        self.assertEqual(summary["skipped_forbidden"], 1)
+        self.assertEqual(summary["skipped_missing_token"], 0)
+        self.assertEqual(summary["rate_limited"], 0)
+        self.assertEqual(summary["deferred_due_to_rate_limit"], 0)
+        self.assertEqual(summary["errors"], [])
+        self.assertEqual(len(summary["forbidden_samples"]), 1)
+
+    @patch(
+        "indy_hub.services.industry_structure_sync.shared_client.fetch_corporation_structures"
+    )
+    def test_sync_stops_after_rate_limit_and_defers_remaining_targets(
+        self,
+        mock_fetch_corporation_structures,
+    ) -> None:
+        mock_fetch_corporation_structures.side_effect = ESIRateLimitError(
+            "Local task ESI throttle hit"
+        )
+
+        sync_targets = [
+            {"id": 98134807, "name": "Acme Corp", "character_id": 2112625428},
+            {"id": 98201666, "name": "Beta Corp", "character_id": 2112625429},
+            {"id": 98209999, "name": "Gamma Corp", "character_id": 2112625430},
+        ]
+        summary = sync_corporation_structure_targets(sync_targets, force_refresh=True)
+
+        self.assertEqual(summary["rate_limited"], 1)
+        self.assertEqual(summary["deferred_due_to_rate_limit"], 2)
+        self.assertEqual(summary["errors"], [])
+        self.assertEqual(mock_fetch_corporation_structures.call_count, 1)

--- a/indy_hub/tests/test_industry_structure_sync_service.py
+++ b/indy_hub/tests/test_industry_structure_sync_service.py
@@ -196,7 +196,7 @@ class IndustryStructureSyncServiceTests(TestCase):
         )
 
         self.assertEqual(summary["skipped_forbidden"], 1)
-        self.assertEqual(summary["skipped_missing_token"], 0)
+        self.assertEqual(summary["skipped_unusable_token"], 0)
         self.assertEqual(summary["rate_limited"], 0)
         self.assertEqual(summary["deferred_due_to_rate_limit"], 0)
         self.assertEqual(summary["errors"], [])


### PR DESCRIPTION
## Description

This change hardens automatic corporation structure sync behavior to better handle both small and large deployments.

What changed:
- Aggregates expected structure sync skip cases instead of logging noisy per-corporation warnings:
  - ESI 403 responses
  - missing/invalid token-scope cases
- Stops the sync loop early when local task scope throttling is hit and marks remaining corporations as deferred for a later run.
- Enriches task summary logging with counters and sampled details:
  - skipped_forbidden
  - skipped_missing_token
  - rate_limited
  - deferred_due_to_rate_limit
- Adds regression tests for:
  - forbidden aggregation behavior
  - early stop/defer behavior on rate limiting

Validation performed:
- `tox -q` passed
- `pre-commit run --all-files` passed

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings