### PR TITLE
Fix migration leaf conflict on update (0101 merge compatibility bridge)

### DIFF
--- a/indy_hub/migrations/0101_merge_20260524_1143.py
+++ b/indy_hub/migrations/0101_merge_20260524_1143.py
@@ -1,0 +1,18 @@
+# Django
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Compatibility no-op migration kept to avoid update conflicts.
+
+    Some production installs upgraded through intermediate package builds that
+    exposed this migration name as an alternate branch from 0100. Keeping this
+    no-op file in the canonical migration set allows Django to resolve historical
+    states cleanly instead of raising a multiple-leaf conflict during `migrate`.
+    """
+
+    dependencies = [
+        ("indy_hub", "0100_repair_blueprint_bp_type_classification"),
+    ]
+
+    operations = []

--- a/indy_hub/migrations/0109_merge_20260723_0001.py
+++ b/indy_hub/migrations/0109_merge_20260723_0001.py
@@ -1,0 +1,13 @@
+# Django
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Merge compatibility branch 0101_merge into the current migration line."""
+
+    dependencies = [
+        ("indy_hub", "0108_remove_character_online_status"),
+        ("indy_hub", "0101_merge_20260524_1143"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Description

This PR ships a migration compatibility bridge to prevent upgrade failures with:

`CommandError: Conflicting migrations detected; multiple leaf nodes ... (0101_merge_20260524_1143, 0108_remove_character_online_status)`

### What changed

- Added `indy_hub/migrations/0101_merge_20260524_1143.py` as a no-op compatibility migration so environments that have seen that branch can resolve historical states cleanly.
- Added `indy_hub/migrations/0109_merge_20260723_0001.py` to merge the compatibility branch with the current migration line.

### Why

Some production instances that upgraded through intermediate package states can retain/expect the historical `0101_merge_20260524_1143` branch, causing multiple-leaf conflicts during `migrate`. This patch makes upgrades resilient without requiring local `makemigrations --merge`.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings