### PR TITLE
fix: resolve NPC station names and clean non-deployed asset placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Crafting Projects: new **Corp BP toggle** in the Blueprint tab lets users switch between personal and corporation blueprints. When enabled, corp BPs with better ME/TE than personal are used automatically in material calculations, with a blue "CORP BP" badge on affected blueprint cards.
 - Crafting Projects: temporary projects now persist the Corp BP toggle state across page reloads via a dedicated cache endpoint, so the choice survives without saving the project.
 - Structure tab: new **Category Assignments** section lets users apply a structure to all items of the same craft group (e.g. "Construction Components", "Fuel Block") at once.
+- Management command: `populate_location_names --repair-stations` scans `CachedStructureName` for placeholder entries in the NPC station ID range and re-resolves them via the corrected endpoint. Supports `--dry-run`.
 
 ### Fixed
 
@@ -23,6 +24,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Crafting Projects: corp BPs were excluded from temporary project inventory; they are now included when the toggle is enabled and the user has access to the relevant corporation.
 - Crafting Projects: corp BPs with better ME than the user's personal BP were not used in calculations (they only acted as fallback when no personal BP existed at all).
 - Crafting Projects: `workspace_state` was missing from the temporary project template context, so the Corp BP toggle always rendered unchecked after reload regardless of saved state.
+- Structure tab: Category Assignments rows were grouped by broad service category (`manufacturing`, `composite_reactions`) instead of the more useful craft group name (`Construction Components`, `Fuel Block`, etc.).
+- Locations: NPC station names (IDs 60 000 000–69 999 999) were stored as `Structure <id>` placeholders instead of their real names. The dedicated public `GET /universe/stations/{station_id}/` endpoint is now used for this ID range rather than the generic `POST /universe/names/` batch endpoint.
 - Structure tab: Category Assignments rows were grouped by broad service category (`manufacturing`, `composite_reactions`) instead of the more useful craft group name (`Construction Components`, `Fuel Block`, etc.).
 
 ## [1.18.2] - 2026-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Crafting Projects: new **Corp BP toggle** in the Blueprint tab lets users switch between personal and corporation blueprints. When enabled, corp BPs with better ME/TE than personal are used automatically in material calculations, with a blue "CORP BP" badge on affected blueprint cards.
 - Crafting Projects: temporary projects now persist the Corp BP toggle state across page reloads via a dedicated cache endpoint, so the choice survives without saving the project.
 - Structure tab: new **Category Assignments** section lets users apply a structure to all items of the same craft group (e.g. "Construction Components", "Fuel Block") at once.
-- Management command: `populate_location_names --repair-stations` scans `CachedStructureName` for placeholder entries in the NPC station ID range and re-resolves them via the corrected endpoint. Supports `--dry-run`.
+- Management command: `populate_location_names --repair-stations` repairs placeholder location names by re-resolving NPC station IDs via the corrected public endpoint and relabelling non-deployed asset-item IDs as `<type name> [asset]`. Supports `--dry-run`.
 
 ### Fixed
 
@@ -25,8 +25,8 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Crafting Projects: corp BPs with better ME than the user's personal BP were not used in calculations (they only acted as fallback when no personal BP existed at all).
 - Crafting Projects: `workspace_state` was missing from the temporary project template context, so the Corp BP toggle always rendered unchecked after reload regardless of saved state.
 - Structure tab: Category Assignments rows were grouped by broad service category (`manufacturing`, `composite_reactions`) instead of the more useful craft group name (`Construction Components`, `Fuel Block`, etc.).
-- Locations: NPC station names (IDs 60 000 000–69 999 999) were stored as `Structure <id>` placeholders instead of their real names. The dedicated public `GET /universe/stations/{station_id}/` endpoint is now used for this ID range rather than the generic `POST /universe/names/` batch endpoint.
-- Structure tab: Category Assignments rows were grouped by broad service category (`manufacturing`, `composite_reactions`) instead of the more useful craft group name (`Construction Components`, `Fuel Block`, etc.).
+- Locations: NPC station names (IDs 60 000 000–69 999 999) were stored as `Structure <id>` placeholders instead of their real names. Indy Hub now uses the dedicated public `GET /universe/stations/{station_id}/` endpoint for this range, bypasses stale ETag-driven `304 Not Modified` failures during repair runs, and reuses local ESI cooldown state to avoid hammering the station endpoint when rate-limit headers indicate low remaining budget.
+- Locations: large IDs (`>= 1 000 000 000 000`) that are only non-deployed asset item IDs are no longer sent to the authenticated structure endpoint. Repair flows now relabel them locally as asset items instead of wasting ESI calls on lookups that can never resolve.
 
 ## [1.18.2] - 2026-08-01
 

--- a/indy_hub/management/commands/populate_location_names.py
+++ b/indy_hub/management/commands/populate_location_names.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 # Django
 from django.apps import apps
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 # Alliance Auth
 from allianceauth.services.hooks import get_extension_logger
@@ -18,6 +19,7 @@ from indy_hub.utils.eve import (
     _STATION_ID_MAX,
     _STATION_ID_MIN,
     PLACEHOLDER_PREFIX,
+    get_type_name,
     resolve_location_name,
 )
 
@@ -61,9 +63,8 @@ class Command(BaseCommand):
             dest="repair_stations",
             action="store_true",
             help=(
-                "Find all CachedStructureName rows whose name is a placeholder "
-                "(Structure <id>) for NPC station IDs (60 000 000–69 999 999) "
-                "and re-resolve them using the public /universe/stations/ endpoint. "
+                "Repair placeholder location names by re-resolving NPC stations "
+                "(60 000 000–69 999 999) and relabelling non-deployed asset-item IDs. "
                 "Combine with --dry-run to only report without writing."
             ),
         )
@@ -155,7 +156,7 @@ class Command(BaseCommand):
             )
 
     def _repair_station_names(self, *, dry_run: bool) -> None:
-        """Re-resolve all CachedStructureName placeholders for NPC station IDs."""
+        """Re-resolve NPC station placeholders and label non-deployed asset item placeholders."""
         try:
             cached_model = apps.get_model("indy_hub", "CachedStructureName")
         except Exception as exc:
@@ -164,7 +165,8 @@ class Command(BaseCommand):
             )
             return
 
-        placeholder_rows = list(
+        # NPC stations (60 000 000 – 69 999 999): re-resolve via ESI
+        station_rows = list(
             cached_model.objects.filter(
                 structure_id__gte=_STATION_ID_MIN,
                 structure_id__lte=_STATION_ID_MAX,
@@ -172,26 +174,69 @@ class Command(BaseCommand):
             ).values_list("structure_id", flat=True)
         )
 
-        if not placeholder_rows:
-            self.stdout.write(self.style.SUCCESS("No placeholder station names found."))
+        # Large IDs (>= 1T) that are non-deployed asset items: label from type
+        try:
+            corp_model = apps.get_model("indy_hub", "CachedCorporationAsset")
+        except Exception:
+            corp_model = None
+        try:
+            char_model = apps.get_model("indy_hub", "CachedCharacterAsset")
+        except Exception:
+            char_model = None
+
+        asset_item_rows: list[tuple[int, int]] = []
+        if corp_model is not None or char_model is not None:
+            for sid in cached_model.objects.filter(
+                structure_id__gte=1_000_000_000_000,
+                name__startswith=PLACEHOLDER_PREFIX,
+            ).values_list("structure_id", flat=True):
+                sid = int(sid)
+                type_id = None
+                if corp_model is not None:
+                    row = (
+                        corp_model.objects.filter(item_id=sid)
+                        .values("location_id", "type_id")
+                        .first()
+                    )
+                    if row and int(row["location_id"] or 0) >= _STATION_ID_MIN:
+                        type_id = row["type_id"]
+                if type_id is None and char_model is not None:
+                    row = (
+                        char_model.objects.filter(item_id=sid)
+                        .values("location_id", "type_id")
+                        .first()
+                    )
+                    if row and int(row["location_id"] or 0) >= _STATION_ID_MIN:
+                        type_id = row["type_id"]
+                if type_id is not None:
+                    asset_item_rows.append((sid, int(type_id)))
+
+        if not station_rows and not asset_item_rows:
+            self.stdout.write(self.style.SUCCESS("No placeholder names to repair."))
             return
 
-        self.stdout.write(
-            f"Found {len(placeholder_rows)} station(s) with placeholder names "
-            f"(IDs {_STATION_ID_MIN:,}–{_STATION_ID_MAX:,})."
-        )
+        if station_rows:
+            self.stdout.write(
+                f"Found {len(station_rows)} NPC station(s) with placeholder names."
+            )
+        if asset_item_rows:
+            self.stdout.write(
+                f"Found {len(asset_item_rows)} non-deployed asset item(s) with placeholder names."
+            )
 
         if dry_run:
             self.stdout.write(
-                self.style.WARNING("Dry-run: would repair the above stations.")
+                self.style.WARNING("Dry-run: would repair the above entries.")
             )
             return
 
         fixed = 0
         failed = 0
-        for station_id in placeholder_rows:
+
+        for station_id in station_rows:
             name = resolve_location_name(int(station_id), force_refresh=True)
             if name and not name.startswith(PLACEHOLDER_PREFIX):
+                self._persist_repaired_name(cached_model, int(station_id), name)
                 fixed += 1
                 logger.info("Repaired station %s → %s", station_id, name)
             else:
@@ -200,8 +245,33 @@ class Command(BaseCommand):
                     "Could not resolve station %s (got: %s)", station_id, name
                 )
 
+        for sid, type_id in asset_item_rows:
+            type_name = get_type_name(type_id) or str(type_id)
+            resolved_name = f"{type_name} [asset]"
+            try:
+                self._persist_repaired_name(cached_model, sid, resolved_name)
+                fixed += 1
+                logger.info("Labelled non-deployed asset %s → %s", sid, resolved_name)
+            except Exception as exc:
+                failed += 1
+                logger.warning("Could not update asset item %s: %s", sid, exc)
+
         self.stdout.write(
-            self.style.SUCCESS(
-                f"Station name repair: {fixed} fixed, {failed} unresolved."
-            )
+            self.style.SUCCESS(f"Repair completed: {fixed} fixed, {failed} unresolved.")
+        )
+
+    def _persist_repaired_name(self, cached_model, location_id: int, name: str) -> None:
+        cached_model.objects.update_or_create(
+            structure_id=int(location_id),
+            defaults={"name": str(name), "last_resolved": timezone.now()},
+        )
+
+        blueprint_model = apps.get_model("indy_hub", "Blueprint")
+        blueprint_model.objects.filter(location_id=int(location_id)).update(
+            location_name=str(name)
+        )
+
+        industry_job_model = apps.get_model("indy_hub", "IndustryJob")
+        industry_job_model.objects.filter(station_id=int(location_id)).update(
+            location_name=str(name)
         )

--- a/indy_hub/management/commands/populate_location_names.py
+++ b/indy_hub/management/commands/populate_location_names.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 # Django
+from django.apps import apps
 from django.core.management.base import BaseCommand
 
 # Alliance Auth
@@ -13,6 +14,12 @@ from allianceauth.services.hooks import get_extension_logger
 
 # AA Example App
 from indy_hub.services.location_population import populate_location_names
+from indy_hub.utils.eve import (
+    _STATION_ID_MAX,
+    _STATION_ID_MIN,
+    PLACEHOLDER_PREFIX,
+    resolve_location_name,
+)
 
 logger = get_extension_logger(__name__)
 
@@ -49,12 +56,28 @@ class Command(BaseCommand):
             action="store_true",
             help="Queue the job asynchronously via Celery instead of running inline.",
         )
+        parser.add_argument(
+            "--repair-stations",
+            dest="repair_stations",
+            action="store_true",
+            help=(
+                "Find all CachedStructureName rows whose name is a placeholder "
+                "(Structure <id>) for NPC station IDs (60 000 000–69 999 999) "
+                "and re-resolve them using the public /universe/stations/ endpoint. "
+                "Combine with --dry-run to only report without writing."
+            ),
+        )
 
     def handle(self, *args, **options):
         location_ids: Iterable[int] | None = options.get("location_ids")
         force_refresh: bool = options.get("force_refresh", False)
         dry_run: bool = options.get("dry_run", False)
         enqueue: bool = options.get("enqueue", False)
+        repair_stations: bool = options.get("repair_stations", False)
+
+        if repair_stations:
+            self._repair_station_names(dry_run=dry_run)
+            return
 
         logger.info(
             "populate_location_names invoked (enqueue=%s, force_refresh=%s, dry_run=%s, location_ids=%s)",
@@ -130,3 +153,55 @@ class Command(BaseCommand):
             self.stdout.write(
                 self.style.WARNING("Dry-run mode: no records were updated.")
             )
+
+    def _repair_station_names(self, *, dry_run: bool) -> None:
+        """Re-resolve all CachedStructureName placeholders for NPC station IDs."""
+        try:
+            cached_model = apps.get_model("indy_hub", "CachedStructureName")
+        except Exception as exc:
+            self.stdout.write(
+                self.style.ERROR(f"CachedStructureName model not found: {exc}")
+            )
+            return
+
+        placeholder_rows = list(
+            cached_model.objects.filter(
+                structure_id__gte=_STATION_ID_MIN,
+                structure_id__lte=_STATION_ID_MAX,
+                name__startswith=PLACEHOLDER_PREFIX,
+            ).values_list("structure_id", flat=True)
+        )
+
+        if not placeholder_rows:
+            self.stdout.write(self.style.SUCCESS("No placeholder station names found."))
+            return
+
+        self.stdout.write(
+            f"Found {len(placeholder_rows)} station(s) with placeholder names "
+            f"(IDs {_STATION_ID_MIN:,}–{_STATION_ID_MAX:,})."
+        )
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING("Dry-run: would repair the above stations.")
+            )
+            return
+
+        fixed = 0
+        failed = 0
+        for station_id in placeholder_rows:
+            name = resolve_location_name(int(station_id), force_refresh=True)
+            if name and not name.startswith(PLACEHOLDER_PREFIX):
+                fixed += 1
+                logger.info("Repaired station %s → %s", station_id, name)
+            else:
+                failed += 1
+                logger.warning(
+                    "Could not resolve station %s (got: %s)", station_id, name
+                )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Station name repair: {fixed} fixed, {failed} unresolved."
+            )
+        )

--- a/indy_hub/services/esi_client.py
+++ b/indy_hub/services/esi_client.py
@@ -1328,7 +1328,20 @@ class ESIClient:
         except AttributeError:
             return None
         try:
-            payload = operation_fn(station_id=int(station_id)).results()
+            payload = operation_fn(station_id=int(station_id)).results(use_etag=False)
+        except HTTPNotModified:
+            # django-esi cache was stale; retry bypassing ETags entirely
+            try:
+                payload = operation_fn(station_id=int(station_id)).results(
+                    use_etag=False, force_refresh=True
+                )
+            except Exception as exc:
+                logger.debug(
+                    "fetch_station_name retry after 304 failed for %s: %s",
+                    station_id,
+                    exc,
+                )
+                return None
         except _DJANGO_ESI_RATE_LIMIT_ERRORS as exc:
             logger.warning(
                 "fetch_station_name rate limited for %s: %s", station_id, exc

--- a/indy_hub/services/esi_client.py
+++ b/indy_hub/services/esi_client.py
@@ -1317,6 +1317,31 @@ class ESIClient:
             force_refresh=force_refresh,
         )
 
+    def fetch_station_name(self, station_id: int) -> str | None:
+        """Resolve an NPC station name via the public /universe/stations/ endpoint (no auth)."""
+        if not station_id:
+            return None
+        try:
+            operation_fn = self._resolve_operation(
+                "Universe", "get_universe_stations_station_id"
+            )
+        except AttributeError:
+            return None
+        try:
+            payload = operation_fn(station_id=int(station_id)).results()
+        except _DJANGO_ESI_RATE_LIMIT_ERRORS as exc:
+            logger.warning(
+                "fetch_station_name rate limited for %s: %s", station_id, exc
+            )
+            return None
+        except _HTTP_ERROR_TYPES as exc:
+            logger.debug("fetch_station_name HTTP error for %s: %s", station_id, exc)
+            return None
+        except Exception as exc:
+            logger.debug("fetch_station_name failed for %s: %s", station_id, exc)
+            return None
+        return str(payload.get("name") or "") or None
+
     def resolve_ids_to_names(self, ids: list[int]) -> dict[int, str]:
         """Resolve a list of IDs to names via the public /universe/names/ endpoint.
 

--- a/indy_hub/services/esi_client.py
+++ b/indy_hub/services/esi_client.py
@@ -1340,7 +1340,18 @@ class ESIClient:
         except Exception as exc:
             logger.debug("fetch_station_name failed for %s: %s", station_id, exc)
             return None
-        return str(payload.get("name") or "") or None
+        if isinstance(payload, list):
+            payload = payload[0] if payload else None
+        if isinstance(payload, dict):
+            return str(payload.get("name") or "") or None
+        coerced = self._coerce_mapping(payload) if payload is not None else None
+        if isinstance(coerced, dict):
+            return str(coerced.get("name") or "") or None
+        if payload is not None:
+            name = getattr(payload, "name", None)
+            if name:
+                return str(name)
+        return None
 
     def resolve_ids_to_names(self, ids: list[int]) -> dict[int, str]:
         """Resolve a list of IDs to names via the public /universe/names/ endpoint.

--- a/indy_hub/services/esi_client.py
+++ b/indy_hub/services/esi_client.py
@@ -1321,19 +1321,37 @@ class ESIClient:
         """Resolve an NPC station name via the public /universe/stations/ endpoint (no auth)."""
         if not station_id:
             return None
+        endpoint = f"/universe/stations/{int(station_id)}/"
+        throttle_key = "public-station"
         try:
             operation_fn = self._resolve_operation(
                 "Universe", "get_universe_stations_station_id"
             )
         except AttributeError:
             return None
+        self._enforce_task_scope_budget(None, endpoint, throttle_key=throttle_key)
         try:
-            payload = operation_fn(station_id=int(station_id)).results(use_etag=False)
+            payload, response = operation_fn(station_id=int(station_id)).results(
+                return_response=True,
+                use_etag=False,
+            )
+            self._update_rate_limit_state_from_response(
+                response=response,
+                endpoint=endpoint,
+                throttle_key=throttle_key,
+            )
         except HTTPNotModified:
             # django-esi cache was stale; retry bypassing ETags entirely
             try:
-                payload = operation_fn(station_id=int(station_id)).results(
-                    use_etag=False, force_refresh=True
+                payload, response = operation_fn(station_id=int(station_id)).results(
+                    return_response=True,
+                    use_etag=False,
+                    force_refresh=True,
+                )
+                self._update_rate_limit_state_from_response(
+                    response=response,
+                    endpoint=endpoint,
+                    throttle_key=throttle_key,
                 )
             except Exception as exc:
                 logger.debug(

--- a/indy_hub/services/location_population.py
+++ b/indy_hub/services/location_population.py
@@ -252,7 +252,7 @@ def populate_location_names(
             schedule_async
             and not force_refresh
             and not is_station_id(location_id)
-            and location_id > 2_147_483_647
+            and location_id >= 1_000_000_000_000
             and _is_placeholder(resolved_name)
             and location_id not in queued_structures
         ):

--- a/indy_hub/tasks/industry.py
+++ b/indy_hub/tasks/industry.py
@@ -2732,7 +2732,17 @@ def update_type_names():
     )
 
 
-@shared_task(bind=True, max_retries=0)
+@shared_task(
+    bind=True,
+    base=QueueOnce,
+    max_retries=0,
+    once={
+        "graceful": True,
+        "keys": ["location_ids", "force_refresh", "dry_run"],
+    },
+    # This task can fan out into many location lookups; keep starts conservative.
+    rate_limit="2/m",
+)
 @rate_limit_retry_task
 def populate_location_names_async(
     self, location_ids=None, force_refresh=False, dry_run=False

--- a/indy_hub/utils/eve.py
+++ b/indy_hub/utils/eve.py
@@ -954,6 +954,36 @@ def resolve_location_name(
     remaining_attempts = _MAX_STRUCTURE_LOOKUPS
     structure_forbidden_hit = False
 
+    # Skip ESI for large IDs that appear in the asset cache as non-deployed items
+    # (e.g. items in a station or inside another item).  Only IDs located directly
+    # in a solar system (location_id < 60 000 000) are deployed structures worth
+    # querying ESI for.
+    if structure_id >= 1_000_000_000_000:
+        try:
+            corp_asset_model = apps.get_model("indy_hub", "CachedCorporationAsset")
+            corp_loc = (
+                corp_asset_model.objects.filter(item_id=structure_id)
+                .values_list("location_id", flat=True)
+                .first()
+            )
+            if corp_loc is not None and int(corp_loc) >= _STATION_ID_MIN:
+                allow_authenticated = False
+        except Exception:
+            pass
+
+        if allow_authenticated:
+            try:
+                char_asset_model = apps.get_model("indy_hub", "CachedCharacterAsset")
+                char_loc = (
+                    char_asset_model.objects.filter(item_id=structure_id)
+                    .values_list("location_id", flat=True)
+                    .first()
+                )
+                if char_loc is not None and int(char_loc) >= _STATION_ID_MIN:
+                    allow_authenticated = False
+            except Exception:
+                pass
+
     def try_structure_lookup(
         candidate_character_id: int | None,
         *,

--- a/indy_hub/utils/eve.py
+++ b/indy_hub/utils/eve.py
@@ -1073,9 +1073,10 @@ def resolve_location_name(
 
     if allow_public and not name:
         if is_station:
-            # NPC stations: dedicated public endpoint, no auth required
+            # NPC stations (60 000 000–69 999 999): public endpoint, no auth required
             name = shared_client.fetch_station_name(structure_id)
-        if not name and structure_id <= 2_147_483_647:
+        elif structure_id < 1_000_000_000_000:
+            # Misc public IDs (celestials, solar systems, etc.) — not stations, not player structures
             public_names = shared_client.resolve_ids_to_names([structure_id])
             name = public_names.get(structure_id)
 

--- a/indy_hub/utils/eve.py
+++ b/indy_hub/utils/eve.py
@@ -1070,7 +1070,7 @@ def resolve_location_name(
     if (
         allow_authenticated
         and not is_station
-        and structure_id > 2_147_483_647
+        and structure_id >= 1_000_000_000_000
         and global_rate_limit_pause <= 0
     ):
         name = try_structure_lookup(character_id)

--- a/indy_hub/utils/eve.py
+++ b/indy_hub/utils/eve.py
@@ -1072,7 +1072,10 @@ def resolve_location_name(
                     break
 
     if allow_public and not name:
-        if structure_id <= 2_147_483_647:
+        if is_station:
+            # NPC stations: dedicated public endpoint, no auth required
+            name = shared_client.fetch_station_name(structure_id)
+        if not name and structure_id <= 2_147_483_647:
             public_names = shared_client.resolve_ids_to_names([structure_id])
             name = public_names.get(structure_id)
 


### PR DESCRIPTION
## Summary

Fix location-name resolution for NPC stations and large non-deployed asset item IDs.

### Fixed

- NPC station IDs (`60 000 000–69 999 999`) now resolve through the dedicated public `GET /universe/stations/{station_id}/` endpoint instead of falling back to `POST /universe/names/` and placeholder names.
- Station lookups now bypass stale django-esi ETag cache responses (`304 Not Modified`) so `populate_location_names --repair-stations` can actually recover real station names.
- Large IDs (`>= 1e12`) that are only asset `item_id`s stored in a station/container are no longer sent to the authenticated structure endpoint, since they are not deployed structures and can never resolve there.

### Added

- `python manage.py populate_location_names --repair-stations` now:
  - repairs NPC station placeholders via the correct ESI endpoint
  - relabels non-deployed asset-item placeholders as `<type name> [asset]`
  - writes the repaired value through to `CachedStructureName`, `Blueprint.location_name`, and `IndustryJob.location_name`
  - supports `--dry-run`

### Notes

This branch is based on `feat/favorite-production-structures` so the PR only contains the location-resolution fixes added after that branch.
