### PR TITLE
feat: favorite production structures, corp BP toggle, category assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,18 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ### Added
 
+- Structure Registry: users can now **star (★) production structures** as favorites directly on the `/indy_hub/industry/structures/` page.
+- Structure tab: favorite structures appear first in all assignment dropdowns with a ★ prefix and are pre-selected as the default recommendation when no explicit structure has been chosen.
 - Crafting Projects: new **Corp BP toggle** in the Blueprint tab lets users switch between personal and corporation blueprints. When enabled, corp BPs with better ME/TE than personal are used automatically in material calculations, with a blue "CORP BP" badge on affected blueprint cards.
 - Crafting Projects: temporary projects now persist the Corp BP toggle state across page reloads via a dedicated cache endpoint, so the choice survives without saving the project.
 - Structure tab: new **Category Assignments** section lets users apply a structure to all items of the same craft group (e.g. "Construction Components", "Fuel Block") at once.
 
 ### Fixed
 
-- Crafting Projects: corp BPs were previously excluded from temporary project inventory; they are now included when the Corp BP toggle is enabled and the user has access to the relevant corporation.
-- Crafting Projects: corp BPs that have better ME than the user's personal BP are now used in calculations when the toggle is on. Previously, corp BPs were only used as a fallback when no personal BP existed at all.
-- Crafting Projects: the `workspace_state` context variable was missing from temporary project template rendering, causing the Corp BP toggle to always render unchecked after reload regardless of the saved state.
+- Structure tab: favorite structure was not pre-selected when the user had no explicit prior assignment for a given item.
+- Crafting Projects: corp BPs were excluded from temporary project inventory; they are now included when the toggle is enabled and the user has access to the relevant corporation.
+- Crafting Projects: corp BPs with better ME than the user's personal BP were not used in calculations (they only acted as fallback when no personal BP existed at all).
+- Crafting Projects: `workspace_state` was missing from the temporary project template context, so the Corp BP toggle always rendered unchecked after reload regardless of saved state.
 - Structure tab: Category Assignments rows were grouped by broad service category (`manufacturing`, `composite_reactions`) instead of the more useful craft group name (`Construction Components`, `Fuel Block`, etc.).
 
 ## [1.18.2] - 2026-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ## [Unreleased]
 
+### Added
+
+- Crafting Projects: new **Corp BP toggle** in the Blueprint tab lets users switch between personal and corporation blueprints. When enabled, corp BPs with better ME/TE than personal are used automatically in material calculations, with a blue "CORP BP" badge on affected blueprint cards.
+- Crafting Projects: temporary projects now persist the Corp BP toggle state across page reloads via a dedicated cache endpoint, so the choice survives without saving the project.
+- Structure tab: new **Category Assignments** section lets users apply a structure to all items of the same craft group (e.g. "Construction Components", "Fuel Block") at once.
+
+### Fixed
+
+- Crafting Projects: corp BPs were previously excluded from temporary project inventory; they are now included when the Corp BP toggle is enabled and the user has access to the relevant corporation.
+- Crafting Projects: corp BPs that have better ME than the user's personal BP are now used in calculations when the toggle is on. Previously, corp BPs were only used as a fallback when no personal BP existed at all.
+- Crafting Projects: the `workspace_state` context variable was missing from temporary project template rendering, causing the Corp BP toggle to always render unchecked after reload regardless of the saved state.
+- Structure tab: Category Assignments rows were grouped by broad service category (`manufacturing`, `composite_reactions`) instead of the more useful craft group name (`Construction Components`, `Fuel Block`, etc.).
+
 ## [1.18.2] - 2026-08-01
 
 ### Added.

--- a/indy_hub/services/corporation_blueprint_visibility.py
+++ b/indy_hub/services/corporation_blueprint_visibility.py
@@ -13,6 +13,16 @@ def _get_accessible_corporation_ids_for_scope(user, scope_field_name: str) -> se
     if not getattr(user, "is_authenticated", False):
         return set()
 
+    # Superusers see all configured corporations regardless of scope
+    if getattr(user, "is_superuser", False):
+        return {
+            int(corp_id)
+            for corp_id in CorporationSharingSetting.objects.values_list(
+                "corporation_id", flat=True
+            )
+            if corp_id
+        }
+
     accessible_ids: set[int] = set()
     if user.has_perm("indy_hub.can_manage_corp_bp_requests"):
         accessible_ids.update(get_managed_corporation_ids(user))

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -3387,9 +3387,19 @@ def _resolve_user_blueprint_inventory(
                 },
             )
             _accumulate(entry, bp_me, bp_te, bp_type, runs, prefix="corp_")
-            # Merge corp into the "best available" fields when no personal BP exists
             if tid not in personal_type_ids:
+                # No personal BP: use corp directly
                 _accumulate(entry, bp_me, bp_te, bp_type, runs)
+            else:
+                # Personal BP exists: use corp only if it improves ME (or same ME + better TE)
+                personal_best, _ = _select_best_owned_blueprint_entry(entry)
+                p_me = int(personal_best.get("me") or 0) if personal_best else 0
+                p_te = int(personal_best.get("te") or 0) if personal_best else 0
+                c_me = int(bp_me or 0)
+                c_te = int(bp_te or 0)
+                if c_me > p_me or (c_me == p_me and c_te > p_te):
+                    _accumulate(entry, bp_me, bp_te, bp_type, runs)
+                    entry["corp_source"] = True
 
     return user_bp_map
 

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -36,6 +36,7 @@ from ..utils.eve import (
     get_type_name,
     is_reaction_blueprint,
 )
+from .corporation_blueprint_visibility import get_viewable_corporation_ids
 from .craft_materials import (
     compute_job_material_quantity,
     is_base_item_material_efficiency_exempt,
@@ -3303,8 +3304,32 @@ def _resolve_user_blueprint_inventory(
         .order_by("type_id", "-material_efficiency", "-time_efficiency")
     )
 
+    # Also include corp blueprints from corporations the user can access
+    viewable_corp_ids = get_viewable_corporation_ids(user)
+    corp_blueprints = (
+        Blueprint.objects.filter(
+            owner_kind=Blueprint.OwnerKind.CORPORATION,
+            corporation_id__in=viewable_corp_ids,
+            type_id__in=numeric_ids,
+        )
+        .values_list(
+            "type_id",
+            "material_efficiency",
+            "time_efficiency",
+            "bp_type",
+            "runs",
+        )
+        .order_by("type_id", "-material_efficiency", "-time_efficiency")
+        if viewable_corp_ids
+        else Blueprint.objects.none().values_list(
+            "type_id", "material_efficiency", "time_efficiency", "bp_type", "runs"
+        )
+    )
+
     user_bp_map: dict[int, dict[str, object]] = {}
-    for bp_type_id, bp_me, bp_te, bp_type, runs in user_blueprints:
+    for bp_type_id, bp_me, bp_te, bp_type, runs in list(user_blueprints) + list(
+        corp_blueprints
+    ):
         entry = user_bp_map.setdefault(
             int(bp_type_id),
             {

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -3307,27 +3307,32 @@ def _resolve_user_blueprint_inventory(
         .order_by("type_id", "-material_efficiency", "-time_efficiency")
     )
 
-    # Also include corp blueprints from corporations the user can access
-    viewable_corp_ids = get_viewable_corporation_ids(user)
-    corp_blueprints = (
-        Blueprint.objects.filter(
-            owner_kind=Blueprint.OwnerKind.CORPORATION,
-            corporation_id__in=viewable_corp_ids,
-            type_id__in=numeric_ids,
+    # Corp blueprints are only queried when the caller explicitly requests them
+    if include_corp:
+        viewable_corp_ids = get_viewable_corporation_ids(user)
+        corp_blueprints = (
+            Blueprint.objects.filter(
+                owner_kind=Blueprint.OwnerKind.CORPORATION,
+                corporation_id__in=viewable_corp_ids,
+                type_id__in=numeric_ids,
+            )
+            .values_list(
+                "type_id",
+                "material_efficiency",
+                "time_efficiency",
+                "bp_type",
+                "runs",
+            )
+            .order_by("type_id", "-material_efficiency", "-time_efficiency")
+            if viewable_corp_ids
+            else Blueprint.objects.none().values_list(
+                "type_id", "material_efficiency", "time_efficiency", "bp_type", "runs"
+            )
         )
-        .values_list(
-            "type_id",
-            "material_efficiency",
-            "time_efficiency",
-            "bp_type",
-            "runs",
-        )
-        .order_by("type_id", "-material_efficiency", "-time_efficiency")
-        if viewable_corp_ids
-        else Blueprint.objects.none().values_list(
+    else:
+        corp_blueprints = Blueprint.objects.none().values_list(
             "type_id", "material_efficiency", "time_efficiency", "bp_type", "runs"
         )
-    )
 
     def _accumulate(entry, bp_me, bp_te, bp_type, runs, *, prefix=""):
         """Merge one BP row into the entry dict under the given prefix."""

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -1695,7 +1695,7 @@ def build_project_workspace_payload(
         _extract_workspace_final_output_quantity_overrides(workspace_state),
         final_output_quantity_overrides,
     )
-    use_corp_blueprints = bool(workspace_state.get("use_corp_blueprints", True))
+    use_corp_blueprints = bool(workspace_state.get("use_corp_blueprints", False))
     is_eft_project = project.source_kind == ProductionProject.SourceKind.EFT
     owned_blueprint_inventory_map: dict[int, dict[str, object]] = {}
     owned_blueprint_efficiency_cache: dict[int, dict[str, int]] = {}

--- a/indy_hub/services/production_projects.py
+++ b/indy_hub/services/production_projects.py
@@ -1695,6 +1695,7 @@ def build_project_workspace_payload(
         _extract_workspace_final_output_quantity_overrides(workspace_state),
         final_output_quantity_overrides,
     )
+    use_corp_blueprints = bool(workspace_state.get("use_corp_blueprints", True))
     is_eft_project = project.source_kind == ProductionProject.SourceKind.EFT
     owned_blueprint_inventory_map: dict[int, dict[str, object]] = {}
     owned_blueprint_efficiency_cache: dict[int, dict[str, int]] = {}
@@ -2283,6 +2284,7 @@ def build_project_workspace_payload(
     owned_blueprint_inventory_map = _resolve_user_blueprint_inventory(
         user=project.user,
         blueprint_type_ids=all_blueprint_type_ids,
+        include_corp=use_corp_blueprints,
     )
     record_timing_step(
         "blueprint-inventory",
@@ -3281,6 +3283,7 @@ def _resolve_user_blueprint_inventory(
     *,
     user,
     blueprint_type_ids: Iterable[int | None],
+    include_corp: bool = True,
 ) -> dict[int, dict[str, object]]:
     numeric_ids = sorted(
         {int(type_id) for type_id in blueprint_type_ids if int(type_id or 0) > 0}
@@ -3326,40 +3329,67 @@ def _resolve_user_blueprint_inventory(
         )
     )
 
+    def _accumulate(entry, bp_me, bp_te, bp_type, runs, *, prefix=""):
+        """Merge one BP row into the entry dict under the given prefix."""
+        orig_key = f"{prefix}original" if prefix else "original"
+        copy_key = f"{prefix}best_copy" if prefix else "best_copy"
+        runs_key = f"{prefix}copy_runs_total" if prefix else "copy_runs_total"
+        if bp_type == Blueprint.BPType.ORIGINAL:
+            existing = entry.get(orig_key)
+            if not existing:
+                entry[orig_key] = {"me": int(bp_me or 0), "te": int(bp_te or 0)}
+            elif bp_me > existing["me"] or (
+                bp_me == existing["me"] and bp_te > existing["te"]
+            ):
+                entry[orig_key] = {"me": int(bp_me or 0), "te": int(bp_te or 0)}
+        else:
+            entry[runs_key] = int(entry.get(runs_key) or 0) + int(runs or 0)
+            existing = entry.get(copy_key)
+            if not existing:
+                entry[copy_key] = {"me": int(bp_me or 0), "te": int(bp_te or 0)}
+            elif bp_me > existing["me"] or (
+                bp_me == existing["me"] and bp_te > existing["te"]
+            ):
+                entry[copy_key] = {"me": int(bp_me or 0), "te": int(bp_te or 0)}
+
     user_bp_map: dict[int, dict[str, object]] = {}
-    for bp_type_id, bp_me, bp_te, bp_type, runs in list(user_blueprints) + list(
-        corp_blueprints
-    ):
+    personal_type_ids: set[int] = set()
+    for bp_type_id, bp_me, bp_te, bp_type, runs in user_blueprints:
         entry = user_bp_map.setdefault(
             int(bp_type_id),
             {
                 "original": None,
                 "best_copy": None,
                 "copy_runs_total": 0,
+                # Corp-specific fields (populated below if include_corp)
+                "corp_original": None,
+                "corp_best_copy": None,
+                "corp_copy_runs_total": 0,
+                "corp_source": False,
             },
         )
+        _accumulate(entry, bp_me, bp_te, bp_type, runs)
+        personal_type_ids.add(int(bp_type_id))
 
-        if bp_type == Blueprint.BPType.ORIGINAL:
-            if not entry["original"]:
-                entry["original"] = {"me": int(bp_me or 0), "te": int(bp_te or 0)}
-            else:
-                current = entry["original"]
-                if bp_me > current["me"] or (
-                    bp_me == current["me"] and bp_te > current["te"]
-                ):
-                    entry["original"] = {"me": int(bp_me or 0), "te": int(bp_te or 0)}
-        else:
-            entry["copy_runs_total"] = int(entry.get("copy_runs_total") or 0) + int(
-                runs or 0
+    if include_corp:
+        for bp_type_id, bp_me, bp_te, bp_type, runs in corp_blueprints:
+            tid = int(bp_type_id)
+            entry = user_bp_map.setdefault(
+                tid,
+                {
+                    "original": None,
+                    "best_copy": None,
+                    "copy_runs_total": 0,
+                    "corp_original": None,
+                    "corp_best_copy": None,
+                    "corp_copy_runs_total": 0,
+                    "corp_source": tid not in personal_type_ids,
+                },
             )
-            if not entry["best_copy"]:
-                entry["best_copy"] = {"me": int(bp_me or 0), "te": int(bp_te or 0)}
-            else:
-                current = entry["best_copy"]
-                if bp_me > current["me"] or (
-                    bp_me == current["me"] and bp_te > current["te"]
-                ):
-                    entry["best_copy"] = {"me": int(bp_me or 0), "te": int(bp_te or 0)}
+            _accumulate(entry, bp_me, bp_te, bp_type, runs, prefix="corp_")
+            # Merge corp into the "best available" fields when no personal BP exists
+            if tid not in personal_type_ids:
+                _accumulate(entry, bp_me, bp_te, bp_type, runs)
 
     return user_bp_map
 
@@ -3454,6 +3484,25 @@ def _build_project_blueprint_configs_grouped(
                 "product_type_name": str(entry.get("type_name") or ""),
                 "total_needed": int(entry.get("total_needed") or 0),
                 "category_name": category_name,
+                # Corp-source fields for client-side toggle
+                "corp_source": bool(user_entry.get("corp_source")),
+                "corp_me": int(
+                    (
+                        user_entry.get("corp_original")
+                        or user_entry.get("corp_best_copy")
+                        or {}
+                    ).get("me")
+                    or 0
+                ),
+                "corp_te": int(
+                    (
+                        user_entry.get("corp_original")
+                        or user_entry.get("corp_best_copy")
+                        or {}
+                    ).get("te")
+                    or 0
+                ),
+                "corp_runs": int(user_entry.get("corp_copy_runs_total") or 0),
             }
         )
 

--- a/indy_hub/services/temporary_project_workspace.py
+++ b/indy_hub/services/temporary_project_workspace.py
@@ -96,6 +96,7 @@ def build_temporary_project_workspace_state(
         "active_tab": "materials",
         "activeBlueprintTab": "materials",
         "runs": 1,
+        "use_corp_blueprints": False,
     }
     if str(source_kind) == ProductionProject.SourceKind.EFT and fit_quantities:
         state["finalOutputQuantities"] = [

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -6990,20 +6990,32 @@ function renderStructureCategoryAssignments(items) {
     }
     section.classList.remove('d-none');
 
-    // Build a union of compatible structures per category
+    // Build an intersection of compatible structures per category (only structures valid for every item)
     const categoryStructures = new Map();
     categoriesMap.forEach((catItems, cat) => {
-        const structureMap = new Map();
+        let structureMap = null;
         catItems.forEach((item) => {
-            const opts = Array.isArray(item.options) ? item.options : [];
-            opts.forEach((opt) => {
-                const sid = Number(opt.structure_id || opt.structureId || 0);
-                if (sid > 0 && !structureMap.has(sid)) {
-                    structureMap.set(sid, opt);
+            const itemIds = new Set(
+                (Array.isArray(item.options) ? item.options : [])
+                    .map((opt) => Number(opt.structure_id || opt.structureId || 0))
+                    .filter((sid) => sid > 0)
+            );
+            if (structureMap === null) {
+                // Seed with first item's structures
+                const opts = Array.isArray(item.options) ? item.options : [];
+                structureMap = new Map();
+                opts.forEach((opt) => {
+                    const sid = Number(opt.structure_id || opt.structureId || 0);
+                    if (sid > 0) structureMap.set(sid, opt);
+                });
+            } else {
+                // Keep only structures present in this item too
+                for (const sid of structureMap.keys()) {
+                    if (!itemIds.has(sid)) structureMap.delete(sid);
                 }
-            });
+            }
         });
-        categoryStructures.set(cat, structureMap);
+        categoryStructures.set(cat, structureMap || new Map());
     });
 
     container.innerHTML = Array.from(categoriesMap.entries()).map(([cat, catItems]) => {

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -7026,8 +7026,11 @@ function renderStructureCategoryAssignments(items) {
         }
 
         return `<div class="d-flex align-items-center gap-2" data-category="${escapeHtml(cat)}">
-            <span class="badge bg-light text-dark border fw-normal" style="min-width:11rem;text-align:left;">${label} <span class="text-muted">(${count})</span></span>
-            <select class="form-select form-select-sm category-structure-select" style="max-width:340px;">
+            <div style="min-width:11rem;">
+                <span class="fw-semibold small">${label}</span>
+                <span class="small text-muted ms-1">(${count})</span>
+            </div>
+            <select class="form-select form-select-sm structure-assignment-select category-structure-select" style="max-width:340px;">
                 <option value="">${escapeHtml(__('Select a structure\u2026'))}</option>
                 ${optionMarkup}
             </select>

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -7026,13 +7026,13 @@ function renderStructureCategoryAssignments(items) {
         }
 
         return `<div class="d-flex align-items-center gap-2" data-category="${escapeHtml(cat)}">
-            <span class="small" style="min-width:11rem;">${label} <span class="text-muted">(${count})</span></span>
+            <span class="badge bg-light text-dark border fw-normal" style="min-width:11rem;text-align:left;">${label} <span class="text-muted">(${count})</span></span>
             <select class="form-select form-select-sm category-structure-select" style="max-width:340px;">
-                <option value="">${escapeHtml(__('Select a structure…'))}</option>
+                <option value="">${escapeHtml(__('Select a structure\u2026'))}</option>
                 ${optionMarkup}
             </select>
-            <button type="button" class="btn btn-sm btn-outline-primary category-apply-btn" title="${escapeHtml(__('Apply to all'))}">
-                <i class="fas fa-check"></i>
+            <button type="button" class="btn btn-sm btn-primary category-apply-btn">
+                ${escapeHtml(__('Apply'))}
             </button>
         </div>`;
     }).join('');

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -3549,7 +3549,7 @@ function collectCraftPageSessionState() {
         pendingWorkspaceSourceTab: String(window.craftBPFlags?.pendingWorkspaceSourceTab || ''),
         use_corp_blueprints: (() => {
             const toggle = document.getElementById('useCorpBlueprintsToggle');
-            return toggle ? toggle.checked : true;
+            return toggle ? toggle.checked : false;
         })(),
         updatedAt: Date.now(),
     };

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -6968,10 +6968,10 @@ function renderStructureCategoryAssignments(items) {
         return;
     }
 
-    // Group items by service_category; skip items with no options
+    // Group items by group_name (e.g. "Construction Components", "Fuel Block"); skip items with no options
     const categoriesMap = new Map();
     items.forEach((item) => {
-        const cat = String(item.serviceCategory || item.service_category || '');
+        const cat = String(item.group_name || item.serviceCategory || item.service_category || '');
         if (!cat) {
             return;
         }

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -7025,15 +7025,14 @@ function renderStructureCategoryAssignments(items) {
             return '';
         }
 
-        return `<div class="d-flex align-items-center gap-2 flex-wrap" data-category="${escapeHtml(cat)}">
-            <span class="badge bg-secondary-subtle text-secondary-emphasis" style="min-width:10rem;">${label}</span>
-            <span class="small text-muted">(${count} ${count === 1 ? __('item') : __('items')})</span>
-            <select class="form-select form-select-sm category-structure-select" style="max-width:420px;">
+        return `<div class="d-flex align-items-center gap-2" data-category="${escapeHtml(cat)}">
+            <span class="small" style="min-width:11rem;">${label} <span class="text-muted">(${count})</span></span>
+            <select class="form-select form-select-sm category-structure-select" style="max-width:340px;">
                 <option value="">${escapeHtml(__('Select a structure…'))}</option>
                 ${optionMarkup}
             </select>
-            <button type="button" class="btn btn-sm btn-primary category-apply-btn">
-                <i class="fas fa-check me-1"></i>${escapeHtml(__('Apply to all'))}
+            <button type="button" class="btn btn-sm btn-outline-primary category-apply-btn" title="${escapeHtml(__('Apply to all'))}">
+                <i class="fas fa-check"></i>
             </button>
         </div>`;
     }).join('');

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -3547,6 +3547,10 @@ function collectCraftPageSessionState() {
         },
         pendingWorkspaceRefresh: Boolean(window.craftBPFlags?.hasPendingWorkspaceRefresh || window.craftBPFlags?.hasPendingMETEChanges),
         pendingWorkspaceSourceTab: String(window.craftBPFlags?.pendingWorkspaceSourceTab || ''),
+        use_corp_blueprints: (() => {
+            const toggle = document.getElementById('useCorpBlueprintsToggle');
+            return toggle ? toggle.checked : true;
+        })(),
         updatedAt: Date.now(),
     };
 }

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -6936,6 +6936,130 @@ function renderStructureMetricCell(option, metric, context = {}) {
     return `<span class="craft-structure-metric" tabindex="0" title="${title}" aria-label="${title}">${formatPercent(spec.value, 2)}</span>`;
 }
 
+// ---------------------------------------------------------------------------
+// Category-level structure assignments
+// ---------------------------------------------------------------------------
+
+const _CATEGORY_LABELS = {
+    manufacturing: 'Manufacturing',
+    manufacturing_capitals: 'Capital Manufacturing',
+    manufacturing_super_capitals: 'Super-capital Manufacturing',
+    biochemical_reactions: 'Biochemical Reactions',
+    hybrid_reactions: 'Hybrid Reactions',
+    composite_reactions: 'Composite Reactions',
+};
+
+function renderStructureCategoryAssignments(items) {
+    const section = document.getElementById('structureCategorySection');
+    const container = document.getElementById('structureCategoryRows');
+    if (!section || !container) {
+        return;
+    }
+
+    // Group items by service_category; skip items with no options
+    const categoriesMap = new Map();
+    items.forEach((item) => {
+        const cat = String(item.serviceCategory || item.service_category || '');
+        if (!cat) {
+            return;
+        }
+        if (!categoriesMap.has(cat)) {
+            categoriesMap.set(cat, []);
+        }
+        categoriesMap.get(cat).push(item);
+    });
+
+    // Hide the section when there's only one item total (no batch value)
+    const totalItems = items.length;
+    if (categoriesMap.size === 0 || totalItems < 2) {
+        section.classList.add('d-none');
+        container.innerHTML = '';
+        return;
+    }
+    section.classList.remove('d-none');
+
+    // Build a union of compatible structures per category
+    const categoryStructures = new Map();
+    categoriesMap.forEach((catItems, cat) => {
+        const structureMap = new Map();
+        catItems.forEach((item) => {
+            const opts = Array.isArray(item.options) ? item.options : [];
+            opts.forEach((opt) => {
+                const sid = Number(opt.structure_id || opt.structureId || 0);
+                if (sid > 0 && !structureMap.has(sid)) {
+                    structureMap.set(sid, opt);
+                }
+            });
+        });
+        categoryStructures.set(cat, structureMap);
+    });
+
+    container.innerHTML = Array.from(categoriesMap.entries()).map(([cat, catItems]) => {
+        const label = escapeHtml(_CATEGORY_LABELS[cat] || cat);
+        const count = catItems.length;
+        const structures = categoryStructures.get(cat) || new Map();
+        const optionMarkup = Array.from(structures.values())
+            .sort((a, b) => {
+                const nameA = String(a.name || '');
+                const nameB = String(b.name || '');
+                return nameA.localeCompare(nameB, undefined, { sensitivity: 'base', numeric: true });
+            })
+            .map((opt) => {
+                const sid = Number(opt.structure_id || opt.structureId || 0);
+                return `<option value="${sid}">${escapeHtml(opt.name || String(sid))}</option>`;
+            }).join('');
+
+        if (!optionMarkup) {
+            return '';
+        }
+
+        return `<div class="d-flex align-items-center gap-2 flex-wrap" data-category="${escapeHtml(cat)}">
+            <span class="badge bg-secondary-subtle text-secondary-emphasis" style="min-width:10rem;">${label}</span>
+            <span class="small text-muted">(${count} ${count === 1 ? __('item') : __('items')})</span>
+            <select class="form-select form-select-sm category-structure-select" style="max-width:420px;">
+                <option value="">${escapeHtml(__('Select a structure…'))}</option>
+                ${optionMarkup}
+            </select>
+            <button type="button" class="btn btn-sm btn-primary category-apply-btn">
+                <i class="fas fa-check me-1"></i>${escapeHtml(__('Apply to all'))}
+            </button>
+        </div>`;
+    }).join('');
+
+    // Bind Apply buttons
+    container.querySelectorAll('[data-category]').forEach((row) => {
+        const applyBtn = row.querySelector('.category-apply-btn');
+        const select = row.querySelector('.category-structure-select');
+        if (!applyBtn || !select) {
+            return;
+        }
+        applyBtn.addEventListener('click', () => {
+            const structureId = Number(select.value) || 0;
+            if (!structureId || !window.SimulationAPI || typeof window.SimulationAPI.setStructureAssignment !== 'function') {
+                return;
+            }
+            const cat = row.getAttribute('data-category');
+            const catItems = categoriesMap.get(cat) || [];
+            let applied = 0;
+            catItems.forEach((item) => {
+                const typeId = Number(item.type_id || item.typeId || 0);
+                if (typeId > 0) {
+                    const ok = window.SimulationAPI.setStructureAssignment(typeId, structureId);
+                    if (ok) {
+                        applied += 1;
+                    }
+                }
+            });
+            if (applied > 0) {
+                refreshPlanTreeAfterStructureAssignment();
+                renderStructurePlanner();
+                markPendingWorkspaceRefresh({ sourceTabName: 'structure' });
+                persistCraftPageSessionState();
+            }
+        });
+    });
+}
+
 function renderStructurePlanner(options = {}) {
     const summaryContainer = document.getElementById('structurePlannerSummary');
     const rowsContainer = document.getElementById('structurePlannerRows');
@@ -6974,9 +7098,11 @@ function renderStructurePlanner(options = {}) {
         summaryContainer.innerHTML = '';
         rowsContainer.innerHTML = '';
         emptyContainer.classList.remove('d-none');
+        renderStructureCategoryAssignments([]);
         return;
     }
 
+    renderStructureCategoryAssignments(items);
     emptyContainer.classList.add('d-none');
     const uniqueStructureNames = new Set();
     let weightedMaterialBonus = 0;

--- a/indy_hub/static/indy_hub/js/craft_bp.js
+++ b/indy_hub/static/indy_hub/js/craft_bp.js
@@ -3650,6 +3650,14 @@ function applyCraftPageSessionState(parsedState) {
     }
     updatePendingWorkspaceRefreshNotice();
 
+    // Restore corp BP toggle state
+    if (parsedState?.use_corp_blueprints != null) {
+        const corpToggle = document.getElementById('useCorpBlueprintsToggle');
+        if (corpToggle) {
+            corpToggle.checked = Boolean(parsedState.use_corp_blueprints);
+        }
+    }
+
     window.craftBPFlags.restoringSessionState = false;
     return true;
 }

--- a/indy_hub/static/indy_hub/js/craft_bp_page.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_page.js
@@ -827,6 +827,39 @@
                 showToast(`${getMessage('reset', 'Reset')} ${count} ${getMessage('blueprints_default_values', 'blueprints to default values')}`, true);
             });
         }
+
+        const corpToggle = document.getElementById('useCorpBlueprintsToggle');
+        if (corpToggle) {
+            corpToggle.addEventListener('change', function () {
+                const useCorpBps = corpToggle.checked;
+                // Visual instant feedback: show/hide corp badges and swap ownership display
+                document.querySelectorAll('.craft-bp-card[data-corp-source="true"]').forEach(function (card) {
+                    const badge = card.querySelector('[data-corp-badge]');
+                    if (useCorpBps) {
+                        card.removeAttribute('data-blueprint-not-owned');
+                        if (badge) {
+                            badge.style.display = '';
+                        }
+                    } else {
+                        card.setAttribute('data-blueprint-not-owned', 'true');
+                        if (badge) {
+                            badge.style.display = 'none';
+                        }
+                    }
+                });
+                // Persist and trigger payload rebuild so calculations update
+                if (window.SimulationAPI && typeof window.SimulationAPI.getState === 'function') {
+                    const state = window.SimulationAPI.getState() || {};
+                    state.use_corp_blueprints = useCorpBps;
+                }
+                if (typeof markPendingWorkspaceRefresh === 'function') {
+                    markPendingWorkspaceRefresh({ sourceTabName: 'configure' });
+                }
+                if (typeof persistCraftPageSessionState === 'function') {
+                    persistCraftPageSessionState();
+                }
+            });
+        }
     }
 
     function bindConfigAccordion() {

--- a/indy_hub/static/indy_hub/js/craft_bp_page.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_page.js
@@ -847,30 +847,61 @@
                         }
                     }
                 });
-                // Persist toggle state in session storage before reload
-                if (typeof persistCraftPageSessionState === 'function') {
-                    persistCraftPageSessionState();
-                }
 
                 const isTemporaryProject = Boolean(
                     window.BLUEPRINT_DATA?.is_temporary_project || window.BLUEPRINT_DATA?.temp_project_ref
                 );
 
-                const handleReload = () => {
-                    if (typeof window.location !== 'undefined') {
-                        window.location.reload();
+                const doReload = () => {
+                    // Persist toggle state in session storage
+                    if (typeof persistCraftPageSessionState === 'function') {
+                        persistCraftPageSessionState();
                     }
+
+                    // For temporary projects only: save to cache before reload
+                    if (isTemporaryProject) {
+                        try {
+                            const tempProjectRef = window.BLUEPRINT_DATA?.temp_project_ref;
+                            const sessionState = typeof collectCraftPageSessionState === 'function'
+                                ? collectCraftPageSessionState()
+                                : {};
+
+                            if (tempProjectRef) {
+                                // Use the temporary workspace state update endpoint
+                                const updateUrl = `/api/temp-production-projects/${tempProjectRef}/update-workspace-state/`;
+                                // Silent save (no await, just fire and forget)
+                                fetch(updateUrl, {
+                                    method: 'POST',
+                                    headers: {
+                                        'Content-Type': 'application/json',
+                                        'X-CSRFToken': document.querySelector('[name="csrfmiddlewaretoken"]')?.value || '',
+                                    },
+                                    credentials: 'same-origin',
+                                    body: JSON.stringify(sessionState),
+                                }).catch((error) => {
+                                    craftBPDebugLog('[CorpBPToggle] Cache save error:', error);
+                                });
+                            }
+                        } catch (error) {
+                            craftBPDebugLog('[CorpBPToggle] Cache save preparation error:', error);
+                        }
+                    }
+
+                    // Reload after a short delay
+                    setTimeout(() => {
+                        window.location.reload();
+                    }, 300);
                 };
 
                 if (isTemporaryProject) {
-                    // Temp projects persist in cache, reload immediately
-                    setTimeout(handleReload, 300);
+                    // Temp projects: reload immediately (with cache save)
+                    doReload();
                 } else {
-                    // Permanent projects need explicit user confirmation
+                    // Permanent projects: show confirmation before reload (no cache save)
                     const msg = __('Changing Corp BP usage requires recalculating materials and financials. Unsaved changes will be lost. Continue?') ||
                                 'Changing Corp BP usage requires recalculating materials and financials. Unsaved changes will be lost. Continue?';
                     if (window.confirm(msg)) {
-                        setTimeout(handleReload, 300);
+                        doReload();
                     } else {
                         // Revert toggle on cancel
                         corpToggle.checked = !useCorpBps;

--- a/indy_hub/static/indy_hub/js/craft_bp_page.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_page.js
@@ -832,21 +832,22 @@
         if (corpToggle) {
             corpToggle.addEventListener('change', function () {
                 const useCorpBps = corpToggle.checked;
-                // Visual instant feedback: show/hide corp badges and swap ownership display
-                document.querySelectorAll('.craft-bp-card[data-corp-source="true"]').forEach(function (card) {
-                    const badge = card.querySelector('[data-corp-badge]');
-                    if (useCorpBps) {
-                        card.removeAttribute('data-blueprint-not-owned');
-                        if (badge) {
-                            badge.style.display = '';
+
+                function applyCorpBPVisualState(enabled) {
+                    document.querySelectorAll('.craft-bp-card[data-corp-source="true"]').forEach(function (card) {
+                        const badge = card.querySelector('[data-corp-badge]');
+                        if (enabled) {
+                            card.removeAttribute('data-blueprint-not-owned');
+                            if (badge) { badge.style.display = ''; }
+                        } else {
+                            card.setAttribute('data-blueprint-not-owned', 'true');
+                            if (badge) { badge.style.display = 'none'; }
                         }
-                    } else {
-                        card.setAttribute('data-blueprint-not-owned', 'true');
-                        if (badge) {
-                            badge.style.display = 'none';
-                        }
-                    }
-                });
+                    });
+                }
+
+                // Visual instant feedback
+                applyCorpBPVisualState(useCorpBps);
 
                 const isTemporaryProject = Boolean(
                     window.BLUEPRINT_DATA?.is_temporary_project || window.BLUEPRINT_DATA?.temp_project_ref
@@ -863,9 +864,9 @@
                         try {
                             const updateUrl = window.BLUEPRINT_DATA?.urls?.update_workspace_state;
                             if (updateUrl) {
-                                // Silent save (no await, just fire and forget)
                                 fetch(updateUrl, {
                                     method: 'POST',
+                                    keepalive: true,
                                     headers: {
                                         'Content-Type': 'application/json',
                                         'X-CSRFToken': document.querySelector('[name="csrfmiddlewaretoken"]')?.value || '',
@@ -897,8 +898,9 @@
                     if (window.confirm(msg)) {
                         doReload();
                     } else {
-                        // Revert toggle on cancel
+                        // Revert both the checkbox and the visual state on cancel
                         corpToggle.checked = !useCorpBps;
+                        applyCorpBPVisualState(!useCorpBps);
                     }
                 }
             });

--- a/indy_hub/static/indy_hub/js/craft_bp_page.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_page.js
@@ -847,67 +847,30 @@
                         }
                     }
                 });
+                // Persist toggle state in session storage before reload
+                if (typeof persistCraftPageSessionState === 'function') {
+                    persistCraftPageSessionState();
+                }
 
                 const isTemporaryProject = Boolean(
                     window.BLUEPRINT_DATA?.is_temporary_project || window.BLUEPRINT_DATA?.temp_project_ref
                 );
 
-                const saveAndReload = async (useNewCorpSetting) => {
-                    try {
-                        // Get current workspace state
-                        const sessionState = typeof collectCraftPageSessionState === 'function'
-                            ? collectCraftPageSessionState()
-                            : {};
-
-                        // Update use_corp_blueprints
-                        sessionState.use_corp_blueprints = useNewCorpSetting;
-
-                        const saveUrl = window.BLUEPRINT_DATA?.save_url
-                            || window.BLUEPRINT_DATA?.urls?.save;
-                        if (!saveUrl) {
-                            throw new Error('Save URL not available');
-                        }
-
-                        // Save to server
-                        const response = await fetch(saveUrl, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRFToken': document.querySelector('[name="csrfmiddlewaretoken"]')?.value || '',
-                            },
-                            credentials: 'same-origin',
-                            body: JSON.stringify(sessionState),
-                        });
-
-                        if (!response.ok) {
-                            throw new Error(`Save failed: ${response.status}`);
-                        }
-
-                        // Reload page after successful save
-                        setTimeout(() => {
-                            window.location.reload();
-                        }, 300);
-                    } catch (error) {
-                        craftBPDebugLog('[CorpBPToggle] Save error:', error);
-                        // Revert toggle on error
-                        corpToggle.checked = !useCorpBps;
-                        showToast(
-                            __('Failed to save workspace state. Please try again.')
-                            || 'Failed to save workspace state. Please try again.',
-                            false
-                        );
+                const handleReload = () => {
+                    if (typeof window.location !== 'undefined') {
+                        window.location.reload();
                     }
                 };
 
                 if (isTemporaryProject) {
-                    // Temp projects: save and reload immediately
-                    saveAndReload(useCorpBps);
+                    // Temp projects persist in cache, reload immediately
+                    setTimeout(handleReload, 300);
                 } else {
-                    // Permanent projects: show confirmation before reload
+                    // Permanent projects need explicit user confirmation
                     const msg = __('Changing Corp BP usage requires recalculating materials and financials. Unsaved changes will be lost. Continue?') ||
                                 'Changing Corp BP usage requires recalculating materials and financials. Unsaved changes will be lost. Continue?';
                     if (window.confirm(msg)) {
-                        saveAndReload(useCorpBps);
+                        setTimeout(handleReload, 300);
                     } else {
                         // Revert toggle on cancel
                         corpToggle.checked = !useCorpBps;

--- a/indy_hub/static/indy_hub/js/craft_bp_page.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_page.js
@@ -847,30 +847,67 @@
                         }
                     }
                 });
-                // Persist and trigger page reload for accurate calculations
-                if (typeof persistCraftPageSessionState === 'function') {
-                    persistCraftPageSessionState();
-                }
 
                 const isTemporaryProject = Boolean(
                     window.BLUEPRINT_DATA?.is_temporary_project || window.BLUEPRINT_DATA?.temp_project_ref
                 );
 
-                const handleReload = () => {
-                    if (typeof window.location !== 'undefined') {
-                        window.location.reload();
+                const saveAndReload = async (useNewCorpSetting) => {
+                    try {
+                        // Get current workspace state
+                        const sessionState = typeof collectCraftPageSessionState === 'function'
+                            ? collectCraftPageSessionState()
+                            : {};
+
+                        // Update use_corp_blueprints
+                        sessionState.use_corp_blueprints = useNewCorpSetting;
+
+                        const saveUrl = window.BLUEPRINT_DATA?.save_url
+                            || window.BLUEPRINT_DATA?.urls?.save;
+                        if (!saveUrl) {
+                            throw new Error('Save URL not available');
+                        }
+
+                        // Save to server
+                        const response = await fetch(saveUrl, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRFToken': document.querySelector('[name="csrfmiddlewaretoken"]')?.value || '',
+                            },
+                            credentials: 'same-origin',
+                            body: JSON.stringify(sessionState),
+                        });
+
+                        if (!response.ok) {
+                            throw new Error(`Save failed: ${response.status}`);
+                        }
+
+                        // Reload page after successful save
+                        setTimeout(() => {
+                            window.location.reload();
+                        }, 300);
+                    } catch (error) {
+                        craftBPDebugLog('[CorpBPToggle] Save error:', error);
+                        // Revert toggle on error
+                        corpToggle.checked = !useCorpBps;
+                        showToast(
+                            __('Failed to save workspace state. Please try again.')
+                            || 'Failed to save workspace state. Please try again.',
+                            false
+                        );
                     }
                 };
 
                 if (isTemporaryProject) {
-                    // Temp projects persist in cache, reload immediately
-                    setTimeout(handleReload, 300);
+                    // Temp projects: save and reload immediately
+                    saveAndReload(useCorpBps);
                 } else {
-                    // Permanent projects need explicit user confirmation
+                    // Permanent projects: show confirmation before reload
                     const msg = __('Changing Corp BP usage requires recalculating materials and financials. Unsaved changes will be lost. Continue?') ||
                                 'Changing Corp BP usage requires recalculating materials and financials. Unsaved changes will be lost. Continue?';
                     if (window.confirm(msg)) {
-                        setTimeout(handleReload, 300);
+                        saveAndReload(useCorpBps);
                     } else {
                         // Revert toggle on cancel
                         corpToggle.checked = !useCorpBps;

--- a/indy_hub/static/indy_hub/js/craft_bp_page.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_page.js
@@ -847,16 +847,34 @@
                         }
                     }
                 });
-                // Persist and trigger payload rebuild so calculations update
-                if (window.SimulationAPI && typeof window.SimulationAPI.getState === 'function') {
-                    const state = window.SimulationAPI.getState() || {};
-                    state.use_corp_blueprints = useCorpBps;
-                }
-                if (typeof markPendingWorkspaceRefresh === 'function') {
-                    markPendingWorkspaceRefresh({ sourceTabName: 'configure' });
-                }
+                // Persist and trigger page reload for accurate calculations
                 if (typeof persistCraftPageSessionState === 'function') {
                     persistCraftPageSessionState();
+                }
+
+                const isTemporaryProject = Boolean(
+                    window.BLUEPRINT_DATA?.is_temporary_project || window.BLUEPRINT_DATA?.temp_project_ref
+                );
+
+                const handleReload = () => {
+                    if (typeof window.location !== 'undefined') {
+                        window.location.reload();
+                    }
+                };
+
+                if (isTemporaryProject) {
+                    // Temp projects persist in cache, reload immediately
+                    setTimeout(handleReload, 300);
+                } else {
+                    // Permanent projects need explicit user confirmation
+                    const msg = __('Changing Corp BP usage requires recalculating materials and financials. Unsaved changes will be lost. Continue?') ||
+                                'Changing Corp BP usage requires recalculating materials and financials. Unsaved changes will be lost. Continue?';
+                    if (window.confirm(msg)) {
+                        setTimeout(handleReload, 300);
+                    } else {
+                        // Revert toggle on cancel
+                        corpToggle.checked = !useCorpBps;
+                    }
                 }
             });
         }

--- a/indy_hub/static/indy_hub/js/craft_bp_page.js
+++ b/indy_hub/static/indy_hub/js/craft_bp_page.js
@@ -861,14 +861,8 @@
                     // For temporary projects only: save to cache before reload
                     if (isTemporaryProject) {
                         try {
-                            const tempProjectRef = window.BLUEPRINT_DATA?.temp_project_ref;
-                            const sessionState = typeof collectCraftPageSessionState === 'function'
-                                ? collectCraftPageSessionState()
-                                : {};
-
-                            if (tempProjectRef) {
-                                // Use the temporary workspace state update endpoint
-                                const updateUrl = `/api/temp-production-projects/${tempProjectRef}/update-workspace-state/`;
+                            const updateUrl = window.BLUEPRINT_DATA?.urls?.update_workspace_state;
+                            if (updateUrl) {
                                 // Silent save (no await, just fire and forget)
                                 fetch(updateUrl, {
                                     method: 'POST',
@@ -877,7 +871,7 @@
                                         'X-CSRFToken': document.querySelector('[name="csrfmiddlewaretoken"]')?.value || '',
                                     },
                                     credentials: 'same-origin',
-                                    body: JSON.stringify(sessionState),
+                                    body: JSON.stringify({ use_corp_blueprints: useCorpBps }),
                                 }).catch((error) => {
                                     craftBPDebugLog('[CorpBPToggle] Cache save error:', error);
                                 });

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -1346,7 +1346,7 @@
 <script src="{% static 'indy_hub/js/craft_bp_simulation_api.js' %}?v=20260524-build-final-targets"></script>
 <script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260505-deferred-tab-init"></script>
 <script src="{% static 'indy_hub/js/craft_bp_financial_planner.js' %}?v=20260428-no-output-override"></script>
-<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260804-compact-category-rows"></script>
+<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260804-compact-category-rows-v2"></script>
 <script src="{% static 'indy_hub/js/craft_bp_inline.js' %}?v=20260801-functional-fixes-v3"></script>
 <script src="{% static 'indy_hub/js/craft_bp_project_rename.js' %}?v=20260523-project-rename-status"></script>
 {% endif %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -1346,7 +1346,7 @@
 <script src="{% static 'indy_hub/js/craft_bp_simulation_api.js' %}?v=20260524-build-final-targets"></script>
 <script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260505-deferred-tab-init"></script>
 <script src="{% static 'indy_hub/js/craft_bp_financial_planner.js' %}?v=20260428-no-output-override"></script>
-<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260804-compact-category-rows-v2"></script>
+<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260804-compact-category-rows-v3"></script>
 <script src="{% static 'indy_hub/js/craft_bp_inline.js' %}?v=20260801-functional-fixes-v3"></script>
 <script src="{% static 'indy_hub/js/craft_bp_project_rename.js' %}?v=20260523-project-rename-status"></script>
 {% endif %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -1344,7 +1344,7 @@
 
 {% block extra_javascript %}
 {{ blueprint_payload|json_script:"blueprint-payload" }}
-<script src="{% static 'indy_hub/js/craft_bp_page.js' %}?v=20260801-functional-fixes-v1"></script>
+<script src="{% static 'indy_hub/js/craft_bp_page.js' %}?v=20260804-corp-bp-toggle-fix"></script>
 {% if not deferred_shell %}
 <script src="{% static 'indy_hub/js/craft_bp_simulation_api.js' %}?v=20260524-build-final-targets"></script>
 <script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260505-deferred-tab-init"></script>

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -920,6 +920,16 @@
                     <div id="structurePlannerSummary" class="craft-structure-summary-grid"></div>
                 </section>
 
+                <section class="craft-section mb-3 d-none" id="structureCategorySection">
+                    <div class="craft-section-header-with-actions">
+                        <h3 class="craft-section-title">
+                            <i class="fas fa-layer-group text-secondary"></i> {% trans "Category Assignments" %}
+                        </h3>
+                        <span class="small text-muted">{% trans "Apply a structure to all items of the same category at once." %}</span>
+                    </div>
+                    <div id="structureCategoryRows" class="d-flex flex-column gap-2 mt-2"></div>
+                </section>
+
                 <section class="craft-section">
                     <div class="craft-section-header-with-actions">
                         <h3 class="craft-section-title">

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -920,14 +920,11 @@
                     <div id="structurePlannerSummary" class="craft-structure-summary-grid"></div>
                 </section>
 
-                <section class="craft-section mb-3 d-none" id="structureCategorySection">
-                    <div class="craft-section-header-with-actions">
-                        <h3 class="craft-section-title">
-                            <i class="fas fa-layer-group text-secondary"></i> {% trans "Category Assignments" %}
-                        </h3>
-                        <span class="small text-muted">{% trans "Apply a structure to all items of the same category at once." %}</span>
-                    </div>
-                    <div id="structureCategoryRows" class="d-flex flex-column gap-2 mt-2"></div>
+                <section class="d-none mb-2" id="structureCategorySection">
+                    <p class="small text-muted mb-1">
+                        <i class="fas fa-layer-group me-1"></i><strong>{% trans "Category Assignments" %}</strong>
+                    </p>
+                    <div id="structureCategoryRows" class="d-flex flex-column gap-1"></div>
                 </section>
 
                 <section class="craft-section">
@@ -1349,7 +1346,7 @@
 <script src="{% static 'indy_hub/js/craft_bp_simulation_api.js' %}?v=20260524-build-final-targets"></script>
 <script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260505-deferred-tab-init"></script>
 <script src="{% static 'indy_hub/js/craft_bp_financial_planner.js' %}?v=20260428-no-output-override"></script>
-<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260804-category-group-assignments"></script>
+<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260804-compact-category-rows"></script>
 <script src="{% static 'indy_hub/js/craft_bp_inline.js' %}?v=20260801-functional-fixes-v3"></script>
 <script src="{% static 'indy_hub/js/craft_bp_project_rename.js' %}?v=20260523-project-rename-status"></script>
 {% endif %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -985,7 +985,14 @@
                         <h3 class="craft-section-title mb-0">
                             <i class="fas fa-sliders-h text-danger"></i> {% trans "Blueprint Configuration" %}
                         </h3>
-                        <div class="d-flex gap-2 align-items-center">
+                        <div class="d-flex gap-2 align-items-center flex-wrap">
+                            <div class="form-check form-switch mb-0 d-flex align-items-center gap-2">
+                                <input class="form-check-input" type="checkbox" id="useCorpBlueprintsToggle" role="switch"
+                                    {% if workspace_state.use_corp_blueprints != False %}checked{% endif %}>
+                                <label class="form-check-label small text-muted" for="useCorpBlueprintsToggle">
+                                    <i class="fas fa-building me-1"></i>{% trans "Corp BPs" %}
+                                </label>
+                            </div>
                             <div class="input-group input-group-sm" style="max-width: 250px;">
                                 <span class="input-group-text bg-white"><i class="fas fa-search text-muted"></i></span>
                                 <input type="text" class="form-control" id="blueprintSearchInput" placeholder="{% trans 'Search blueprints...' %}">
@@ -1019,7 +1026,7 @@
                                     <div class="craft-config-level">
                                         <div class="craft-config-items-grid">
                                             {% for bc in level.blueprints %}
-                                            <div class="craft-bp-card card h-100" data-blueprint-type-id="{{ bc.type_id }}" {% if not bc.user_owns %}data-blueprint-not-owned="true"{% endif %} {% if bc.is_reaction %}data-blueprint-is-reaction="true"{% endif %}>
+                                            <div class="craft-bp-card card h-100" data-blueprint-type-id="{{ bc.type_id }}" {% if not bc.user_owns %}data-blueprint-not-owned="true"{% endif %} {% if bc.is_reaction %}data-blueprint-is-reaction="true"{% endif %} data-corp-source="{{ bc.corp_source|yesno:'true,false' }}" data-corp-me="{{ bc.corp_me }}" data-corp-te="{{ bc.corp_te }}" data-corp-runs="{{ bc.corp_runs }}">
                                                 <div class="card-header text-center py-1 {% if bc.user_owns %}bg-success bg-opacity-10{% elif not bc.user_owns and not bc.is_reaction %}bg-warning bg-opacity-10{% else %}bg-danger bg-opacity-10{% endif %}">
                                                     <img
                                                         src="https://images.evetech.net/types/{{ bc.type_id }}/bp?size=128"
@@ -1028,7 +1035,11 @@
                                                         onerror="this.style.display='none';"
                                                     >
                                                     {% if bc.user_owns %}
-                                                        {% if bc.is_copy %}
+                                                        {% if bc.corp_source %}
+                                                        <span class="badge bg-primary w-100 mb-1" style="font-size:0.7rem;" data-corp-badge>
+                                                            <i class="fas fa-building me-1"></i>CORP BP{% if not bc.is_reaction %} - {{ bc.corp_runs|default:"0" }} runs{% endif %}
+                                                        </span>
+                                                        {% elif bc.is_copy %}
                                                         <span class="badge bg-info w-100 mb-1" style="font-size: 0.7rem;">
                                                             <i class="fas fa-copy me-1"></i>COPY OWNED{% if not bc.is_reaction %} - {{ bc.runs_available|default:"0" }} runs{% endif %}
                                                         </span>

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -988,7 +988,7 @@
                         <div class="d-flex gap-2 align-items-center flex-wrap">
                             <div class="form-check form-switch mb-0 d-flex align-items-center gap-2">
                                 <input class="form-check-input" type="checkbox" id="useCorpBlueprintsToggle" role="switch"
-                                    {% if workspace_state.use_corp_blueprints != False %}checked{% endif %}>
+                                    {% if workspace_state.use_corp_blueprints %}checked{% endif %}>
                                 <label class="form-check-label small text-muted" for="useCorpBlueprintsToggle">
                                     <i class="fas fa-building me-1"></i>{% trans "Corp BPs" %}
                                 </label>

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -1349,7 +1349,7 @@
 <script src="{% static 'indy_hub/js/craft_bp_simulation_api.js' %}?v=20260524-build-final-targets"></script>
 <script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260505-deferred-tab-init"></script>
 <script src="{% static 'indy_hub/js/craft_bp_financial_planner.js' %}?v=20260428-no-output-override"></script>
-<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260801-stock-location-filter-v4"></script>
+<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260804-category-group-assignments"></script>
 <script src="{% static 'indy_hub/js/craft_bp_inline.js' %}?v=20260801-functional-fixes-v3"></script>
 <script src="{% static 'indy_hub/js/craft_bp_project_rename.js' %}?v=20260523-project-rename-status"></script>
 {% endif %}

--- a/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
+++ b/indy_hub/templates/indy_hub/industry/Craft_BP_v2.html
@@ -1341,12 +1341,12 @@
 
 {% block extra_javascript %}
 {{ blueprint_payload|json_script:"blueprint-payload" }}
-<script src="{% static 'indy_hub/js/craft_bp_page.js' %}?v=20260804-corp-bp-toggle-fix"></script>
+<script src="{% static 'indy_hub/js/craft_bp_page.js' %}?v=20260804-pr154-review-fixes"></script>
 {% if not deferred_shell %}
 <script src="{% static 'indy_hub/js/craft_bp_simulation_api.js' %}?v=20260524-build-final-targets"></script>
 <script src="{% static 'indy_hub/js/craft_bp_active_tab.js' %}?v=20260505-deferred-tab-init"></script>
 <script src="{% static 'indy_hub/js/craft_bp_financial_planner.js' %}?v=20260428-no-output-override"></script>
-<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260804-compact-category-rows-v3"></script>
+<script src="{% static 'indy_hub/js/craft_bp.js' %}?v=20260804-pr154-review-fixes"></script>
 <script src="{% static 'indy_hub/js/craft_bp_inline.js' %}?v=20260801-functional-fixes-v3"></script>
 <script src="{% static 'indy_hub/js/craft_bp_project_rename.js' %}?v=20260523-project-rename-status"></script>
 {% endif %}

--- a/indy_hub/tests/craft/test_craft_payload_api.py
+++ b/indy_hub/tests/craft/test_craft_payload_api.py
@@ -20,6 +20,7 @@ from indy_hub.views.api import (
     fuzzwork_price,
     production_project_payload,
     temporary_production_project_payload,
+    update_temporary_project_workspace_state,
 )
 
 
@@ -513,3 +514,80 @@ class CraftBlueprintPayloadApiTests(TestCase):
             json.loads(response.content), {"error": "solar_system_not_found"}
         )
         mock_resolve_solar_system_reference.assert_called_once()
+
+
+class UpdateTemporaryProjectWorkspaceStateTests(TestCase):
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(username="builder2", password="secret")
+        permission = Permission.objects.get(codename="can_access_indy_hub")
+        self.user.user_permissions.add(permission)
+
+    def _call(self, ref, body, user=None):
+        request = self.factory.post(
+            f"/indy_hub/api/temp-production-projects/{ref}/update-workspace-state/",
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+        request.user = user or self.user
+        view = update_temporary_project_workspace_state
+        while hasattr(view, "__wrapped__"):
+            view = view.__wrapped__
+        return view(request, ref)
+
+    @patch("indy_hub.views.api.set_temporary_project_workspace")
+    @patch("indy_hub.views.api.get_temporary_project_workspace")
+    @patch("indy_hub.views.api.emit_view_analytics_event")
+    def test_sets_use_corp_blueprints_true(self, mock_emit, mock_get, mock_set):
+        mock_emit.return_value = None
+        mock_get.return_value = {"user_id": self.user.id, "workspace_state": {}}
+
+        response = self._call("abc123", {"use_corp_blueprints": True})
+
+        self.assertEqual(response.status_code, 200)
+        saved = mock_set.call_args[0][1]
+        self.assertIs(saved["workspace_state"]["use_corp_blueprints"], True)
+
+    @patch("indy_hub.views.api.set_temporary_project_workspace")
+    @patch("indy_hub.views.api.get_temporary_project_workspace")
+    @patch("indy_hub.views.api.emit_view_analytics_event")
+    def test_string_false_does_not_enable_corp_blueprints(
+        self, mock_emit, mock_get, mock_set
+    ):
+        """bool('false') == True; the endpoint must reject truthy strings."""
+        mock_emit.return_value = None
+        mock_get.return_value = {"user_id": self.user.id, "workspace_state": {}}
+
+        response = self._call("abc123", {"use_corp_blueprints": "false"})
+
+        self.assertEqual(response.status_code, 200)
+        saved = mock_set.call_args[0][1]
+        self.assertIs(saved["workspace_state"]["use_corp_blueprints"], False)
+
+    @patch("indy_hub.views.api.get_temporary_project_workspace")
+    @patch("indy_hub.views.api.emit_view_analytics_event")
+    def test_returns_404_when_temp_project_not_found(self, mock_emit, mock_get):
+        mock_emit.return_value = None
+        mock_get.return_value = None
+
+        response = self._call("missing", {"use_corp_blueprints": True})
+
+        self.assertEqual(response.status_code, 404)
+
+    @patch("indy_hub.views.api.set_temporary_project_workspace")
+    @patch("indy_hub.views.api.get_temporary_project_workspace")
+    @patch("indy_hub.views.api.emit_view_analytics_event")
+    def test_strips_cached_payload_on_update(self, mock_emit, mock_get, mock_set):
+        """Cached payload must be cleared so the next load rebuilds with new settings."""
+        mock_emit.return_value = None
+        mock_get.return_value = {
+            "user_id": self.user.id,
+            "workspace_state": {"cachedProjectPayload": {"some": "data"}, "runs": 5},
+        }
+
+        response = self._call("abc123", {"use_corp_blueprints": True})
+
+        self.assertEqual(response.status_code, 200)
+        saved = mock_set.call_args[0][1]
+        self.assertNotIn("cachedProjectPayload", saved["workspace_state"])
+        self.assertEqual(saved["workspace_state"]["runs"], 5)

--- a/indy_hub/urls.py
+++ b/indy_hub/urls.py
@@ -18,6 +18,7 @@ from .views.api import (
     set_production_project_status,
     temporary_production_project_payload,
     toggle_favorite_structure,
+    update_temporary_project_workspace_state,
 )
 from .views.hubs import (
     settings_hub,
@@ -318,6 +319,11 @@ urlpatterns = [
         "api/temp-production-projects/<str:temp_project_ref>/save-workspace/",
         save_temporary_production_project_workspace,
         name="save_temporary_production_project_workspace",
+    ),
+    path(
+        "api/temp-production-projects/<str:temp_project_ref>/update-workspace-state/",
+        update_temporary_project_workspace_state,
+        name="update_temporary_project_workspace_state",
     ),
     re_path(
         r"^api/production-projects/(?P<project_ref>[0-9A-Za-z]{10})/rename/$",

--- a/indy_hub/views/api.py
+++ b/indy_hub/views/api.py
@@ -497,7 +497,7 @@ def save_temporary_production_project_workspace(request, temp_project_ref: str):
 @login_required
 @require_http_methods(["POST"])
 def update_temporary_project_workspace_state(request, temp_project_ref: str):
-    """Update workspace_state of a temporary project cache without finalizing it."""
+    """Patch specific fields in a temporary project workspace_state cache entry."""
     emit_view_analytics_event(
         view_name="api.update_temporary_project_workspace_state",
         request=request,
@@ -512,12 +512,13 @@ def update_temporary_project_workspace_state(request, temp_project_ref: str):
     except json.JSONDecodeError:
         return JsonResponse({"error": "Invalid JSON data"}, status=400)
 
-    # Update only the workspace_state in the temporary cache
-    workspace_state = _sanitize_production_workspace_state(
-        project=None,
-        data=data,
+    # Patch only allowed fields into the existing workspace_state, stripping cached payload
+    workspace_state = strip_project_workspace_cache(
+        dict(temp_state.get("workspace_state") or {})
     )
-    temp_state.update({"workspace_state": workspace_state})
+    if "use_corp_blueprints" in data:
+        workspace_state["use_corp_blueprints"] = bool(data["use_corp_blueprints"])
+    temp_state["workspace_state"] = workspace_state
     set_temporary_project_workspace(temp_project_ref, temp_state)
 
     return JsonResponse(

--- a/indy_hub/views/api.py
+++ b/indy_hub/views/api.py
@@ -147,11 +147,13 @@ def _sanitize_production_workspace_state(
         or existing_workspace_state.get("blueprint_name")
         or ""
     )
-    use_corp_blueprints = bool(
+    raw_corp = (
         data.get("use_corp_blueprints")
         if "use_corp_blueprints" in data
         else existing_workspace_state.get("use_corp_blueprints", False)
     )
+    # Explicit parse: reject truthy strings like "false" or "0"
+    use_corp_blueprints = raw_corp is True or raw_corp == 1
 
     return {
         "blueprint_type_id": blueprint_type_id,
@@ -517,7 +519,8 @@ def update_temporary_project_workspace_state(request, temp_project_ref: str):
         dict(temp_state.get("workspace_state") or {})
     )
     if "use_corp_blueprints" in data:
-        workspace_state["use_corp_blueprints"] = bool(data["use_corp_blueprints"])
+        raw = data["use_corp_blueprints"]
+        workspace_state["use_corp_blueprints"] = raw is True or raw == 1
     temp_state["workspace_state"] = workspace_state
     set_temporary_project_workspace(temp_project_ref, temp_state)
 

--- a/indy_hub/views/api.py
+++ b/indy_hub/views/api.py
@@ -147,6 +147,11 @@ def _sanitize_production_workspace_state(
         or existing_workspace_state.get("blueprint_name")
         or ""
     )
+    use_corp_blueprints = bool(
+        data.get("use_corp_blueprints")
+        if "use_corp_blueprints" in data
+        else existing_workspace_state.get("use_corp_blueprints", False)
+    )
 
     return {
         "blueprint_type_id": blueprint_type_id,
@@ -156,6 +161,7 @@ def _sanitize_production_workspace_state(
         "simulationName": simulation_name,
         "active_tab": active_blueprint_tab,
         "activeBlueprintTab": active_blueprint_tab,
+        "use_corp_blueprints": use_corp_blueprints,
         "buyTypeIds": sanitize_list(data.get("buyTypeIds")),
         "stockAllocations": sanitize_dict(data.get("stockAllocations")),
         "manualPrices": sanitize_list(data.get("manualPrices")),

--- a/indy_hub/views/api.py
+++ b/indy_hub/views/api.py
@@ -489,6 +489,42 @@ def save_temporary_production_project_workspace(request, temp_project_ref: str):
 @indy_hub_access_required
 @indy_hub_permission_required("can_access_indy_hub")
 @login_required
+@require_http_methods(["POST"])
+def update_temporary_project_workspace_state(request, temp_project_ref: str):
+    """Update workspace_state of a temporary project cache without finalizing it."""
+    emit_view_analytics_event(
+        view_name="api.update_temporary_project_workspace_state",
+        request=request,
+    )
+
+    temp_state = get_temporary_project_workspace(request.user, temp_project_ref)
+    if not temp_state:
+        return JsonResponse({"error": "Temporary craft table not found"}, status=404)
+
+    try:
+        data = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON data"}, status=400)
+
+    # Update only the workspace_state in the temporary cache
+    workspace_state = _sanitize_production_workspace_state(
+        project=None,
+        data=data,
+    )
+    temp_state.update({"workspace_state": workspace_state})
+    set_temporary_project_workspace(temp_project_ref, temp_state)
+
+    return JsonResponse(
+        {
+            "success": True,
+            "message": "Temporary project workspace state updated successfully",
+        }
+    )
+
+
+@indy_hub_access_required
+@indy_hub_permission_required("can_access_indy_hub")
+@login_required
 @require_http_methods(["GET"])
 def production_project_payload(request, project_ref: str):
     emit_view_analytics_event(

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -2468,6 +2468,7 @@ def craft_temp_project(request, temp_project_ref):
         "craft_header_controls": craft_header_controls,
         "deferred_shell": False,
         "active_tab": active_tab,
+        "workspace_state": render_workspace_state,
         "num_runs": payload.get("num_runs") or 1,
         "final_product_qty": payload.get("final_product_qty")
         or total_requested_quantity,

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -2420,6 +2420,10 @@ def craft_temp_project(request, temp_project_ref):
                 "toggle_favorite_structure": reverse(
                     "indy_hub:toggle_favorite_structure"
                 ),
+                "update_workspace_state": reverse(
+                    "indy_hub:update_temporary_project_workspace_state",
+                    args=[temp_project_ref],
+                ),
             },
         }
     )


### PR DESCRIPTION
## Summary

Three features + several bug fixes for the Crafting Projects workflow.

### Added

- **Favorite production structures** – users can star structures on the Structure Registry page; starred structures appear first in the Structure tab dropdowns with a ★ prefix and are pre-selected as the default recommendation when no explicit choice has been made.
- **Corp BP toggle** in the Blueprint tab – switch between personal and corporation blueprints for a project. When ON, corp BPs with better ME/TE than personal are used in material calculations, with a blue "CORP BP" badge on affected cards. For temporary projects the choice persists across page reloads via a dedicated cache-only endpoint.
- **Category Assignments** in the Structure tab – apply a structure to all items of the same craft group (e.g. "Construction Components", "Fuel Block") at once with a compact inline row.

### Fixed

- Corp BPs were fully excluded from temporary project inventory; they are now resolved and compared against personal BPs.
- Corp BPs with better ME than personal were not used in calculations (only fell back to corp when *no* personal BP existed).
- `workspace_state` was missing from the temporary project template context, so the Corp BP toggle always rendered unchecked after reload.
- Category Assignments rows grouped by `service_category` (`manufacturing`, `composite_reactions`) instead of the more useful craft group name.
- Various smaller polish and pre-commit fixes from PR #153 review.
