### PR TITLE
Harden settings usage tracking and admin views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Location-name repair/sync flows now use stricter station/public-endpoint semantics and safer handling for large non-deployed asset-item IDs.
 - Async location-name population now uses stronger dedupe/rate-limit protections to reduce duplicate background fan-out.
 - Settings / User admin access policy is explicitly superuser-only, and UI/docs/tests were aligned to that rule.
+- Settings / User admin: usage tracking excludes the admin-users page itself from counted page hits to keep the analytics scope aligned with end-user activity.
+- Usage tracking middleware: global tracking is now explicit opt-in and allowlisted by app name, reducing accidental capture outside intended Indy Hub routes.
+- Settings / User admin: sensitive actions that mutate state are now enforced as POST-only flows.
 
 ### Fixed
 
@@ -36,12 +39,9 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Locations: large IDs (`>= 1 000 000 000 000`) that are non-deployed asset-item IDs are no longer sent to authenticated structure lookups; repair flows relabel them locally as asset items.
 - Settings / User admin: token-scope coverage and usage/health aggregation paths were hardened for consistency and edge cases.
 - CharLink / scope-health display: users are no longer incorrectly shown as fully `OK` when required scopes are split across multiple tokens; scope completeness is now evaluated per token before user-level aggregation.
-- Settings / User admin: sensitive actions that mutate state are now enforced as POST-only flows.
 - Settings / User admin: 7-day and 30-day usage metrics now remain accurate over time by using rolling-window read-time aggregation.
-- Settings / User admin: usage tracking now excludes the admin-users page itself from counted page hits to avoid analytics self-inflation.
 - Settings / User admin: unauthorized users now receive explicit `403` responses instead of redirect loops toward protected Indy Hub pages.
 - Industry Jobs pages: `page` / `per_page` parsing is now bounded and fault-tolerant, preventing invalid query values from crashing or forcing oversized result pages.
-- Usage tracking middleware: global tracking is now explicit opt-in and allowlisted by app name, reducing accidental capture outside intended Indy Hub routes.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,13 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Crafting Projects / Blueprint tab: added a Corp BP toggle to switch personal/corporation blueprint sourcing; corp BPs with better ME/TE are used automatically and marked with a `CORP BP` badge.
 - Crafting Projects (temporary projects): Corp BP toggle state now persists across reloads through the temporary workspace cache flow.
 - Settings: added private `Settings > User admin` page (superuser-only) with scope/usage filters, health scoring, per-user usage detail, and global 30-day page-usage analytics (`Pages visited (30d)`).
-- Usage analytics: added persistent `IndyHubUserUsage` tracking with rolling daily counters and per-page usage snapshots.
+- Usage analytics: added rolling daily counters and per-page usage snapshots.
 - Management command: `populate_location_names --repair-stations` repairs placeholder location names by re-resolving NPC station IDs and relabelling non-deployed asset-item IDs as `<type name> [asset]` (supports `--dry-run`).
 
 ### Changed
 
-- Location-name repair/sync flows now use stricter station/public-endpoint semantics and safer handling for large non-deployed asset-item IDs.
-- Async location-name population now uses stronger dedupe/rate-limit protections to reduce duplicate background fan-out.
-- Settings / User admin access policy is explicitly superuser-only, and UI/docs/tests were aligned to that rule.
-- Settings / User admin: usage tracking excludes the admin-users page itself from counted page hits to keep the analytics scope aligned with end-user activity.
-- Usage tracking middleware: global tracking is now explicit opt-in and allowlisted by app name, reducing accidental capture outside intended Indy Hub routes.
-- Settings / User admin: sensitive actions that mutate state are now enforced as POST-only flows.
+- Location-name repair/sync flows now resolve station names more reliably and avoid misclassifying large non-deployed asset-item IDs.
+- Location-name background refresh now avoids duplicate bursts, resulting in more stable updates under load.
 
 ### Fixed
 
@@ -35,13 +31,12 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Structure tab: category assignment rows are grouped by craft group name (for example `Construction Components`, `Fuel Block`) instead of broad service category.
 - Crafting Projects / Blueprint tab: fixed multiple corp-BP toggle persistence and reload edge cases, including missing temporary `workspace_state` context and stale/default toggle behavior.
 - Crafting Projects / Blueprint sourcing: corp BPs are now included in temporary project inventory and correctly selected when they outperform personal BPs on ME.
-- Locations: NPC station placeholders (`Structure <id>`) are repaired through the dedicated public station endpoint, including ETag/304 fallback handling and local cooldown-aware retry behavior.
-- Locations: large IDs (`>= 1 000 000 000 000`) that are non-deployed asset-item IDs are no longer sent to authenticated structure lookups; repair flows relabel them locally as asset items.
-- Settings / User admin: token-scope coverage and usage/health aggregation paths were hardened for consistency and edge cases.
+- Locations: NPC station placeholders (`Structure <id>`) are now repaired more reliably, including when upstream responses are cached or delayed.
+- Locations: very large non-deployed asset-item IDs are no longer looked up as structures, preventing wrong labels and noisy retries.
 - CharLink / scope-health display: users are no longer incorrectly shown as fully `OK` when required scopes are split across multiple tokens; scope completeness is now evaluated per token before user-level aggregation.
-- Settings / User admin: 7-day and 30-day usage metrics now remain accurate over time by using rolling-window read-time aggregation.
-- Settings / User admin: unauthorized users now receive explicit `403` responses instead of redirect loops toward protected Indy Hub pages.
-- Industry Jobs pages: `page` / `per_page` parsing is now bounded and fault-tolerant, preventing invalid query values from crashing or forcing oversized result pages.
+- Settings / User admin: 7-day and 30-day usage metrics now stay accurate over time.
+- Settings / User admin: unauthorized users now receive explicit `403` responses instead of redirect loops.
+- Industry Jobs pages: invalid `page` / `per_page` values are now handled safely, preventing crashes and oversized result pages.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,31 +11,39 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 
 ### Added
 
-- Structure Registry: users can now **star (★) production structures** as favorites directly on the `/indy_hub/industry/structures/` page.
-- Structure tab: favorite structures appear first in all assignment dropdowns with a ★ prefix and are pre-selected as the default recommendation when no explicit structure has been chosen.
-- Crafting Projects: new **Corp BP toggle** in the Blueprint tab lets users switch between personal and corporation blueprints. When enabled, corp BPs with better ME/TE than personal are used automatically in material calculations, with a blue "CORP BP" badge on affected blueprint cards.
-- Crafting Projects: temporary projects now persist the Corp BP toggle state across page reloads via a dedicated cache endpoint, so the choice survives without saving the project.
-- Structure tab: new **Category Assignments** section lets users apply a structure to all items of the same craft group (e.g. "Construction Components", "Fuel Block") at once.
-- Management command: `populate_location_names --repair-stations` repairs placeholder location names by re-resolving NPC station IDs via the corrected public endpoint and relabelling non-deployed asset-item IDs as `<type name> [asset]`. Supports `--dry-run`.
-- Settings: added a private `Settings > User admin` page for superusers only, with scope/usage filters, health scoring, and detailed usage analytics.
-- Settings / User admin: added per-user usage detail modal plus a global all-users section with 30-day page-consultation analytics (`Pages visited (30d)`).
-- Usage analytics: added persistent Indy Hub usage tracking (`IndyHubUserUsage`) with rolling daily counters and per-page usage snapshots.
+- Structure Registry: users can now star (★) production structures directly on `/indy_hub/industry/structures/`.
+- Crafting Projects / Structure tab: favorite structures are prioritized in assignment dropdowns and used as default recommendations when no explicit structure is selected.
+- Crafting Projects / Structure tab: added Category Assignments to apply a structure to all items in the same craft group in one action.
+- Crafting Projects / Blueprint tab: added a Corp BP toggle to switch personal/corporation blueprint sourcing; corp BPs with better ME/TE are used automatically and marked with a `CORP BP` badge.
+- Crafting Projects (temporary projects): Corp BP toggle state now persists across reloads through the temporary workspace cache flow.
+- Settings: added private `Settings > User admin` page (superuser-only) with scope/usage filters, health scoring, per-user usage detail, and global 30-day page-usage analytics (`Pages visited (30d)`).
+- Usage analytics: added persistent `IndyHubUserUsage` tracking with rolling daily counters and per-page usage snapshots.
+- Management command: `populate_location_names --repair-stations` repairs placeholder location names by re-resolving NPC station IDs and relabelling non-deployed asset-item IDs as `<type name> [asset]` (supports `--dry-run`).
+
+### Changed
+
+- Location-name repair/sync flows now use stricter station/public-endpoint semantics and safer handling for large non-deployed asset-item IDs.
+- Async location-name population now uses stronger dedupe/rate-limit protections to reduce duplicate background fan-out.
+- Settings / User admin access policy is explicitly superuser-only, and UI/docs/tests were aligned to that rule.
+
 
 ### Fixed
 
-- Structure tab: favorite structure was not pre-selected when the user had no explicit prior assignment for a given item.
-- Crafting Projects: corp BPs were excluded from temporary project inventory; they are now included when the toggle is enabled and the user has access to the relevant corporation.
-- Crafting Projects: corp BPs with better ME than the user's personal BP were not used in calculations (they only acted as fallback when no personal BP existed at all).
-- Crafting Projects: `workspace_state` was missing from the temporary project template context, so the Corp BP toggle always rendered unchecked after reload regardless of saved state.
-- Structure tab: Category Assignments rows were grouped by broad service category (`manufacturing`, `composite_reactions`) instead of the more useful craft group name (`Construction Components`, `Fuel Block`, etc.).
-- Locations: NPC station names (IDs 60 000 000–69 999 999) were stored as `Structure <id>` placeholders instead of their real names. Indy Hub now uses the dedicated public `GET /universe/stations/{station_id}/` endpoint for this range, bypasses stale ETag-driven `304 Not Modified` failures during repair runs, and reuses local ESI cooldown state to avoid hammering the station endpoint when rate-limit headers indicate low remaining budget.
-- Locations: large IDs (`>= 1 000 000 000 000`) that are only non-deployed asset item IDs are no longer sent to the authenticated structure endpoint. Repair flows now relabel them locally as asset items instead of wasting ESI calls on lookups that can never resolve.
-- Settings: private user-admin scope checks now batch token-scope coverage lookups instead of repeating per-user scope queries during page render.
+- Structure tab: favorite structure defaulting now behaves correctly when no prior per-item assignment exists.
+- Structure tab: category assignment rows are grouped by craft group name (for example `Construction Components`, `Fuel Block`) instead of broad service category.
+- Crafting Projects / Blueprint tab: fixed multiple corp-BP toggle persistence and reload edge cases, including missing temporary `workspace_state` context and stale/default toggle behavior.
+- Crafting Projects / Blueprint sourcing: corp BPs are now included in temporary project inventory and correctly selected when they outperform personal BPs on ME.
+- Locations: NPC station placeholders (`Structure <id>`) are repaired through the dedicated public station endpoint, including ETag/304 fallback handling and local cooldown-aware retry behavior.
+- Locations: large IDs (`>= 1 000 000 000 000`) that are non-deployed asset-item IDs are no longer sent to authenticated structure lookups; repair flows relabel them locally as asset items.
+- Settings / User admin: token-scope coverage and usage/health aggregation paths were hardened for consistency and edge cases.
+
 
 ### Internal
 
-- Migrations: added `0112_indyhubuserusage` for user usage tracking and merged the former follow-up `0113` field addition into the same migration for a cleaner upgrade path.
-- Tests: added focused coverage for user-admin visibility rules, user-admin view behavior, health scoring, and usage tracking/regression paths.
+- Service-layer refactor: consolidated industry-related logic into dedicated helper modules (eligibility, chat/offer actions, estimated values, task helpers, temporary workspace helpers) to reduce coupling in large view/task paths.
+- Migrations: added `0111_add_user_favorite_structure` and `0112_indyhubuserusage` (with the former `0113` field addition merged into `0112` for a cleaner upgrade path).
+- Tests: added/extended focused coverage for favorites toggles, user-admin visibility/view behavior, health scoring, usage tracking, craft payload API behavior, and industry chat services.
+
 
 ## [1.18.2] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Locations: NPC station placeholders (`Structure <id>`) are repaired through the dedicated public station endpoint, including ETag/304 fallback handling and local cooldown-aware retry behavior.
 - Locations: large IDs (`>= 1 000 000 000 000`) that are non-deployed asset-item IDs are no longer sent to authenticated structure lookups; repair flows relabel them locally as asset items.
 - Settings / User admin: token-scope coverage and usage/health aggregation paths were hardened for consistency and edge cases.
+- CharLink / scope-health display: users are no longer incorrectly shown as fully `OK` when required scopes are split across multiple tokens; scope completeness is now evaluated per token before user-level aggregation.
+- Settings / User admin: sensitive actions that mutate state are now enforced as POST-only flows.
+- Settings / User admin: 7-day and 30-day usage metrics now remain accurate over time by using rolling-window read-time aggregation.
+- Settings / User admin: usage tracking now excludes the admin-users page itself from counted page hits to avoid analytics self-inflation.
+- Settings / User admin: unauthorized users now receive explicit `403` responses instead of redirect loops toward protected Indy Hub pages.
+- Industry Jobs pages: `page` / `per_page` parsing is now bounded and fault-tolerant, preventing invalid query values from crashing or forcing oversized result pages.
+- Usage tracking middleware: global tracking is now explicit opt-in and allowlisted by app name, reducing accidental capture outside intended Indy Hub routes.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Async location-name population now uses stronger dedupe/rate-limit protections to reduce duplicate background fan-out.
 - Settings / User admin access policy is explicitly superuser-only, and UI/docs/tests were aligned to that rule.
 
-
 ### Fixed
 
 - Structure tab: favorite structure defaulting now behaves correctly when no prior per-item assignment exists.
@@ -37,13 +36,11 @@ Entries should stay short and grouped by meaningful outcomes. Each release shoul
 - Locations: large IDs (`>= 1 000 000 000 000`) that are non-deployed asset-item IDs are no longer sent to authenticated structure lookups; repair flows relabel them locally as asset items.
 - Settings / User admin: token-scope coverage and usage/health aggregation paths were hardened for consistency and edge cases.
 
-
 ### Internal
 
 - Service-layer refactor: consolidated industry-related logic into dedicated helper modules (eligibility, chat/offer actions, estimated values, task helpers, temporary workspace helpers) to reduce coupling in large view/task paths.
 - Migrations: added `0111_add_user_favorite_structure` and `0112_indyhubuserusage` (with the former `0113` field addition merged into `0112` for a cleaner upgrade path).
 - Tests: added/extended focused coverage for favorites toggles, user-admin visibility/view behavior, health scoring, usage tracking, craft payload API behavior, and industry chat services.
-
 
 ## [1.18.2] - 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,36 @@ INDY_HUB_INDUSTRY_JOBS_BULK_WINDOW_MINUTES = 0  # Default: 0
 INDY_HUB_SKILL_SNAPSHOT_STALE_HOURS = 24  # Default: 24
 INDY_HUB_ROLE_SNAPSHOT_STALE_HOURS = 24  # Default: 24
 INDY_HUB_STRUCTURE_NAME_STALE_HOURS = 24  # Default: 24
+
+# Optional: global usage tracking middleware (explicit opt-in)
+INDY_HUB_USAGE_MIDDLEWARE_ENABLED = False  # Default: False
+INDY_HUB_USAGE_MIDDLEWARE_ALLOWED_APP_NAMES = ("indy_hub",)  # Default scope
 ```
+
+### Optional Global Usage Tracking Middleware
+
+- By default, Indy Hub usage tracking is performed by Indy Hub view decorators.
+- To track Indy Hub requests globally, explicitly enable the middleware below.
+- The middleware records only allowlisted app routes and stores normalized route keys (`route:app:view`) instead of raw URL paths.
+
+Add to `MIDDLEWARE` in `local.py` (after authentication/session middleware):
+
+```python
+MIDDLEWARE = [
+    # ... existing middleware ...
+    "indy_hub.middleware.IndyHubUsageTrackingMiddleware",
+]
+```
+
+Recommended scope configuration:
+
+```python
+# Keep scope explicit; default tracks Indy Hub routes only.
+INDY_HUB_USAGE_MIDDLEWARE_ENABLED = True
+INDY_HUB_USAGE_MIDDLEWARE_ALLOWED_APP_NAMES = ("indy_hub",)
+```
+
+If you broaden `INDY_HUB_USAGE_MIDDLEWARE_ALLOWED_APP_NAMES`, only include app names you intentionally want in usage analytics.
 
 Notification dispatch modes:
 

--- a/indy_hub/decorators.py
+++ b/indy_hub/decorators.py
@@ -3,7 +3,7 @@
 from functools import wraps
 
 # Django
-from django.contrib import messages
+from django.http import HttpResponseForbidden
 from django.shortcuts import redirect
 
 # AA Example App
@@ -17,8 +17,9 @@ def indy_hub_access_required(view_func):
         if not request.user.is_authenticated:
             return redirect("auth_login_user")
         if not request.user.has_perm("indy_hub.can_access_indy_hub"):
-            messages.error(request, "You do not have permission to access Indy Hub.")
-            return redirect("indy_hub:index")
+            return HttpResponseForbidden(
+                "You do not have permission to access Indy Hub."
+            )
         track_indy_hub_usage_once_per_request(request)
         return view_func(request, *args, **kwargs)
 
@@ -35,10 +36,9 @@ def indy_hub_permission_required(permission_codename):
                 return redirect("auth_login_user")
             full_codename = f"indy_hub.{permission_codename}"
             if not request.user.has_perm(full_codename):
-                messages.error(
-                    request, "You do not have the required Indy Hub permission."
+                return HttpResponseForbidden(
+                    "You do not have the required Indy Hub permission."
                 )
-                return redirect("indy_hub:index")
             track_indy_hub_usage_once_per_request(request)
             return view_func(request, *args, **kwargs)
 

--- a/indy_hub/middleware.py
+++ b/indy_hub/middleware.py
@@ -3,22 +3,50 @@
 from __future__ import annotations
 
 # Django
+from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
 # AA Example App
 # Local
 from indy_hub.services.user_usage import (
     is_usage_tracking_path_excluded,
-    track_indy_hub_usage_for_user,
+    track_indy_hub_usage_once_per_request,
 )
 
 
 class IndyHubUsageTrackingMiddleware(MiddlewareMixin):
-    """Record authenticated page views once per request."""
+    """Record authenticated page views once per request.
+
+    This middleware is intentionally opt-in and only tracks routes from an
+    explicit app-name allowlist to avoid recording sensitive dynamic URL paths.
+    """
 
     _EXCLUDED_PREFIXES = ("/static/", "/media/")
 
+    @staticmethod
+    def _is_enabled() -> bool:
+        return bool(getattr(settings, "INDY_HUB_USAGE_MIDDLEWARE_ENABLED", False))
+
+    @staticmethod
+    def _allowed_app_names() -> set[str]:
+        raw_value = getattr(
+            settings,
+            "INDY_HUB_USAGE_MIDDLEWARE_ALLOWED_APP_NAMES",
+            ("indy_hub",),
+        )
+        if isinstance(raw_value, str):
+            values = [raw_value]
+        elif isinstance(raw_value, (list, tuple, set)):
+            values = list(raw_value)
+        else:
+            values = ["indy_hub"]
+        normalized = {str(value).strip() for value in values if str(value).strip()}
+        return normalized or {"indy_hub"}
+
     def process_view(self, request, view_func, view_args, view_kwargs):
+        if not self._is_enabled():
+            return None
+
         if getattr(request, "_indy_hub_usage_tracked", False):
             return None
 
@@ -38,22 +66,20 @@ class IndyHubUsageTrackingMiddleware(MiddlewareMixin):
             return None
 
         resolver_match = getattr(request, "resolver_match", None)
-        app_names = tuple(getattr(resolver_match, "app_names", ()) or ())
-        if "indy_hub" in app_names:
-            page_label = (
-                getattr(resolver_match, "url_name", None)
-                or getattr(resolver_match, "view_name", None)
-                or getattr(resolver_match, "route", None)
-                or path
-            )
-            page_label = str(page_label).replace("_", " ").strip() or path
-        else:
-            page_label = path
+        if resolver_match is None:
+            return None
 
-        track_indy_hub_usage_for_user(
-            user,
-            page_path=path,
-            page_label=page_label,
-        )
-        request._indy_hub_usage_tracked = True
+        app_names = {
+            str(app_name).strip()
+            for app_name in (getattr(resolver_match, "app_names", ()) or ())
+            if str(app_name).strip()
+        }
+        if not app_names.intersection(self._allowed_app_names()):
+            return None
+
+        view_name = str(getattr(resolver_match, "view_name", None) or "").strip()
+        if not view_name:
+            return None
+
+        track_indy_hub_usage_once_per_request(request)
         return None

--- a/indy_hub/models.py
+++ b/indy_hub/models.py
@@ -1,7 +1,7 @@
 # Standard Library
 import random
 import secrets
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from decimal import ROUND_CEILING, Decimal
 
 # Django
@@ -996,6 +996,9 @@ class UserOnboardingProgress(models.Model):
 
 
 class IndyHubUserUsage(models.Model):
+    PAGE_USAGE_RETENTION_DAYS = 90
+    PAGE_USAGE_MAX_KEYS = 64
+
     """Simple usage history and rolling activity counters per user."""
 
     user = models.OneToOneField(
@@ -1095,7 +1098,41 @@ class IndyHubUserUsage(models.Model):
                 "last_used_at": moment.isoformat(),
                 "daily_usage": page_daily_usage,
             }
-            self.page_usage = normalized_page_usage
+
+            retention_cutoff = moment - timedelta(days=self.PAGE_USAGE_RETENTION_DAYS)
+
+            def _parse_entry_last_used(raw_value):
+                if not raw_value:
+                    return None
+                if hasattr(raw_value, "tzinfo"):
+                    return raw_value
+                try:
+                    return datetime.fromisoformat(str(raw_value))
+                except (TypeError, ValueError):
+                    return None
+
+            retained_page_usage: dict[str, dict[str, object]] = {}
+            for key, entry in normalized_page_usage.items():
+                if not isinstance(entry, dict):
+                    continue
+                last_used_at = _parse_entry_last_used(entry.get("last_used_at"))
+                if last_used_at and last_used_at < retention_cutoff:
+                    continue
+                retained_page_usage[str(key)] = entry
+
+            if len(retained_page_usage) > self.PAGE_USAGE_MAX_KEYS:
+                sorted_entries = sorted(
+                    retained_page_usage.items(),
+                    key=lambda item: (
+                        _parse_entry_last_used(item[1].get("last_used_at"))
+                        or datetime.min,
+                        int(item[1].get("total_usage_count") or 0),
+                    ),
+                    reverse=True,
+                )
+                retained_page_usage = dict(sorted_entries[: self.PAGE_USAGE_MAX_KEYS])
+
+            self.page_usage = retained_page_usage
 
 
 class UserFavoriteStructure(models.Model):

--- a/indy_hub/models.py
+++ b/indy_hub/models.py
@@ -2,6 +2,7 @@
 import random
 import secrets
 from datetime import date, datetime, timedelta
+from datetime import timezone as datetime_timezone
 from decimal import ROUND_CEILING, Decimal
 
 # Django
@@ -1111,21 +1112,35 @@ class IndyHubUserUsage(models.Model):
                 except (TypeError, ValueError):
                     return None
 
+            def _normalize_entry_last_used(raw_value):
+                parsed = _parse_entry_last_used(raw_value)
+                if not parsed:
+                    return None
+                if parsed.tzinfo is None:
+                    return parsed.replace(tzinfo=datetime_timezone.utc)
+                return parsed
+
             retained_page_usage: dict[str, dict[str, object]] = {}
             for key, entry in normalized_page_usage.items():
                 if not isinstance(entry, dict):
                     continue
-                last_used_at = _parse_entry_last_used(entry.get("last_used_at"))
+                last_used_at = _normalize_entry_last_used(entry.get("last_used_at"))
                 if last_used_at and last_used_at < retention_cutoff:
                     continue
                 retained_page_usage[str(key)] = entry
 
             if len(retained_page_usage) > self.PAGE_USAGE_MAX_KEYS:
+
+                def _entry_last_used_sort_value(entry) -> float:
+                    parsed = _normalize_entry_last_used(entry.get("last_used_at"))
+                    if not parsed:
+                        return float("-inf")
+                    return parsed.timestamp()
+
                 sorted_entries = sorted(
                     retained_page_usage.items(),
                     key=lambda item: (
-                        _parse_entry_last_used(item[1].get("last_used_at"))
-                        or datetime.min,
+                        _entry_last_used_sort_value(item[1]),
                         int(item[1].get("total_usage_count") or 0),
                     ),
                     reverse=True,

--- a/indy_hub/services/admin_user_bulk_actions.py
+++ b/indy_hub/services/admin_user_bulk_actions.py
@@ -42,9 +42,33 @@ def _build_scope_status_from_scope_names(scope_names: set[str]) -> dict[str, obj
     }
 
 
+def _merge_scope_statuses(
+    statuses: list[dict[str, object]],
+) -> dict[str, object]:
+    if not statuses:
+        return _build_scope_status_from_scope_names(set())
+
+    merged_flags: dict[str, bool] = {
+        label: False for label, _required_scopes in _SCOPE_REQUIREMENTS
+    }
+    for status in statuses:
+        status_flags = status.get("flags") or {}
+        for label in merged_flags:
+            merged_flags[label] = merged_flags[label] or bool(status_flags.get(label))
+
+    missing_labels = [
+        label for label, has_scope in merged_flags.items() if not has_scope
+    ]
+    return {
+        "flags": merged_flags,
+        "is_complete": all(merged_flags.values()),
+        "missing_labels": missing_labels,
+    }
+
+
 def collect_user_scope_status_map(user_ids: list[int]) -> dict[int, dict[str, object]]:
     normalized_user_ids = [int(user_id) for user_id in user_ids if user_id]
-    scope_names_by_user_id: dict[int, set[str]] = defaultdict(set)
+    scope_statuses_by_user_id: dict[int, list[dict[str, object]]] = defaultdict(list)
 
     if normalized_user_ids:
         tokens = (
@@ -53,15 +77,18 @@ def collect_user_scope_status_map(user_ids: list[int]) -> dict[int, dict[str, ob
             .prefetch_related("scopes")
         )
         for token in tokens:
-            scope_names_by_user_id[int(token.user_id)].update(
-                str(scope_name)
-                for scope_name in token.scopes.values_list("name", flat=True)
-                if scope_name
+            scope_names = {
+                str(scope.name)
+                for scope in token.scopes.all()
+                if getattr(scope, "name", None)
+            }
+            scope_statuses_by_user_id[int(token.user_id)].append(
+                _build_scope_status_from_scope_names(scope_names)
             )
 
     return {
-        int(user_id): _build_scope_status_from_scope_names(
-            scope_names_by_user_id.get(int(user_id), set())
+        int(user_id): _merge_scope_statuses(
+            scope_statuses_by_user_id.get(int(user_id), [])
         )
         for user_id in normalized_user_ids
     }

--- a/indy_hub/services/user_usage.py
+++ b/indy_hub/services/user_usage.py
@@ -37,7 +37,12 @@ _PAGE_RING_PALETTE = (
 
 _USAGE_EXCLUDED_PATHS = {
     "/user_notifications_count/",
-    "/indy_hub/settings/admin-users/",
+}
+_USAGE_EXCLUDED_ROUTE_NAMES = {
+    "indy_hub:settings_admin_users_global_usage_fragment",
+    "indy_hub:settings_admin_users_usage_detail_fragment",
+    "settings_admin_users_global_usage_fragment",
+    "settings_admin_users_usage_detail_fragment",
 }
 _USAGE_REQUEST_DEBOUNCE_SECONDS = 60
 
@@ -47,6 +52,9 @@ def is_usage_tracking_path_excluded(path: str | None) -> bool:
     normalized_path = str(path or "").strip()
     if not normalized_path:
         return True
+    if normalized_path.startswith("route:"):
+        route_name = normalized_path.split("route:", 1)[1].strip()
+        return route_name in _USAGE_EXCLUDED_ROUTE_NAMES
     # Ignore query string/fragments and normalize trailing slash variants.
     split_path = urlsplit(normalized_path).path.strip()
     if split_path and split_path != "/":
@@ -57,6 +65,21 @@ def is_usage_tracking_path_excluded(path: str | None) -> bool:
     return (
         normalized_path in _USAGE_EXCLUDED_PATHS
         or f"{normalized_path}/" in _USAGE_EXCLUDED_PATHS
+    )
+
+
+def is_usage_tracking_route_excluded(resolver_match) -> bool:
+    """Return True when a resolved route should not be counted in usage metrics."""
+    if not resolver_match:
+        return False
+
+    route_candidates = {
+        str(getattr(resolver_match, "view_name", "") or "").strip(),
+        str(getattr(resolver_match, "url_name", "") or "").strip(),
+    }
+    route_candidates.discard("")
+    return any(
+        candidate in _USAGE_EXCLUDED_ROUTE_NAMES for candidate in route_candidates
     )
 
 
@@ -639,6 +662,9 @@ def track_indy_hub_usage_once_per_request(request) -> None:
         return
 
     resolver_match = getattr(request, "resolver_match", None)
+    if is_usage_tracking_route_excluded(resolver_match):
+        return
+
     page_label = (
         getattr(resolver_match, "url_name", None)
         or getattr(resolver_match, "view_name", None)

--- a/indy_hub/services/user_usage.py
+++ b/indy_hub/services/user_usage.py
@@ -5,16 +5,23 @@ from __future__ import annotations
 # Standard Library
 import math
 from datetime import date, datetime, timedelta
+from hashlib import sha1
 from types import SimpleNamespace
 from urllib.parse import urlsplit
 
 # Django
+from django.core.cache import cache
 from django.db import transaction
 from django.utils import timezone
+
+# Alliance Auth
+from allianceauth.services.hooks import get_extension_logger
 
 # AA Example App
 # Local
 from indy_hub.models import IndyHubUserUsage
+
+logger = get_extension_logger(__name__)
 
 USAGE_HISTORY_WINDOW_DAYS = 30
 _PAGE_RING_PALETTE = (
@@ -30,7 +37,9 @@ _PAGE_RING_PALETTE = (
 
 _USAGE_EXCLUDED_PATHS = {
     "/user_notifications_count/",
+    "/indy_hub/settings/admin-users/",
 }
+_USAGE_REQUEST_DEBOUNCE_SECONDS = 60
 
 
 def is_usage_tracking_path_excluded(path: str | None) -> bool:
@@ -78,6 +87,48 @@ def _parse_iso_datetime(raw_value):
         return datetime.fromisoformat(str(raw_value))
     except (TypeError, ValueError):
         return None
+
+
+def calculate_recent_activity_counts(
+    raw_counts,
+    *,
+    reference_day: date | None = None,
+) -> tuple[int, int]:
+    normalized_counts = _normalize_daily_counts(raw_counts)
+    day_ref = reference_day or timezone.localdate()
+    start_30d = day_ref - timedelta(days=29)
+    start_7d = day_ref - timedelta(days=6)
+
+    activity_30d_count = sum(
+        count
+        for day_key, count in normalized_counts.items()
+        if date.fromisoformat(day_key) >= start_30d
+    )
+    activity_7d_count = sum(
+        count
+        for day_key, count in normalized_counts.items()
+        if date.fromisoformat(day_key) >= start_7d
+    )
+    return activity_7d_count, activity_30d_count
+
+
+def _build_usage_route_key(resolver_match) -> str | None:
+    if not resolver_match:
+        return None
+
+    view_name = str(
+        getattr(resolver_match, "view_name", None)
+        or getattr(resolver_match, "url_name", None)
+        or ""
+    ).strip()
+    if not view_name:
+        return None
+    return f"route:{view_name}"
+
+
+def _usage_request_debounce_cache_key(*, user_id: int, page_key: str) -> str:
+    digest = sha1(page_key.encode("utf-8")).hexdigest()[:20]
+    return f"indy_hub:usage:debounce:{int(user_id)}:{digest}"
 
 
 def build_usage_timeline(
@@ -183,7 +234,11 @@ def build_indy_hub_usage_detail(usage) -> dict[str, object]:
         }
 
     overall_daily_usage = _normalize_daily_counts(getattr(usage, "daily_usage", {}))
-    reference_day = timezone.localdate(usage.last_used_at or timezone.now())
+    reference_day = timezone.localdate()
+    activity_7d_count, activity_30d_count = calculate_recent_activity_counts(
+        overall_daily_usage,
+        reference_day=reference_day,
+    )
     overall_timeline_data = build_usage_timeline(
         overall_daily_usage,
         end_day=reference_day,
@@ -357,8 +412,8 @@ def build_indy_hub_usage_detail(usage) -> dict[str, object]:
         "first_used_at": _parse_iso_datetime(usage.first_used_at),
         "last_used_at": _parse_iso_datetime(usage.last_used_at),
         "total_usage_count": int(usage.total_usage_count or 0),
-        "activity_7d_count": int(usage.activity_7d_count or 0),
-        "activity_30d_count": int(usage.activity_30d_count or 0),
+        "activity_7d_count": int(activity_7d_count or 0),
+        "activity_30d_count": int(activity_30d_count or 0),
         "overall_timeline": overall_timeline,
         "active_days_30d": active_days_30d,
         "active_days_total": active_days_total,
@@ -473,19 +528,10 @@ def build_indy_hub_global_usage_detail(usages) -> dict[str, object]:
 
             aggregated_page_usage[page_key] = page_entry
 
-    reference_day = timezone.localdate(last_used_at or timezone.now())
-    start_30d = reference_day - timedelta(days=29)
-    start_7d = reference_day - timedelta(days=6)
-
-    activity_30d_count = sum(
-        count
-        for day_key, count in aggregated_daily_usage.items()
-        if date.fromisoformat(day_key) >= start_30d
-    )
-    activity_7d_count = sum(
-        count
-        for day_key, count in aggregated_daily_usage.items()
-        if date.fromisoformat(day_key) >= start_7d
+    reference_day = timezone.localdate()
+    activity_7d_count, activity_30d_count = calculate_recent_activity_counts(
+        aggregated_daily_usage,
+        reference_day=reference_day,
     )
 
     synthetic_usage = SimpleNamespace(
@@ -512,7 +558,11 @@ def build_indy_hub_global_usage_detail(usages) -> dict[str, object]:
                 [
                     usage
                     for usage in usage_list
-                    if int(getattr(usage, "activity_30d_count", 0) or 0) > 0
+                    if calculate_recent_activity_counts(
+                        getattr(usage, "daily_usage", {}),
+                        reference_day=reference_day,
+                    )[1]
+                    > 0
                 ]
             ),
             "timeline_30d": timeline_30d_data["timeline"],
@@ -536,14 +586,18 @@ def track_indy_hub_usage_for_user(
 
     normalized_page_path = None
     if page_path is not None:
-        normalized_page_path = urlsplit(str(page_path).strip()).path.strip()
-        if normalized_page_path and normalized_page_path != "/":
-            normalized_page_path = normalized_page_path.rstrip("/")
-        normalized_page_path = normalized_page_path or "/"
-        if not normalized_page_path.startswith("/"):
-            normalized_page_path = f"/{normalized_page_path}"
-        if is_usage_tracking_path_excluded(normalized_page_path):
-            return
+        raw_page_path = str(page_path).strip()
+        if raw_page_path.startswith("route:"):
+            normalized_page_path = raw_page_path
+        else:
+            normalized_page_path = urlsplit(raw_page_path).path.strip()
+            if normalized_page_path and normalized_page_path != "/":
+                normalized_page_path = normalized_page_path.rstrip("/")
+            normalized_page_path = normalized_page_path or "/"
+            if not normalized_page_path.startswith("/"):
+                normalized_page_path = f"/{normalized_page_path}"
+            if is_usage_tracking_path_excluded(normalized_page_path):
+                return
 
     with transaction.atomic():
         usage, _created = IndyHubUserUsage.objects.select_for_update().get_or_create(
@@ -595,9 +649,28 @@ def track_indy_hub_usage_once_per_request(request) -> None:
         getattr(request, "path", "")
     )
 
-    track_indy_hub_usage_for_user(
-        user,
-        page_path=request_path,
-        page_label=page_label,
-    )
+    usage_page_key = _build_usage_route_key(resolver_match) or request_path
     request._indy_hub_usage_tracked = True
+    try:
+        cache_key = _usage_request_debounce_cache_key(
+            user_id=int(user.id),
+            page_key=usage_page_key,
+        )
+        if cache.get(cache_key):
+            if IndyHubUserUsage.objects.filter(user=user).exists():
+                return
+
+        track_indy_hub_usage_for_user(
+            user,
+            page_path=usage_page_key,
+            page_label=page_label,
+        )
+        cache.set(cache_key, 1, timeout=_USAGE_REQUEST_DEBOUNCE_SECONDS)
+    except Exception:
+        # Tracking must never block page rendering.
+        logger.warning(
+            "Unable to record Indy Hub usage (user_id=%s, path=%s)",
+            getattr(user, "id", None),
+            request_path,
+            exc_info=True,
+        )

--- a/indy_hub/services/user_usage.py
+++ b/indy_hub/services/user_usage.py
@@ -38,6 +38,10 @@ _PAGE_RING_PALETTE = (
 _USAGE_EXCLUDED_PATHS = {
     "/user_notifications_count/",
 }
+_USAGE_EXCLUDED_PATH_PREFIXES = {
+    "/indy_hub/settings/admin-users/global-usage-fragment",
+    "/indy_hub/settings/admin-users/usage-detail-fragment",
+}
 _USAGE_EXCLUDED_ROUTE_NAMES = {
     "indy_hub:settings_admin_users_global_usage_fragment",
     "indy_hub:settings_admin_users_usage_detail_fragment",
@@ -62,6 +66,11 @@ def is_usage_tracking_path_excluded(path: str | None) -> bool:
     normalized_path = split_path or "/"
     if not normalized_path.startswith("/"):
         normalized_path = f"/{normalized_path}"
+    if any(
+        normalized_path == prefix or normalized_path.startswith(f"{prefix}/")
+        for prefix in _USAGE_EXCLUDED_PATH_PREFIXES
+    ):
+        return True
     return (
         normalized_path in _USAGE_EXCLUDED_PATHS
         or f"{normalized_path}/" in _USAGE_EXCLUDED_PATHS

--- a/indy_hub/templates/indy_hub/settings/admin_users.html
+++ b/indy_hub/templates/indy_hub/settings/admin_users.html
@@ -2,6 +2,14 @@
 {% load i18n %}
 {% load static %}
 
+{% blocktrans asvar adminUsersNoGlobalPageDetailText %}No global page detail has been recorded yet.{% endblocktrans %}
+{% blocktrans asvar adminUsersGlobalUsageErrorText %}Unable to load usage analytics right now.{% endblocktrans %}
+{% blocktrans asvar adminUsersNoPageDetailText %}No page detail has been recorded yet.{% endblocktrans %}
+{% blocktrans asvar adminUsersUserUsageErrorText %}Unable to load user analytics right now.{% endblocktrans %}
+{% blocktrans asvar adminUsersSortAscendingText %}A-Z{% endblocktrans %}
+{% blocktrans asvar adminUsersSortDescendingText %}Z-A{% endblocktrans %}
+{% blocktrans asvar adminUsersShownText %}users shown{% endblocktrans %}
+
 {% block page_title %}{% trans "Settings - User admin" %}{% endblock page_title %}
 
 {% block extra_css %}
@@ -495,10 +503,10 @@
             }
             fetchFragment(url)
                 .then(function (payload) {
-                    container.innerHTML = payload && payload.html ? payload.html : '<div class="text-muted small">{% trans "No global page detail has been recorded yet." %}</div>';
+                    container.innerHTML = payload && payload.html ? payload.html : '<div class="text-muted small">{{ adminUsersNoGlobalPageDetailText|escapejs }}</div>';
                 })
                 .catch(function () {
-                    container.innerHTML = '<div class="alert alert-warning mb-0">{% trans "Unable to load usage analytics right now." %}</div>';
+                    container.innerHTML = '<div class="alert alert-warning mb-0">{{ adminUsersGlobalUsageErrorText|escapejs }}</div>';
                 });
         }
 
@@ -518,11 +526,11 @@
 
             fetchFragment(url)
                 .then(function (payload) {
-                    target.innerHTML = payload && payload.html ? payload.html : '<div class="text-muted small">{% trans "No page detail has been recorded yet." %}</div>';
+                    target.innerHTML = payload && payload.html ? payload.html : '<div class="text-muted small">{{ adminUsersNoPageDetailText|escapejs }}</div>';
                     target.dataset.loaded = '1';
                 })
                 .catch(function () {
-                    target.innerHTML = '<div class="alert alert-warning mb-0">{% trans "Unable to load user analytics right now." %}</div>';
+                    target.innerHTML = '<div class="alert alert-warning mb-0">{{ adminUsersUserUsageErrorText|escapejs }}</div>';
                 });
         }
 
@@ -609,12 +617,12 @@
                     }
                     var isActive = button.dataset.sortKey === sortState.key;
                     if (!isActive) {
-                        indicator.textContent = '{% trans "A-Z" %}';
+                        indicator.textContent = '{{ adminUsersSortAscendingText|escapejs }}';
                         return;
                     }
                     indicator.textContent = sortState.direction === 'asc'
-                        ? '{% trans "A-Z" %}'
-                        : '{% trans "Z-A" %}';
+                        ? '{{ adminUsersSortAscendingText|escapejs }}'
+                        : '{{ adminUsersSortDescendingText|escapejs }}';
                 });
             }
 
@@ -649,7 +657,7 @@
                 });
 
                 if (resultCounter) {
-                    resultCounter.textContent = visibleCount + ' / ' + rows.length + ' {% trans "users shown" %}';
+                    resultCounter.textContent = visibleCount + ' / ' + rows.length + ' {{ adminUsersShownText|escapejs }}';
                 }
                 updateSortIndicators();
             }

--- a/indy_hub/templates/indy_hub/settings/admin_users.html
+++ b/indy_hub/templates/indy_hub/settings/admin_users.html
@@ -28,6 +28,52 @@
         border-bottom-width: 1px;
     }
 
+    .admin-users-sort-trigger {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        border: 0;
+        background: transparent;
+        color: inherit;
+        font-size: inherit;
+        letter-spacing: inherit;
+        text-transform: inherit;
+        font-weight: 700;
+        padding: 0;
+    }
+
+    .admin-users-sort-trigger:hover,
+    .admin-users-sort-trigger:focus {
+        color: var(--bs-emphasis-color);
+    }
+
+    .admin-users-sort-indicator {
+        font-size: 0.66rem;
+        letter-spacing: normal;
+        text-transform: none;
+        color: var(--bs-secondary-color);
+        min-width: 2.4rem;
+    }
+
+    .admin-users-filter-row th {
+        background: var(--bs-body-bg);
+        border-bottom-width: 1px;
+        padding-top: 0.45rem;
+        padding-bottom: 0.45rem;
+    }
+
+    .admin-users-filter-row .form-control,
+    .admin-users-filter-row .form-select {
+        min-width: 9rem;
+    }
+
+    .admin-users-table-tools {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
     .admin-users-users-table td,
     .admin-users-usage-table td,
     .admin-users-usage-table th {
@@ -222,96 +268,83 @@
                         <p class="text-muted small mb-0">{% trans "Aggregated usage across all visible users." %}</p>
                     </div>
                 </div>
-
-                <div class="admin-users-usage-summary-grid">
-                    <div class="admin-users-usage-summary-card">
-                        <div class="admin-users-usage-summary-label">{% trans "Visible users" %}</div>
-                        <div class="admin-users-usage-summary-value">{{ global_usage_detail.visible_user_count }}</div>
-                        <div class="admin-users-usage-summary-note">{% trans "Users included in this aggregated view." %}</div>
+                <div id="adminUsersGlobalUsageContainer" data-url="{% url 'indy_hub:settings_admin_users_global_usage_fragment' %}">
+                    <div class="d-flex align-items-center gap-2 text-muted small" role="status" aria-live="polite">
+                        <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>
+                        <span>{% trans "Loading usage analytics..." %}</span>
                     </div>
-                    <div class="admin-users-usage-summary-card">
-                        <div class="admin-users-usage-summary-label">{% trans "Active users (30d)" %}</div>
-                        <div class="admin-users-usage-summary-value">{{ global_usage_detail.active_user_count_30d }}</div>
-                        <div class="admin-users-usage-summary-note">{% trans "Visible users with at least one hit in the last 30 days." %}</div>
-                    </div>
-                    <div class="admin-users-usage-summary-card">
-                        <div class="admin-users-usage-summary-label">{% trans "Total hits" %}</div>
-                        <div class="admin-users-usage-summary-value">{{ global_usage_detail.total_usage_count }}</div>
-                        <div class="admin-users-usage-summary-note">{% trans "All recorded accesses across visible users." %}</div>
-                    </div>
-                    <div class="admin-users-usage-summary-card">
-                        <div class="admin-users-usage-summary-label">{% trans "Hits in 30d" %}</div>
-                        <div class="admin-users-usage-summary-value">{{ global_usage_detail.activity_30d_count }}</div>
-                        <div class="admin-users-usage-summary-note">
-                            {% if global_usage_detail.timeline_30d_peak_day_label %}
-                            {% trans "Peak" %}: {{ global_usage_detail.timeline_30d_peak_day_label }} · {{ global_usage_detail.timeline_30d_peak_day_count }}
-                            {% else %}
-                            {% trans "No recent usage yet." %}
-                            {% endif %}
-                        </div>
-                    </div>
-                </div>
-
-                <div class="mt-3">
-                    <div class="section-heading mb-2">
-                        <div>
-                            <h6 class="section-title mb-0">{% trans "Pages visited (30d)" %}</h6>
-                            <p class="text-muted small mb-0">{% trans "Page visits over the last 30 days." %}</p>
-                        </div>
-                    </div>
-                    {% if global_usage_detail.page_rings %}
-                    <div class="admin-users-pages-layout">
-                        <div class="admin-users-page-legend">
-                            {% for ring in global_usage_detail.page_rings %}
-                            <span class="admin-users-page-legend-item" title="{{ ring.label }} · {{ ring.recent_30d_count }}">
-                                <span class="d-inline-flex align-items-center gap-2">
-                                    <span class="admin-users-page-legend-swatch" style="background: {{ ring.page_color }};"></span>
-                                    <span>{{ ring.label }}</span>
-                                </span>
-                                <strong class="text-body">{{ ring.recent_30d_count }}</strong>
-                            </span>
-                            {% endfor %}
-                        </div>
-                        <div class="admin-users-page-chart-wrap">
-                            <svg class="admin-users-page-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 220" role="img" aria-label="{% trans '30-day usage by page across all users' %}" preserveAspectRatio="xMidYMid meet">
-                                <title>{% trans "30-day usage by page across all users" %}</title>
-                                <circle class="admin-users-page-svg-ring-track" cx="{{ global_usage_detail.page_ring_center_x }}" cy="{{ global_usage_detail.page_ring_center_y }}" r="{{ global_usage_detail.page_ring_outer_radius|add:'-13' }}"></circle>
-                                {% for ring in global_usage_detail.page_rings %}
-                                <path d="{{ ring.page_arc_path }}" fill="{{ ring.page_color }}"></path>
-                                {% endfor %}
-                                <circle class="admin-users-page-svg-radar-center" cx="{{ global_usage_detail.page_ring_center_x }}" cy="{{ global_usage_detail.page_ring_center_y }}" r="16"></circle>
-                                <text class="admin-users-page-svg-radar-center-value" x="{{ global_usage_detail.page_ring_center_x }}" y="{{ global_usage_detail.page_ring_center_y|add:'-2' }}">{{ global_usage_detail.page_total_30d }}</text>
-                                <text class="admin-users-page-svg-radar-center-label" x="{{ global_usage_detail.page_ring_center_x }}" y="{{ global_usage_detail.page_ring_center_y|add:'10' }}">{% trans "30d hits" %}</text>
-                                {% for ring in global_usage_detail.page_rings %}
-                                <text class="admin-users-page-svg-ring-label" x="{{ ring.page_label_x }}" y="{{ ring.page_label_y }}" text-anchor="{{ ring.page_label_anchor }}" transform="rotate({{ ring.page_label_rotation }} {{ ring.page_label_x }} {{ ring.page_label_y }})">{{ ring.page_label_short }}</text>
-                                {% endfor %}
-                            </svg>
-                        </div>
-                    </div>
-                    {% else %}
-                    <div class="text-muted small">{% trans "No global page detail has been recorded yet." %}</div>
-                    {% endif %}
                 </div>
             </div>
         </div>
 
         <div class="card focus-card admin-users-panel">
             <div class="card-body p-0">
+                <div class="px-3 pt-3 admin-users-table-tools">
+                    <div id="adminUsersTableResultCount" class="text-muted small" aria-live="polite"></div>
+                    <button id="adminUsersTableReset" type="button" class="btn btn-sm btn-outline-secondary">{% trans "Reset table filters" %}</button>
+                </div>
                 <div class="table-responsive">
-                    <table class="table table-sm table-striped table-hover align-middle mb-0 admin-users-users-table">
+                    <table id="adminUsersUsersTable" class="table table-sm table-striped table-hover align-middle mb-0 admin-users-users-table">
                         <thead class="admin-users-table-head">
                             <tr>
-                                <th>{% trans "User" %}</th>
-                                <th>{% trans "Corporations" %}</th>
-                                <th>{% trans "Health" %}</th>
-                                <th>{% trans "Scopes" %}</th>
-                                <th>{% trans "Usage" %}</th>
+                                <th>
+                                    <button type="button" class="admin-users-sort-trigger" data-sort-key="user" data-sort-type="text">{% trans "User" %} <span class="admin-users-sort-indicator" data-sort-indicator>{% trans "A-Z" %}</span></button>
+                                </th>
+                                <th>
+                                    <button type="button" class="admin-users-sort-trigger" data-sort-key="corporations" data-sort-type="text">{% trans "Corporations" %} <span class="admin-users-sort-indicator" data-sort-indicator>{% trans "A-Z" %}</span></button>
+                                </th>
+                                <th>
+                                    <button type="button" class="admin-users-sort-trigger" data-sort-key="health" data-sort-type="number">{% trans "Health" %} <span class="admin-users-sort-indicator" data-sort-indicator>{% trans "A-Z" %}</span></button>
+                                </th>
+                                <th>
+                                    <button type="button" class="admin-users-sort-trigger" data-sort-key="scopes" data-sort-type="text">{% trans "Scopes" %} <span class="admin-users-sort-indicator" data-sort-indicator>{% trans "A-Z" %}</span></button>
+                                </th>
+                                <th>
+                                    <button type="button" class="admin-users-sort-trigger" data-sort-key="usage" data-sort-type="number">{% trans "Usage" %} <span class="admin-users-sort-indicator" data-sort-indicator>{% trans "A-Z" %}</span></button>
+                                </th>
+                            </tr>
+                            <tr class="admin-users-filter-row">
+                                <th><input type="text" class="form-control form-control-sm" data-filter-key="user" placeholder="{% trans 'Filter user' %}"></th>
+                                <th><input type="text" class="form-control form-control-sm" data-filter-key="corporations" placeholder="{% trans 'Filter corp' %}"></th>
+                                <th>
+                                    <select class="form-select form-select-sm" data-filter-key="health">
+                                        <option value="">{% trans "All health" %}</option>
+                                        <option value="good">{% trans "Good" %}</option>
+                                        <option value="medium">{% trans "Medium" %}</option>
+                                        <option value="critical">{% trans "Critical" %}</option>
+                                    </select>
+                                </th>
+                                <th>
+                                    <select class="form-select form-select-sm" data-filter-key="scopes">
+                                        <option value="">{% trans "All scopes" %}</option>
+                                        <option value="complete">{% trans "Complete" %}</option>
+                                        <option value="incomplete">{% trans "Incomplete" %}</option>
+                                        <option value="active">{% trans "Active" %}</option>
+                                        <option value="inactive">{% trans "Inactive" %}</option>
+                                    </select>
+                                </th>
+                                <th>
+                                    <select class="form-select form-select-sm" data-filter-key="usage">
+                                        <option value="">{% trans "All usage" %}</option>
+                                        <option value="has_usage">{% trans "Has usage" %}</option>
+                                        <option value="no_usage">{% trans "No usage" %}</option>
+                                    </select>
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
                             {% if rows %}
                             {% for row in rows %}
-                            <tr>
+                            <tr
+                                class="admin-users-data-row"
+                                data-user="{{ row.user.username }} ID {{ row.user.id }}"
+                                data-corporations="{% if row.corporations %}{% for corp in row.corporations %}{{ corp.corporation_name }} {% endfor %}{% else %}{% trans 'No linked corporation' %}{% endif %}"
+                                data-health="{{ row.health.level }}"
+                                data-health-score="{{ row.health.score }}"
+                                data-scopes="{% if row.scope_is_complete %}complete{% else %}incomplete{% endif %} {% if row.is_inactive %}inactive{% else %}active{% endif %} {{ row.missing_scopes|join:' ' }}"
+                                data-usage="{% if row.total_usage_count|default:0 > 0 %}has_usage{% else %}no_usage{% endif %}"
+                                data-usage-total="{{ row.total_usage_count|default:0 }}"
+                            >
                                 <td>
                                     <div class="admin-users-user-meta">
                                         <div class="fw-semibold">{{ row.user.username }}</div>
@@ -364,8 +397,9 @@
                                         </svg>
                                         {% trans "Details" %}
                                     </button>
+                                    <div class="text-muted small mt-1">{% trans "30d" %}: {{ row.activity_30d_count|default:0 }} · {% trans "Total" %}: {{ row.total_usage_count|default:0 }}</div>
 
-                                    <div class="modal fade admin-users-usage-modal" id="usageDetailModal{{ row.user.id }}" tabindex="-1" aria-labelledby="usageDetailModalLabel{{ row.user.id }}" aria-hidden="true">
+                                    <div class="modal fade admin-users-usage-modal" id="usageDetailModal{{ row.user.id }}" tabindex="-1" aria-labelledby="usageDetailModalLabel{{ row.user.id }}" aria-hidden="true" data-usage-url="{% url 'indy_hub:settings_admin_users_usage_detail_fragment' row.user.id %}">
                                         <div class="modal-dialog modal-xl modal-dialog-scrollable modal-dialog-centered">
                                             <div class="modal-content">
                                                 <div class="modal-header border-0 pb-0">
@@ -379,83 +413,16 @@
                                                             <h5 class="modal-title" id="usageDetailModalLabel{{ row.user.id }}">{% trans "Usage detail" %} · {{ row.user.username }}</h5>
                                                         </div>
                                                         <div class="text-muted small mt-1">
-                                                            {% if row.usage_detail.has_usage %}
-                                                                {% blocktrans with total=row.usage_detail.total_usage_count %}{{ total }} recorded access hit(s){% endblocktrans %}
-                                                            {% else %}
-                                                                {% trans "No Indy Hub usage has been recorded yet." %}
-                                                            {% endif %}
+                                                            {% trans "Detailed analytics load on demand." %}
                                                         </div>
                                                     </div>
                                                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
                                                 </div>
-                                                <div class="modal-body pt-2">
-                                                    {% if row.usage_detail.has_usage %}
-                                                    <div class="admin-users-usage-summary-grid">
-                                                        <div class="admin-users-usage-summary-card">
-                                                            <div class="admin-users-usage-summary-label">{% trans "Total hits" %}</div>
-                                                            <div class="admin-users-usage-summary-value">{{ row.usage_detail.total_usage_count }}</div>
-                                                            <div class="admin-users-usage-summary-note">{% trans "All recorded Indy Hub accesses." %}</div>
-                                                        </div>
-                                                        <div class="admin-users-usage-summary-card">
-                                                            <div class="admin-users-usage-summary-label">{% trans "Active days" %}</div>
-                                                            <div class="admin-users-usage-summary-value">{{ row.usage_detail.active_days_total }}</div>
-                                                            <div class="admin-users-usage-summary-note">{% trans "Distinct days with at least one access." %}</div>
-                                                        </div>
-                                                        <div class="admin-users-usage-summary-card">
-                                                            <div class="admin-users-usage-summary-label">{% trans "First access" %}</div>
-                                                            <div class="admin-users-usage-summary-value">{{ row.usage_detail.first_used_at|date:"Y-m-d H:i" }}</div>
-                                                            <div class="admin-users-usage-summary-note">{% trans "Earliest recorded access." %}</div>
-                                                        </div>
-                                                        <div class="admin-users-usage-summary-card">
-                                                            <div class="admin-users-usage-summary-label">{% trans "Last access" %}</div>
-                                                            <div class="admin-users-usage-summary-value">{{ row.usage_detail.last_used_at|date:"Y-m-d H:i" }}</div>
-                                                            <div class="admin-users-usage-summary-note">{% trans "Most recent recorded access." %}</div>
-                                                        </div>
+                                                <div class="modal-body pt-2 js-usage-detail-target" data-loaded="0">
+                                                    <div class="d-flex align-items-center gap-2 text-muted small" role="status" aria-live="polite">
+                                                        <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>
+                                                        <span>{% trans "Loading user analytics..." %}</span>
                                                     </div>
-
-                                                    <div class="mt-4">
-                                                        <div class="section-heading mb-2">
-                                                            <div>
-                                                                <h6 class="section-title mb-0">{% trans "Pages visited" %}</h6>
-                                                                <p class="text-muted small mb-0">{% trans "Usage by page over the last 30 days." %}</p>
-                                                            </div>
-                                                        </div>
-                                                        {% if row.usage_detail.page_rings %}
-                                                        <div class="admin-users-pages-layout">
-                                                            <div class="admin-users-page-legend">
-                                                                {% for ring in row.usage_detail.page_rings %}
-                                                                <span class="admin-users-page-legend-item" title="{{ ring.label }} · {{ ring.recent_30d_count }}">
-                                                                    <span class="d-inline-flex align-items-center gap-2">
-                                                                        <span class="admin-users-page-legend-swatch" style="background: {{ ring.page_color }};"></span>
-                                                                        <span>{{ ring.label }}</span>
-                                                                    </span>
-                                                                    <strong class="text-body">{{ ring.recent_30d_count }}</strong>
-                                                                </span>
-                                                                {% endfor %}
-                                                            </div>
-                                                            <div class="admin-users-page-chart-wrap">
-                                                                <svg class="admin-users-page-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 220" role="img" aria-label="{% trans '30-day usage by page' %} · {{ row.user.username }}" preserveAspectRatio="xMidYMid meet">
-                                                                    <title>{% trans "30-day usage by page" %} · {{ row.user.username }}</title>
-                                                                    <circle class="admin-users-page-svg-ring-track" cx="{{ row.usage_detail.page_ring_center_x }}" cy="{{ row.usage_detail.page_ring_center_y }}" r="{{ row.usage_detail.page_ring_outer_radius|add:'-13' }}"></circle>
-                                                                    {% for ring in row.usage_detail.page_rings %}
-                                                                    <path d="{{ ring.page_arc_path }}" fill="{{ ring.page_color }}"></path>
-                                                                    {% endfor %}
-                                                                    <circle class="admin-users-page-svg-radar-center" cx="{{ row.usage_detail.page_ring_center_x }}" cy="{{ row.usage_detail.page_ring_center_y }}" r="16"></circle>
-                                                                    <text class="admin-users-page-svg-radar-center-value" x="{{ row.usage_detail.page_ring_center_x }}" y="{{ row.usage_detail.page_ring_center_y|add:'-2' }}">{{ row.usage_detail.page_total_30d }}</text>
-                                                                    <text class="admin-users-page-svg-radar-center-label" x="{{ row.usage_detail.page_ring_center_x }}" y="{{ row.usage_detail.page_ring_center_y|add:'10' }}">{% trans "30d hits" %}</text>
-                                                                    {% for ring in row.usage_detail.page_rings %}
-                                                                    <text class="admin-users-page-svg-ring-label" x="{{ ring.page_label_x }}" y="{{ ring.page_label_y }}" text-anchor="{{ ring.page_label_anchor }}" transform="rotate({{ ring.page_label_rotation }} {{ ring.page_label_x }} {{ ring.page_label_y }})">{{ ring.page_label_short }}</text>
-                                                                    {% endfor %}
-                                                                </svg>
-                                                            </div>
-                                                        </div>
-                                                        {% else %}
-                                                        <div class="text-muted small">{% trans "No page detail has been recorded yet." %}</div>
-                                                        {% endif %}
-                                                    </div>
-                                                    {% else %}
-                                                    <div class="alert alert-secondary mb-0">{% trans "Usage detail will appear after the user opens an Indy Hub page." %}</div>
-                                                    {% endif %}
                                                 </div>
                                             </div>
                                         </div>
@@ -491,3 +458,240 @@
     </section>
 </div>
 {% endblock content %}
+
+{% block extra_javascript %}
+{{ block.super }}
+<script>
+    (function () {
+        function appendQuery(url, query) {
+            if (!query) {
+                return url;
+            }
+            return url + (url.indexOf('?') >= 0 ? '&' : '?') + query;
+        }
+
+        function fetchFragment(url) {
+            return fetch(url, {
+                credentials: 'same-origin',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            }).then(function (response) {
+                if (!response.ok) {
+                    throw new Error('http_' + response.status);
+                }
+                return response.json();
+            });
+        }
+
+        function loadGlobalUsageFragment() {
+            var container = document.getElementById('adminUsersGlobalUsageContainer');
+            if (!container) {
+                return;
+            }
+            var url = appendQuery(container.dataset.url || '', window.location.search.replace(/^\?/, ''));
+            if (!url) {
+                return;
+            }
+            fetchFragment(url)
+                .then(function (payload) {
+                    container.innerHTML = payload && payload.html ? payload.html : '<div class="text-muted small">{% trans "No global page detail has been recorded yet." %}</div>';
+                })
+                .catch(function () {
+                    container.innerHTML = '<div class="alert alert-warning mb-0">{% trans "Unable to load usage analytics right now." %}</div>';
+                });
+        }
+
+        function onUsageModalShow(event) {
+            var modal = event.target;
+            if (!modal || !modal.classList.contains('admin-users-usage-modal')) {
+                return;
+            }
+            var target = modal.querySelector('.js-usage-detail-target');
+            if (!target || target.dataset.loaded === '1') {
+                return;
+            }
+            var url = modal.dataset.usageUrl || '';
+            if (!url) {
+                return;
+            }
+
+            fetchFragment(url)
+                .then(function (payload) {
+                    target.innerHTML = payload && payload.html ? payload.html : '<div class="text-muted small">{% trans "No page detail has been recorded yet." %}</div>';
+                    target.dataset.loaded = '1';
+                })
+                .catch(function () {
+                    target.innerHTML = '<div class="alert alert-warning mb-0">{% trans "Unable to load user analytics right now." %}</div>';
+                });
+        }
+
+        function setupAdminUsersTableTools() {
+            var table = document.getElementById('adminUsersUsersTable');
+            if (!table) {
+                return;
+            }
+            var tbody = table.querySelector('tbody');
+            if (!tbody) {
+                return;
+            }
+            var rows = Array.from(tbody.querySelectorAll('tr.admin-users-data-row'));
+            if (!rows.length) {
+                return;
+            }
+
+            var resultCounter = document.getElementById('adminUsersTableResultCount');
+            var resetButton = document.getElementById('adminUsersTableReset');
+            var filterInputs = Array.from(table.querySelectorAll('[data-filter-key]'));
+            var sortButtons = Array.from(table.querySelectorAll('.admin-users-sort-trigger'));
+            var sortState = {
+                key: 'user',
+                direction: 'asc',
+                type: 'text'
+            };
+
+            function normalizeText(value) {
+                return String(value || '').toLowerCase().trim();
+            }
+
+            function getRowValue(row, key) {
+                if (key === 'health') {
+                    return Number(row.dataset.healthScore || 0);
+                }
+                if (key === 'usage') {
+                    return Number(row.dataset.usageTotal || 0);
+                }
+                if (key === 'corporations') {
+                    return row.dataset.corporations || '';
+                }
+                if (key === 'scopes') {
+                    return row.dataset.scopes || '';
+                }
+                return row.dataset.user || '';
+            }
+
+            function rowMatchesFilters(row) {
+                var userFilter = normalizeText((table.querySelector('[data-filter-key="user"]') || {}).value);
+                var corpFilter = normalizeText((table.querySelector('[data-filter-key="corporations"]') || {}).value);
+                var healthFilter = normalizeText((table.querySelector('[data-filter-key="health"]') || {}).value);
+                var scopesFilter = normalizeText((table.querySelector('[data-filter-key="scopes"]') || {}).value);
+                var usageFilter = normalizeText((table.querySelector('[data-filter-key="usage"]') || {}).value);
+
+                var userData = normalizeText(row.dataset.user);
+                var corpData = normalizeText(row.dataset.corporations);
+                var healthData = normalizeText(row.dataset.health);
+                var scopesData = normalizeText(row.dataset.scopes);
+                var usageData = normalizeText(row.dataset.usage);
+
+                if (userFilter && userData.indexOf(userFilter) === -1) {
+                    return false;
+                }
+                if (corpFilter && corpData.indexOf(corpFilter) === -1) {
+                    return false;
+                }
+                if (healthFilter && healthData !== healthFilter) {
+                    return false;
+                }
+                if (scopesFilter && scopesData.indexOf(scopesFilter) === -1) {
+                    return false;
+                }
+                if (usageFilter && usageData !== usageFilter) {
+                    return false;
+                }
+                return true;
+            }
+
+            function updateSortIndicators() {
+                sortButtons.forEach(function (button) {
+                    var indicator = button.querySelector('[data-sort-indicator]');
+                    if (!indicator) {
+                        return;
+                    }
+                    var isActive = button.dataset.sortKey === sortState.key;
+                    if (!isActive) {
+                        indicator.textContent = '{% trans "A-Z" %}';
+                        return;
+                    }
+                    indicator.textContent = sortState.direction === 'asc'
+                        ? '{% trans "A-Z" %}'
+                        : '{% trans "Z-A" %}';
+                });
+            }
+
+            function applyTableTools() {
+                rows.sort(function (a, b) {
+                    var left = getRowValue(a, sortState.key);
+                    var right = getRowValue(b, sortState.key);
+
+                    if (sortState.type === 'number') {
+                        var delta = Number(left) - Number(right);
+                        return sortState.direction === 'asc' ? delta : -delta;
+                    }
+
+                    var textDelta = String(left).localeCompare(String(right), undefined, {
+                        sensitivity: 'base',
+                        numeric: true
+                    });
+                    return sortState.direction === 'asc' ? textDelta : -textDelta;
+                });
+
+                rows.forEach(function (row) {
+                    tbody.appendChild(row);
+                });
+
+                var visibleCount = 0;
+                rows.forEach(function (row) {
+                    var isVisible = rowMatchesFilters(row);
+                    row.style.display = isVisible ? '' : 'none';
+                    if (isVisible) {
+                        visibleCount += 1;
+                    }
+                });
+
+                if (resultCounter) {
+                    resultCounter.textContent = visibleCount + ' / ' + rows.length + ' {% trans "users shown" %}';
+                }
+                updateSortIndicators();
+            }
+
+            sortButtons.forEach(function (button) {
+                button.addEventListener('click', function () {
+                    var clickedKey = button.dataset.sortKey || 'user';
+                    var clickedType = button.dataset.sortType || 'text';
+                    if (sortState.key === clickedKey) {
+                        sortState.direction = sortState.direction === 'asc' ? 'desc' : 'asc';
+                    } else {
+                        sortState.key = clickedKey;
+                        sortState.type = clickedType;
+                        sortState.direction = 'asc';
+                    }
+                    applyTableTools();
+                });
+            });
+
+            filterInputs.forEach(function (input) {
+                input.addEventListener('input', applyTableTools);
+                input.addEventListener('change', applyTableTools);
+            });
+
+            if (resetButton) {
+                resetButton.addEventListener('click', function () {
+                    filterInputs.forEach(function (input) {
+                        input.value = '';
+                    });
+                    sortState.key = 'user';
+                    sortState.type = 'text';
+                    sortState.direction = 'asc';
+                    applyTableTools();
+                });
+            }
+
+            applyTableTools();
+        }
+
+        document.addEventListener('DOMContentLoaded', loadGlobalUsageFragment);
+        document.addEventListener('show.bs.modal', onUsageModalShow);
+        document.addEventListener('DOMContentLoaded', setupAdminUsersTableTools);
+    })();
+</script>
+{% endblock extra_javascript %}

--- a/indy_hub/templates/indy_hub/settings/admin_users.html
+++ b/indy_hub/templates/indy_hub/settings/admin_users.html
@@ -98,67 +98,6 @@
         margin-bottom: 1rem;
     }
 
-    .admin-users-usage-chart {
-        display: grid;
-        grid-template-columns: repeat(7, minmax(0, 1fr));
-        gap: 0.45rem;
-        align-items: end;
-        margin-top: 0.5rem;
-    }
-
-    .admin-users-usage-bar-shell {
-        height: 7rem;
-        display: flex;
-        align-items: flex-end;
-        justify-content: center;
-        padding: 0.35rem 0.35rem 0;
-        border-radius: 0.85rem;
-        background: rgba(var(--bs-secondary-rgb), 0.06);
-        border: 1px solid rgba(var(--bs-secondary-rgb), 0.08);
-    }
-
-    .admin-users-usage-bar {
-        width: 100%;
-        min-height: 0.35rem;
-        border-radius: 0.55rem 0.55rem 0 0;
-        background: linear-gradient(180deg, rgba(var(--bs-primary-rgb), 0.95), rgba(var(--bs-primary-rgb), 0.55));
-    }
-
-    .admin-users-usage-chart-day,
-    .admin-users-usage-page-day {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-        text-align: center;
-    }
-
-    .admin-users-usage-chart-label,
-    .admin-users-usage-page-label {
-        font-size: 0.72rem;
-        color: var(--bs-secondary-color);
-        line-height: 1.1;
-    }
-
-    .admin-users-usage-chart-count,
-    .admin-users-usage-page-count {
-        font-size: 0.78rem;
-        font-weight: 600;
-        color: var(--bs-emphasis-color);
-    }
-
-    .admin-users-usage-table th {
-        font-size: 0.74rem;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        color: var(--bs-secondary-color);
-        white-space: nowrap;
-    }
-
-    .admin-users-usage-page-path {
-        max-width: 18rem;
-        word-break: break-word;
-    }
-
     .admin-users-pages-layout {
         display: grid;
         grid-template-columns: minmax(14rem, 20rem) minmax(0, 1fr);
@@ -177,37 +116,6 @@
         height: auto;
         display: block;
         overflow: visible;
-    }
-
-    .admin-users-page-svg-radar-grid {
-        stroke: rgba(var(--bs-secondary-rgb), 0.12);
-        stroke-width: 1;
-        shape-rendering: geometricPrecision;
-    }
-
-    .admin-users-page-svg-radar-area {
-        fill: rgba(var(--bs-primary-rgb), 0.13);
-        stroke: rgba(var(--bs-primary-rgb), 0.72);
-        stroke-width: 1.6;
-        stroke-linejoin: round;
-    }
-
-    .admin-users-page-svg-radar-spoke {
-        stroke: rgba(var(--bs-secondary-rgb), 0.16);
-        stroke-width: 1;
-    }
-
-    .admin-users-page-svg-radar-point {
-        fill: rgb(var(--bs-primary-rgb));
-        stroke: var(--bs-body-bg);
-        stroke-width: 1.5;
-    }
-
-    .admin-users-page-svg-radar-label {
-        font-size: 5.5px;
-        font-weight: 600;
-        fill: var(--bs-secondary-color);
-        letter-spacing: 0.02em;
     }
 
     .admin-users-page-svg-radar-center {
@@ -257,9 +165,9 @@
         gap: 0.35rem;
         padding: 0.28rem 0.55rem;
         border: 1px solid var(--bs-border-color);
-        border-radius: 999px;
+        border-radius: 0.65rem;
         font-size: 0.75rem;
-        background: var(--bs-body-bg);
+        background: var(--bs-tertiary-bg);
         color: var(--bs-secondary-color);
         width: 100%;
         justify-content: space-between;
@@ -390,7 +298,7 @@
         <div class="card focus-card admin-users-panel">
             <div class="card-body p-0">
                 <div class="table-responsive">
-                    <table class="table table-striped table-hover align-middle mb-0 admin-users-users-table">
+                    <table class="table table-sm table-striped table-hover align-middle mb-0 admin-users-users-table">
                         <thead class="admin-users-table-head">
                             <tr>
                                 <th>{% trans "User" %}</th>
@@ -414,7 +322,7 @@
                                     {% if row.corporations %}
                                     <div class="admin-users-chip-stack">
                                         {% for corp in row.corporations %}
-                                        <span class="badge bg-body-tertiary text-secondary border">{{ corp.corporation_name }}</span>
+                                        <span class="badge rounded-pill bg-body-tertiary text-secondary border">{{ corp.corporation_name }}</span>
                                         {% endfor %}
                                     </div>
                                     {% else %}
@@ -431,7 +339,7 @@
                                         {% else %}
                                             <span class="badge bg-danger-subtle text-danger">{% trans "Critical" %}</span>
                                         {% endif %}
-                                        <div class="text-muted small">{% trans "Blocking" %}: {{ row.problem_counts.blocking }} | {% trans "Comfort" %}: {{ row.problem_counts.comfort }}</div>
+                                        <div class="text-muted small">{% trans "Blocking" %}: {{ row.problem_counts.blocking }} · {% trans "Comfort" %}: {{ row.problem_counts.comfort }}</div>
                                     </div>
                                 </td>
                                 <td>

--- a/indy_hub/templates/indy_hub/settings/partials/admin_user_usage_modal_body.html
+++ b/indy_hub/templates/indy_hub/settings/partials/admin_user_usage_modal_body.html
@@ -1,0 +1,68 @@
+{% load i18n %}
+{% if usage_detail.has_usage %}
+<div class="admin-users-usage-summary-grid">
+    <div class="admin-users-usage-summary-card">
+        <div class="admin-users-usage-summary-label">{% trans "Total hits" %}</div>
+        <div class="admin-users-usage-summary-value">{{ usage_detail.total_usage_count }}</div>
+        <div class="admin-users-usage-summary-note">{% trans "All recorded Indy Hub accesses." %}</div>
+    </div>
+    <div class="admin-users-usage-summary-card">
+        <div class="admin-users-usage-summary-label">{% trans "Active days" %}</div>
+        <div class="admin-users-usage-summary-value">{{ usage_detail.active_days_total }}</div>
+        <div class="admin-users-usage-summary-note">{% trans "Distinct days with at least one access." %}</div>
+    </div>
+    <div class="admin-users-usage-summary-card">
+        <div class="admin-users-usage-summary-label">{% trans "First access" %}</div>
+        <div class="admin-users-usage-summary-value">{{ usage_detail.first_used_at|date:"Y-m-d H:i" }}</div>
+        <div class="admin-users-usage-summary-note">{% trans "Earliest recorded access." %}</div>
+    </div>
+    <div class="admin-users-usage-summary-card">
+        <div class="admin-users-usage-summary-label">{% trans "Last access" %}</div>
+        <div class="admin-users-usage-summary-value">{{ usage_detail.last_used_at|date:"Y-m-d H:i" }}</div>
+        <div class="admin-users-usage-summary-note">{% trans "Most recent recorded access." %}</div>
+    </div>
+</div>
+
+<div class="mt-4">
+    <div class="section-heading mb-2">
+        <div>
+            <h6 class="section-title mb-0">{% trans "Pages visited" %}</h6>
+            <p class="text-muted small mb-0">{% trans "Usage by page over the last 30 days." %}</p>
+        </div>
+    </div>
+    {% if usage_detail.page_rings %}
+    <div class="admin-users-pages-layout">
+        <div class="admin-users-page-legend">
+            {% for ring in usage_detail.page_rings %}
+            <span class="admin-users-page-legend-item" title="{{ ring.label }} · {{ ring.recent_30d_count }}">
+                <span class="d-inline-flex align-items-center gap-2">
+                    <span class="admin-users-page-legend-swatch" style="background: {{ ring.page_color }};"></span>
+                    <span>{{ ring.label }}</span>
+                </span>
+                <strong class="text-body">{{ ring.recent_30d_count }}</strong>
+            </span>
+            {% endfor %}
+        </div>
+        <div class="admin-users-page-chart-wrap">
+            <svg class="admin-users-page-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 220" role="img" aria-label="{% trans '30-day usage by page' %} · {{ usage_user.username }}" preserveAspectRatio="xMidYMid meet">
+                <title>{% trans "30-day usage by page" %} · {{ usage_user.username }}</title>
+                <circle class="admin-users-page-svg-ring-track" cx="{{ usage_detail.page_ring_center_x }}" cy="{{ usage_detail.page_ring_center_y }}" r="{{ usage_detail.page_ring_outer_radius|add:'-13' }}"></circle>
+                {% for ring in usage_detail.page_rings %}
+                <path d="{{ ring.page_arc_path }}" fill="{{ ring.page_color }}"></path>
+                {% endfor %}
+                <circle class="admin-users-page-svg-radar-center" cx="{{ usage_detail.page_ring_center_x }}" cy="{{ usage_detail.page_ring_center_y }}" r="16"></circle>
+                <text class="admin-users-page-svg-radar-center-value" x="{{ usage_detail.page_ring_center_x }}" y="{{ usage_detail.page_ring_center_y|add:'-2' }}">{{ usage_detail.page_total_30d }}</text>
+                <text class="admin-users-page-svg-radar-center-label" x="{{ usage_detail.page_ring_center_x }}" y="{{ usage_detail.page_ring_center_y|add:'10' }}">{% trans "30d hits" %}</text>
+                {% for ring in usage_detail.page_rings %}
+                <text class="admin-users-page-svg-ring-label" x="{{ ring.page_label_x }}" y="{{ ring.page_label_y }}" text-anchor="{{ ring.page_label_anchor }}" transform="rotate({{ ring.page_label_rotation }} {{ ring.page_label_x }} {{ ring.page_label_y }})">{{ ring.page_label_short }}</text>
+                {% endfor %}
+            </svg>
+        </div>
+    </div>
+    {% else %}
+    <div class="text-muted small">{% trans "No page detail has been recorded yet." %}</div>
+    {% endif %}
+</div>
+{% else %}
+<div class="alert alert-secondary mb-0">{% trans "Usage detail will appear after the user opens an Indy Hub page." %}</div>
+{% endif %}

--- a/indy_hub/templates/indy_hub/settings/partials/admin_users_global_usage_content.html
+++ b/indy_hub/templates/indy_hub/settings/partials/admin_users_global_usage_content.html
@@ -1,0 +1,70 @@
+{% load i18n %}
+<div class="admin-users-usage-summary-grid">
+    <div class="admin-users-usage-summary-card">
+        <div class="admin-users-usage-summary-label">{% trans "Visible users" %}</div>
+        <div class="admin-users-usage-summary-value">{{ global_usage_detail.visible_user_count }}</div>
+        <div class="admin-users-usage-summary-note">{% trans "Users included in this aggregated view." %}</div>
+    </div>
+    <div class="admin-users-usage-summary-card">
+        <div class="admin-users-usage-summary-label">{% trans "Active users (30d)" %}</div>
+        <div class="admin-users-usage-summary-value">{{ global_usage_detail.active_user_count_30d }}</div>
+        <div class="admin-users-usage-summary-note">{% trans "Visible users with at least one hit in the last 30 days." %}</div>
+    </div>
+    <div class="admin-users-usage-summary-card">
+        <div class="admin-users-usage-summary-label">{% trans "Total hits" %}</div>
+        <div class="admin-users-usage-summary-value">{{ global_usage_detail.total_usage_count }}</div>
+        <div class="admin-users-usage-summary-note">{% trans "All recorded accesses across visible users." %}</div>
+    </div>
+    <div class="admin-users-usage-summary-card">
+        <div class="admin-users-usage-summary-label">{% trans "Hits in 30d" %}</div>
+        <div class="admin-users-usage-summary-value">{{ global_usage_detail.activity_30d_count }}</div>
+        <div class="admin-users-usage-summary-note">
+            {% if global_usage_detail.timeline_30d_peak_day_label %}
+            {% trans "Peak" %}: {{ global_usage_detail.timeline_30d_peak_day_label }} · {{ global_usage_detail.timeline_30d_peak_day_count }}
+            {% else %}
+            {% trans "No recent usage yet." %}
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+<div class="mt-3">
+    <div class="section-heading mb-2">
+        <div>
+            <h6 class="section-title mb-0">{% trans "Pages visited (30d)" %}</h6>
+            <p class="text-muted small mb-0">{% trans "Page visits over the last 30 days." %}</p>
+        </div>
+    </div>
+    {% if global_usage_detail.page_rings %}
+    <div class="admin-users-pages-layout">
+        <div class="admin-users-page-legend">
+            {% for ring in global_usage_detail.page_rings %}
+            <span class="admin-users-page-legend-item" title="{{ ring.label }} · {{ ring.recent_30d_count }}">
+                <span class="d-inline-flex align-items-center gap-2">
+                    <span class="admin-users-page-legend-swatch" style="background: {{ ring.page_color }};"></span>
+                    <span>{{ ring.label }}</span>
+                </span>
+                <strong class="text-body">{{ ring.recent_30d_count }}</strong>
+            </span>
+            {% endfor %}
+        </div>
+        <div class="admin-users-page-chart-wrap">
+            <svg class="admin-users-page-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 220" role="img" aria-label="{% trans '30-day usage by page across all users' %}" preserveAspectRatio="xMidYMid meet">
+                <title>{% trans "30-day usage by page across all users" %}</title>
+                <circle class="admin-users-page-svg-ring-track" cx="{{ global_usage_detail.page_ring_center_x }}" cy="{{ global_usage_detail.page_ring_center_y }}" r="{{ global_usage_detail.page_ring_outer_radius|add:'-13' }}"></circle>
+                {% for ring in global_usage_detail.page_rings %}
+                <path d="{{ ring.page_arc_path }}" fill="{{ ring.page_color }}"></path>
+                {% endfor %}
+                <circle class="admin-users-page-svg-radar-center" cx="{{ global_usage_detail.page_ring_center_x }}" cy="{{ global_usage_detail.page_ring_center_y }}" r="16"></circle>
+                <text class="admin-users-page-svg-radar-center-value" x="{{ global_usage_detail.page_ring_center_x }}" y="{{ global_usage_detail.page_ring_center_y|add:'-2' }}">{{ global_usage_detail.page_total_30d }}</text>
+                <text class="admin-users-page-svg-radar-center-label" x="{{ global_usage_detail.page_ring_center_x }}" y="{{ global_usage_detail.page_ring_center_y|add:'10' }}">{% trans "30d hits" %}</text>
+                {% for ring in global_usage_detail.page_rings %}
+                <text class="admin-users-page-svg-ring-label" x="{{ ring.page_label_x }}" y="{{ ring.page_label_y }}" text-anchor="{{ ring.page_label_anchor }}" transform="rotate({{ ring.page_label_rotation }} {{ ring.page_label_x }} {{ ring.page_label_y }})">{{ ring.page_label_short }}</text>
+                {% endfor %}
+            </svg>
+        </div>
+    </div>
+    {% else %}
+    <div class="text-muted small">{% trans "No global page detail has been recorded yet." %}</div>
+    {% endif %}
+</div>

--- a/indy_hub/tests/core/test_admin_user_bulk_actions.py
+++ b/indy_hub/tests/core/test_admin_user_bulk_actions.py
@@ -1,0 +1,74 @@
+"""Tests for admin user bulk action scope helpers."""
+
+from __future__ import annotations
+
+# Standard Library
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Django
+from django.test import SimpleTestCase
+
+# AA Example App
+from indy_hub.services.admin_user_bulk_actions import collect_user_scope_status_map
+
+
+class CollectUserScopeStatusMapTests(SimpleTestCase):
+    @patch("indy_hub.services.admin_user_bulk_actions.Token")
+    def test_uses_prefetched_scopes_without_values_list(self, mock_token) -> None:
+        scope_names = [
+            "esi-characters.read_blueprints.v1",
+            "esi-universe.read_structures.v1",
+            "esi-industry.read_character_jobs.v1",
+            "esi-assets.read_assets.v1",
+            "esi-skills.read_skills.v1",
+            "esi-location.read_online.v1",
+        ]
+        scope_manager = MagicMock()
+        scope_manager.all.return_value = [
+            SimpleNamespace(name=name) for name in scope_names
+        ]
+        scope_manager.values_list.side_effect = AssertionError(
+            "values_list should not be used with prefetched scopes"
+        )
+        fake_token = SimpleNamespace(user_id=77, scopes=scope_manager)
+
+        tokens_qs = MagicMock()
+        tokens_qs.require_valid.return_value = tokens_qs
+        tokens_qs.prefetch_related.return_value = [fake_token]
+        mock_token.objects.filter.return_value = tokens_qs
+
+        result = collect_user_scope_status_map([77])
+
+        scope_manager.all.assert_called_once_with()
+        self.assertIn(77, result)
+        self.assertTrue(bool(result[77]["is_complete"]))
+        self.assertEqual(list(result[77]["missing_labels"]), [])
+
+    @patch("indy_hub.services.admin_user_bulk_actions.Token")
+    def test_does_not_count_split_scopes_across_tokens_as_complete(
+        self, mock_token
+    ) -> None:
+        scope_manager_a = MagicMock()
+        scope_manager_a.all.return_value = [
+            SimpleNamespace(name="esi-characters.read_blueprints.v1")
+        ]
+        scope_manager_b = MagicMock()
+        scope_manager_b.all.return_value = [
+            SimpleNamespace(name="esi-universe.read_structures.v1")
+        ]
+
+        token_a = SimpleNamespace(user_id=77, scopes=scope_manager_a)
+        token_b = SimpleNamespace(user_id=77, scopes=scope_manager_b)
+
+        tokens_qs = MagicMock()
+        tokens_qs.require_valid.return_value = tokens_qs
+        tokens_qs.prefetch_related.return_value = [token_a, token_b]
+        mock_token.objects.filter.return_value = tokens_qs
+
+        result = collect_user_scope_status_map([77])
+
+        self.assertIn(77, result)
+        self.assertFalse(result[77]["flags"]["blueprints"])
+        self.assertIn("blueprints", result[77]["missing_labels"])
+        self.assertFalse(result[77]["is_complete"])

--- a/indy_hub/tests/core/test_settings_admin_users_view.py
+++ b/indy_hub/tests/core/test_settings_admin_users_view.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 # Standard Library
+import json
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -17,13 +18,15 @@ from django.urls import reverse
 from django.utils import timezone
 
 # Alliance Auth
-from allianceauth.authentication.models import CharacterOwnership
+from allianceauth.authentication.models import CharacterOwnership, UserProfile
 from allianceauth.eveonline.models import EveCharacter
 
 # AA Example App
 from indy_hub.models import CharacterSettings, IndyHubUserUsage
 from indy_hub.views.hubs import (
     settings_admin_users,
+    settings_admin_users_global_usage_fragment,
+    settings_admin_users_usage_detail_fragment,
     settings_hub,
 )
 
@@ -44,7 +47,7 @@ def _link_character(
     character_id: int,
     corporation_id: int,
     corporation_name: str,
-) -> None:
+) -> EveCharacter:
     character, _ = EveCharacter.objects.get_or_create(
         character_id=character_id,
         defaults={
@@ -59,6 +62,11 @@ def _link_character(
         character=character,
         defaults={"owner_hash": f"hash-{user.id}-{character_id}"},
     )
+    profile, _ = UserProfile.objects.get_or_create(user=user)
+    if not profile.main_character_id:
+        profile.main_character = character
+        profile.save(update_fields=["main_character"])
+    return character
 
 
 class SettingsAdminUsersViewTests(TestCase):
@@ -220,6 +228,14 @@ class SettingsAdminUsersViewTests(TestCase):
     def _settings_admin_view(self):
         return settings_admin_users.__wrapped__.__wrapped__
 
+    @property
+    def _settings_admin_global_usage_fragment_view(self):
+        return settings_admin_users_global_usage_fragment.__wrapped__.__wrapped__
+
+    @property
+    def _settings_admin_usage_detail_fragment_view(self):
+        return settings_admin_users_usage_detail_fragment.__wrapped__.__wrapped__
+
     def _prepare_request(self, request: HttpRequest, *, user: User) -> HttpRequest:
         request.user = user
         middleware = SessionMiddleware(lambda req: None)
@@ -302,8 +318,58 @@ class SettingsAdminUsersViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Details", users_html)
         self.assertIn("Usage detail", users_html)
-        self.assertIn("Pages visited", users_html)
-        self.assertIn("Overview", users_html)
+        self.assertIn("Loading user analytics", users_html)
+
+    def test_global_usage_fragment_loads_for_superuser(self) -> None:
+        request = self._prepare_request(
+            self.factory.get(
+                reverse("indy_hub:settings_admin_users_global_usage_fragment")
+            ),
+            user=self.superuser,
+        )
+        response = self._settings_admin_global_usage_fragment_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content.decode())
+        self.assertIn("html", payload)
+        self.assertIn("Visible users", payload["html"])
+
+    def test_usage_detail_fragment_loads_for_superuser(self) -> None:
+        request = self._prepare_request(
+            self.factory.get(
+                reverse(
+                    "indy_hub:settings_admin_users_usage_detail_fragment",
+                    args=[self.manager.id],
+                )
+            ),
+            user=self.superuser,
+        )
+        response = self._settings_admin_usage_detail_fragment_view(
+            request,
+            user_id=self.manager.id,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content.decode())
+        self.assertIn("html", payload)
+        self.assertIn("Pages visited", payload["html"])
+
+    def test_usage_detail_fragment_forbidden_without_admin_scope(self) -> None:
+        request = self._prepare_request(
+            self.factory.get(
+                reverse(
+                    "indy_hub:settings_admin_users_usage_detail_fragment",
+                    args=[self.superuser.id],
+                )
+            ),
+            user=self.manager,
+        )
+        response = self._settings_admin_usage_detail_fragment_view(
+            request,
+            user_id=self.superuser.id,
+        )
+
+        self.assertEqual(response.status_code, 403)
 
     def test_managed_corporation_filter(self) -> None:
         request = self._prepare_request(
@@ -320,6 +386,33 @@ class SettingsAdminUsersViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(self.member_other.username, users_html)
         self.assertNotIn(self.member_managed.username, users_html)
+
+    def test_user_table_displays_main_character_corporation_only(self) -> None:
+        secondary_character = _link_character(
+            self.member_managed,
+            character_id=9100099,
+            corporation_id=4444,
+            corporation_name="Secondary Corp",
+        )
+        profile = UserProfile.objects.get(user=self.member_managed)
+        profile.main_character = secondary_character
+        profile.save(update_fields=["main_character"])
+
+        request = self._prepare_request(
+            self.factory.get(
+                reverse("indy_hub:settings_admin_users"),
+                {"managed_corporation_id": "4444"},
+            ),
+            user=self.superuser,
+        )
+
+        response = self._settings_admin_view(request)
+        users_html = self._users_section_html(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.member_managed.username, users_html)
+        self.assertIn("Secondary Corp", users_html)
+        self.assertNotIn("Managed Corp", users_html)
 
     def test_incomplete_filter(self) -> None:
         fake_status_map = {
@@ -398,6 +491,61 @@ class SettingsAdminUsersViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(self.member_other.username, users_html)
         self.assertNotIn(self.member_managed.username, users_html)
+
+    def test_scope_status_fallback_is_not_eagerly_evaluated(self) -> None:
+        complete_flags = {
+            "blueprints": True,
+            "jobs": True,
+            "assets": True,
+            "skills": True,
+            "online": True,
+        }
+        fake_status_map = {
+            self.superuser.id: {
+                "flags": complete_flags,
+                "is_complete": True,
+                "missing_labels": [],
+            },
+            self.manager.id: {
+                "flags": complete_flags,
+                "is_complete": True,
+                "missing_labels": [],
+            },
+            self.member_managed.id: {
+                "flags": complete_flags,
+                "is_complete": True,
+                "missing_labels": [],
+            },
+            self.member_other.id: {
+                "flags": complete_flags,
+                "is_complete": True,
+                "missing_labels": [],
+            },
+            self.regular.id: {
+                "flags": complete_flags,
+                "is_complete": True,
+                "missing_labels": [],
+            },
+        }
+
+        request = self._prepare_request(
+            self.factory.get(reverse("indy_hub:settings_admin_users")),
+            user=self.superuser,
+        )
+
+        with (
+            patch(
+                "indy_hub.views.hubs.collect_user_scope_status_map",
+                return_value=fake_status_map,
+            ),
+            patch(
+                "indy_hub.views.hubs.collect_user_scope_status",
+                side_effect=AssertionError("Fallback should not be called"),
+            ),
+        ):
+            response = self._settings_admin_view(request)
+
+        self.assertEqual(response.status_code, 200)
 
     def test_admin_page_paginates_visible_rows(self) -> None:
         for index in range(30):

--- a/indy_hub/tests/core/test_user_usage_tracking.py
+++ b/indy_hub/tests/core/test_user_usage_tracking.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 # Standard Library
 from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
 
 # Django
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.http import HttpResponse
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.utils import timezone
 
 # AA Example App
@@ -18,6 +20,7 @@ from indy_hub.decorators import indy_hub_access_required, indy_hub_permission_re
 from indy_hub.middleware import IndyHubUsageTrackingMiddleware
 from indy_hub.models import IndyHubUserUsage
 from indy_hub.services.user_usage import (
+    build_indy_hub_global_usage_detail,
     build_indy_hub_usage_detail,
     track_indy_hub_usage_for_user,
     track_indy_hub_usage_once_per_request,
@@ -80,18 +83,10 @@ class IndyHubUserUsageModelTests(TestCase):
         usage = IndyHubUserUsage.objects.get(user=self.user)
 
         self.assertIn("/indy_hub/index", usage.page_usage)
-        self.assertIn("/indy_hub/settings/admin-users", usage.page_usage)
+        self.assertNotIn("/indy_hub/settings/admin-users", usage.page_usage)
         self.assertEqual(
             usage.page_usage["/indy_hub/index"]["total_usage_count"],
             1,
-        )
-        self.assertEqual(
-            usage.page_usage["/indy_hub/settings/admin-users"]["total_usage_count"],
-            2,
-        )
-        self.assertEqual(
-            usage.page_usage["/indy_hub/settings/admin-users"]["label"],
-            "User admin",
         )
 
     def test_usage_detail_hides_excluded_notification_endpoint(self) -> None:
@@ -137,13 +132,130 @@ class IndyHubUserUsageModelTests(TestCase):
         self.assertNotIn("/user_notifications_count/?foo=1", rendered_paths)
         self.assertIn("/audit/r/96515342/account/walletactivity", rendered_paths)
 
+    def test_register_usage_prunes_old_and_excess_page_usage_keys(self) -> None:
+        now = timezone.now()
+        max_keys = IndyHubUserUsage.PAGE_USAGE_MAX_KEYS
+        usage = IndyHubUserUsage.objects.create(
+            user=self.user,
+            first_used_at=now - timedelta(days=2),
+            last_used_at=now - timedelta(days=1),
+            total_usage_count=1,
+            activity_7d_count=1,
+            activity_30d_count=1,
+            daily_usage={
+                (now - timedelta(days=1)).date().isoformat(): 1,
+            },
+            page_usage={
+                "/old": {
+                    "label": "old",
+                    "path": "/old",
+                    "total_usage_count": 1,
+                    "first_used_at": (now - timedelta(days=200)).isoformat(),
+                    "last_used_at": (now - timedelta(days=200)).isoformat(),
+                    "daily_usage": {
+                        (now - timedelta(days=200)).date().isoformat(): 1,
+                    },
+                },
+                **{
+                    f"/k/{idx}": {
+                        "label": f"k{idx}",
+                        "path": f"/k/{idx}",
+                        "total_usage_count": 1,
+                        "first_used_at": now.isoformat(),
+                        "last_used_at": now.isoformat(),
+                        "daily_usage": {now.date().isoformat(): 1},
+                    }
+                    for idx in range(max_keys + 5)
+                },
+            },
+        )
+
+        usage.register_usage(at=now, page_path="/recent", page_label="recent")
+        usage.register_usage(
+            at=now + timedelta(seconds=1),
+            page_path="/recent",
+            page_label="recent",
+        )
+
+        self.assertNotIn("/old", usage.page_usage)
+        self.assertIn("/recent", usage.page_usage)
+        self.assertLessEqual(len(usage.page_usage), usage.PAGE_USAGE_MAX_KEYS)
+
+    def test_usage_detail_recomputes_rolling_windows_from_today(self) -> None:
+        now = timezone.now()
+        usage = IndyHubUserUsage.objects.create(
+            user=self.user,
+            first_used_at=now - timedelta(days=90),
+            last_used_at=now - timedelta(days=60),
+            total_usage_count=12,
+            activity_7d_count=6,
+            activity_30d_count=9,
+            daily_usage={
+                (now - timedelta(days=60)).date().isoformat(): 12,
+            },
+        )
+
+        detail = build_indy_hub_usage_detail(usage)
+
+        self.assertEqual(int(detail["activity_7d_count"]), 0)
+        self.assertEqual(int(detail["activity_30d_count"]), 0)
+        self.assertEqual(
+            str(detail["overall_timeline"][-1]["iso"]),
+            timezone.localdate().isoformat(),
+        )
+
+    def test_global_usage_detail_recomputes_active_users_30d_from_daily_usage(
+        self,
+    ) -> None:
+        now = timezone.now()
+        stale_user = User.objects.create_user("stale_usage", password="secret123")
+        active_user = User.objects.create_user("active_usage", password="secret123")
+
+        stale_usage = IndyHubUserUsage.objects.create(
+            user=stale_user,
+            first_used_at=now - timedelta(days=80),
+            last_used_at=now - timedelta(days=60),
+            total_usage_count=5,
+            activity_7d_count=2,
+            activity_30d_count=5,
+            daily_usage={
+                (now - timedelta(days=60)).date().isoformat(): 5,
+            },
+        )
+        active_usage = IndyHubUserUsage.objects.create(
+            user=active_user,
+            first_used_at=now - timedelta(days=2),
+            last_used_at=now - timedelta(days=1),
+            total_usage_count=3,
+            activity_7d_count=0,
+            activity_30d_count=0,
+            daily_usage={
+                timezone.localdate().isoformat(): 3,
+            },
+        )
+
+        detail = build_indy_hub_global_usage_detail([stale_usage, active_usage])
+
+        self.assertEqual(int(detail["activity_30d_count"]), 3)
+        self.assertEqual(int(detail["activity_7d_count"]), 3)
+        self.assertEqual(int(detail["active_user_count_30d"]), 1)
+
 
 class IndyHubUsageDecoratorHookTests(TestCase):
     def setUp(self) -> None:
         self.factory = RequestFactory()
         self.user = User.objects.create_user("decorator_user", password="secret123")
+        self.user_without_access = User.objects.create_user(
+            "decorator_user_no_access",
+            password="secret123",
+        )
+        self.user_without_manage_permission = User.objects.create_user(
+            "decorator_user_no_manage",
+            password="secret123",
+        )
         _grant_permission(self.user, "can_access_indy_hub")
         _grant_permission(self.user, "can_manage_corp_bp_requests")
+        _grant_permission(self.user_without_manage_permission, "can_access_indy_hub")
 
     def test_access_required_decorator_records_usage(self) -> None:
         @indy_hub_access_required
@@ -188,39 +300,107 @@ class IndyHubUsageDecoratorHookTests(TestCase):
         usage = IndyHubUserUsage.objects.get(user=self.user)
         self.assertEqual(usage.total_usage_count, 1)
 
+    def test_access_required_returns_403_without_indy_hub_access(self) -> None:
+        @indy_hub_access_required
+        def protected_view(request):
+            return HttpResponse("ok")
+
+        request = self.factory.get("/indy_hub/test")
+        request.user = self.user_without_access
+
+        response = protected_view(request)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_permission_required_returns_403_without_specific_permission(self) -> None:
+        @indy_hub_permission_required("can_manage_corp_bp_requests")
+        def protected_view(request):
+            return HttpResponse("ok")
+
+        request = self.factory.get("/indy_hub/test")
+        request.user = self.user_without_manage_permission
+
+        response = protected_view(request)
+
+        self.assertEqual(response.status_code, 403)
+
 
 class IndyHubUsageMiddlewareTests(TestCase):
     def setUp(self) -> None:
         self.factory = RequestFactory()
         self.user = User.objects.create_user("middleware_user", password="secret123")
 
-    def test_tracks_corptools_audit_path_as_exact_page_path(self) -> None:
+    @override_settings(INDY_HUB_USAGE_MIDDLEWARE_ENABLED=True)
+    def test_tracks_allowed_route_as_normalized_route_key(self) -> None:
         middleware = IndyHubUsageTrackingMiddleware(lambda request: HttpResponse("ok"))
         request = self.factory.get("/audit/r/96515342/account/walletactivity")
         request.user = self.user
+        request.resolver_match = SimpleNamespace(
+            app_names=("indy_hub",),
+            view_name="indy_hub:settings_hub",
+            url_name="settings_hub",
+        )
 
         middleware.process_view(request, lambda req: HttpResponse("ok"), (), {})
 
         usage = IndyHubUserUsage.objects.get(user=self.user)
-        self.assertIn("/audit/r/96515342/account/walletactivity", usage.page_usage)
-        self.assertEqual(
-            usage.page_usage["/audit/r/96515342/account/walletactivity"]["path"],
-            "/audit/r/96515342/account/walletactivity",
-        )
+        self.assertIn("route:indy_hub:settings_hub", usage.page_usage)
+        self.assertNotIn("/audit/r/96515342/account/walletactivity", usage.page_usage)
 
-    def test_does_not_track_non_get_requests(self) -> None:
+    def test_does_not_track_when_middleware_is_disabled(self) -> None:
         middleware = IndyHubUsageTrackingMiddleware(lambda request: HttpResponse("ok"))
-        request = self.factory.post("/audit/r/96515342/account/walletactivity")
+        request = self.factory.get("/indy_hub/index/")
         request.user = self.user
+        request.resolver_match = SimpleNamespace(
+            app_names=("indy_hub",),
+            view_name="indy_hub:index",
+            url_name="index",
+        )
 
         middleware.process_view(request, lambda req: HttpResponse("ok"), (), {})
 
         self.assertFalse(IndyHubUserUsage.objects.filter(user=self.user).exists())
 
+    @override_settings(INDY_HUB_USAGE_MIDDLEWARE_ENABLED=True)
+    def test_does_not_track_non_get_requests(self) -> None:
+        middleware = IndyHubUsageTrackingMiddleware(lambda request: HttpResponse("ok"))
+        request = self.factory.post("/audit/r/96515342/account/walletactivity")
+        request.user = self.user
+        request.resolver_match = SimpleNamespace(
+            app_names=("indy_hub",),
+            view_name="indy_hub:settings_hub",
+            url_name="settings_hub",
+        )
+
+        middleware.process_view(request, lambda req: HttpResponse("ok"), (), {})
+
+        self.assertFalse(IndyHubUserUsage.objects.filter(user=self.user).exists())
+
+    @override_settings(INDY_HUB_USAGE_MIDDLEWARE_ENABLED=True)
     def test_does_not_track_user_notifications_count_endpoint(self) -> None:
         middleware = IndyHubUsageTrackingMiddleware(lambda request: HttpResponse("ok"))
         request = self.factory.get("/user_notifications_count/")
         request.user = self.user
+        request.resolver_match = SimpleNamespace(
+            app_names=("indy_hub",),
+            view_name="indy_hub:notifications",
+            url_name="notifications",
+        )
+
+        middleware.process_view(request, lambda req: HttpResponse("ok"), (), {})
+
+        self.assertFalse(IndyHubUserUsage.objects.filter(user=self.user).exists())
+
+    @override_settings(INDY_HUB_USAGE_MIDDLEWARE_ENABLED=True)
+    def test_does_not_track_disallowed_app_name(self) -> None:
+        middleware = IndyHubUsageTrackingMiddleware(lambda request: HttpResponse("ok"))
+        request = self.factory.get("/some/aa/page/")
+        request.user = self.user
+        request.resolver_match = SimpleNamespace(
+            app_names=("allianceauth",),
+            view_name="allianceauth:dashboard",
+            url_name="dashboard",
+        )
 
         middleware.process_view(request, lambda req: HttpResponse("ok"), (), {})
 
@@ -239,3 +419,38 @@ class IndyHubUsageServiceHookTests(TestCase):
         track_indy_hub_usage_once_per_request(request)
 
         self.assertFalse(IndyHubUserUsage.objects.filter(user=self.user).exists())
+
+    def test_once_per_request_skips_settings_admin_users_endpoint(self) -> None:
+        request = self.factory.get("/indy_hub/settings/admin-users/")
+        request.user = self.user
+
+        track_indy_hub_usage_once_per_request(request)
+
+        self.assertFalse(IndyHubUserUsage.objects.filter(user=self.user).exists())
+
+    def test_once_per_request_uses_route_key_for_indy_hub_pages(self) -> None:
+        request = self.factory.get("/indy_hub/settings/")
+        request.user = self.user
+        request.resolver_match = SimpleNamespace(
+            app_names=("indy_hub",),
+            view_name="indy_hub:settings_hub",
+            url_name="settings_hub",
+        )
+
+        track_indy_hub_usage_once_per_request(request)
+
+        usage = IndyHubUserUsage.objects.get(user=self.user)
+        self.assertIn("route:indy_hub:settings_hub", usage.page_usage)
+
+    def test_once_per_request_never_raises_when_tracking_fails(self) -> None:
+        request = self.factory.get("/indy_hub/index/")
+        request.user = self.user
+
+        with patch(
+            "indy_hub.services.user_usage.track_indy_hub_usage_for_user",
+            side_effect=RuntimeError("tracking down"),
+        ):
+            track_indy_hub_usage_once_per_request(request)
+
+        self.assertFalse(IndyHubUserUsage.objects.filter(user=self.user).exists())
+        self.assertTrue(getattr(request, "_indy_hub_usage_tracked", False))

--- a/indy_hub/tests/core/test_user_usage_tracking.py
+++ b/indy_hub/tests/core/test_user_usage_tracking.py
@@ -83,10 +83,14 @@ class IndyHubUserUsageModelTests(TestCase):
         usage = IndyHubUserUsage.objects.get(user=self.user)
 
         self.assertIn("/indy_hub/index", usage.page_usage)
-        self.assertNotIn("/indy_hub/settings/admin-users", usage.page_usage)
+        self.assertIn("/indy_hub/settings/admin-users", usage.page_usage)
         self.assertEqual(
             usage.page_usage["/indy_hub/index"]["total_usage_count"],
             1,
+        )
+        self.assertEqual(
+            usage.page_usage["/indy_hub/settings/admin-users"]["total_usage_count"],
+            2,
         )
 
     def test_usage_detail_hides_excluded_notification_endpoint(self) -> None:
@@ -420,9 +424,25 @@ class IndyHubUsageServiceHookTests(TestCase):
 
         self.assertFalse(IndyHubUserUsage.objects.filter(user=self.user).exists())
 
-    def test_once_per_request_skips_settings_admin_users_endpoint(self) -> None:
+    def test_once_per_request_tracks_settings_admin_users_endpoint(self) -> None:
         request = self.factory.get("/indy_hub/settings/admin-users/")
         request.user = self.user
+
+        track_indy_hub_usage_once_per_request(request)
+
+        usage = IndyHubUserUsage.objects.get(user=self.user)
+        self.assertIn("/indy_hub/settings/admin-users", usage.page_usage)
+
+    def test_once_per_request_skips_settings_admin_users_fragment_routes(self) -> None:
+        request = self.factory.get(
+            "/indy_hub/settings/admin-users/global-usage-fragment/"
+        )
+        request.user = self.user
+        request.resolver_match = SimpleNamespace(
+            app_names=("indy_hub",),
+            view_name="indy_hub:settings_admin_users_global_usage_fragment",
+            url_name="settings_admin_users_global_usage_fragment",
+        )
 
         track_indy_hub_usage_once_per_request(request)
 

--- a/indy_hub/tests/core/test_user_usage_tracking.py
+++ b/indy_hub/tests/core/test_user_usage_tracking.py
@@ -185,6 +185,56 @@ class IndyHubUserUsageModelTests(TestCase):
         self.assertIn("/recent", usage.page_usage)
         self.assertLessEqual(len(usage.page_usage), usage.PAGE_USAGE_MAX_KEYS)
 
+    def test_register_usage_pruning_handles_mixed_naive_and_aware_timestamps(
+        self,
+    ) -> None:
+        now = timezone.now()
+        max_keys = IndyHubUserUsage.PAGE_USAGE_MAX_KEYS
+        usage = IndyHubUserUsage.objects.create(
+            user=self.user,
+            first_used_at=now - timedelta(days=2),
+            last_used_at=now - timedelta(days=1),
+            total_usage_count=1,
+            activity_7d_count=1,
+            activity_30d_count=1,
+            daily_usage={
+                (now - timedelta(days=1)).date().isoformat(): 1,
+            },
+            page_usage={
+                "/naive": {
+                    "label": "naive",
+                    "path": "/naive",
+                    "total_usage_count": 1,
+                    "first_used_at": "2026-08-01T10:00:00",
+                    "last_used_at": "2026-08-01T10:00:00",
+                    "daily_usage": {now.date().isoformat(): 1},
+                },
+                "/aware": {
+                    "label": "aware",
+                    "path": "/aware",
+                    "total_usage_count": 1,
+                    "first_used_at": now.isoformat(),
+                    "last_used_at": now.isoformat(),
+                    "daily_usage": {now.date().isoformat(): 1},
+                },
+                **{
+                    f"/k/{idx}": {
+                        "label": f"k{idx}",
+                        "path": f"/k/{idx}",
+                        "total_usage_count": 1,
+                        "first_used_at": now.isoformat(),
+                        "last_used_at": now.isoformat(),
+                        "daily_usage": {now.date().isoformat(): 1},
+                    }
+                    for idx in range(max_keys + 5)
+                },
+            },
+        )
+
+        usage.register_usage(at=now, page_path="/recent", page_label="recent")
+
+        self.assertLessEqual(len(usage.page_usage), usage.PAGE_USAGE_MAX_KEYS)
+
     def test_usage_detail_recomputes_rolling_windows_from_today(self) -> None:
         now = timezone.now()
         usage = IndyHubUserUsage.objects.create(

--- a/indy_hub/tests/core/test_user_usage_tracking.py
+++ b/indy_hub/tests/core/test_user_usage_tracking.py
@@ -448,6 +448,16 @@ class IndyHubUsageServiceHookTests(TestCase):
 
         self.assertFalse(IndyHubUserUsage.objects.filter(user=self.user).exists())
 
+    def test_once_per_request_skips_settings_admin_users_fragment_paths(self) -> None:
+        request = self.factory.get(
+            "/indy_hub/settings/admin-users/usage-detail-fragment/5"
+        )
+        request.user = self.user
+
+        track_indy_hub_usage_once_per_request(request)
+
+        self.assertFalse(IndyHubUserUsage.objects.filter(user=self.user).exists())
+
     def test_once_per_request_uses_route_key_for_indy_hub_pages(self) -> None:
         request = self.factory.get("/indy_hub/settings/")
         request.user = self.user

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -520,7 +520,7 @@ class BlueprintCopyHistoryAccessTests(TestCase):
     def test_history_requires_manage_permission(self) -> None:
         self.client.force_login(self.base_user)
         response = self.client.get(reverse("indy_hub:bp_copy_history"))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
 
     def test_history_page_renders_for_authorized_user(self) -> None:
         self.client.force_login(self.viewer)

--- a/indy_hub/tests/test_smoke.py
+++ b/indy_hub/tests/test_smoke.py
@@ -630,6 +630,51 @@ class NavbarIndustryJobsTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, reverse("indy_hub:corporation_job_list"))
 
+    def test_personal_jobs_page_uses_fixed_safe_pagination_defaults(self) -> None:
+        now = timezone.now()
+        for index in range(2):
+            IndustryJob.objects.create(
+                owner_user=self.user,
+                owner_kind=Blueprint.OwnerKind.CHARACTER,
+                character_id=7011001,
+                job_id=9910000 + index,
+                installer_id=self.user.id,
+                station_id=PUBLIC_STATION_ID,
+                location_name="Test Station",
+                activity_id=1,
+                blueprint_id=6010000 + index,
+                blueprint_type_id=6011000 + index,
+                runs=1,
+                status="active",
+                duration=3600,
+                start_date=now,
+                end_date=now + timedelta(hours=1),
+                activity_name="Manufacturing",
+                blueprint_type_name=f"Blueprint {index}",
+                product_type_name=f"Product {index}",
+                character_name="Jobs User",
+            )
+
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse("indy_hub:personnal_job_list"),
+            {"page": "abc", "per_page": "abc"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["jobs"].paginator.per_page, 50)
+        self.assertEqual(response.context["jobs"].number, 1)
+
+    def test_personal_jobs_page_clamps_per_page_to_100(self) -> None:
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse("indy_hub:personnal_job_list"),
+            {"per_page": "999"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["jobs"].paginator.per_page, 100)
+
     def test_my_orders_lists_in_progress_before_completed(self) -> None:
         config = MaterialExchangeConfig.objects.create(
             corporation_id=1234,
@@ -3555,6 +3600,48 @@ class BlueprintCopyMyRequestsTests(TestCase):
             BlueprintCopyRequest.objects.filter(id=request_obj.id).exists()
         )
 
+    def test_cancel_requires_post(self) -> None:
+        request_obj = BlueprintCopyRequest.objects.create(
+            type_id=700001,
+            material_efficiency=8,
+            time_efficiency=10,
+            requested_by=self.user,
+            runs_requested=2,
+            copies_requested=1,
+        )
+
+        response = self.client.get(
+            reverse("indy_hub:bp_cancel_copy_request", args=[request_obj.id])
+        )
+
+        self.assertEqual(response.status_code, 405)
+        self.assertTrue(BlueprintCopyRequest.objects.filter(id=request_obj.id).exists())
+
+    def test_buyer_accept_offer_requires_post(self) -> None:
+        request_obj = BlueprintCopyRequest.objects.create(
+            type_id=700001,
+            material_efficiency=8,
+            time_efficiency=10,
+            requested_by=self.user,
+            runs_requested=2,
+            copies_requested=1,
+        )
+        offer = BlueprintCopyOffer.objects.create(
+            request=request_obj,
+            owner=self.provider,
+            status="conditional",
+            accepted_by_buyer=False,
+            accepted_by_seller=False,
+        )
+
+        response = self.client.get(
+            reverse("indy_hub:bp_buyer_accept_offer", args=[offer.id])
+        )
+
+        self.assertEqual(response.status_code, 405)
+        offer.refresh_from_db()
+        self.assertFalse(offer.accepted_by_buyer)
+
 
 class StructureLookupForbiddenCacheTests(TestCase):
     def tearDown(self) -> None:
@@ -5087,6 +5174,51 @@ class CorporationJobListViewTests(TestCase):
         visible_job_ids = {job.job_id for job in page_obj}
         self.assertIn(9900001, visible_job_ids)
 
+    def test_corporation_jobs_page_clamps_per_page_to_200(self) -> None:
+        provider = User.objects.create_user(
+            "corpjob_provider_limit", password="secret123"
+        )
+        assign_main_character(provider, character_id=103201)
+        grant_indy_permissions(provider, "can_manage_corp_bp_requests")
+
+        viewer = User.objects.create_user("corpjob_viewer_limit", password="secret123")
+        assign_main_character(viewer, character_id=103202)
+        grant_indy_permissions(viewer, "can_manage_corp_bp_requests")
+
+        start = timezone.now()
+        IndustryJob.objects.create(
+            owner_user=provider,
+            owner_kind=Blueprint.OwnerKind.CORPORATION,
+            corporation_id=2_000_000,
+            corporation_name="Test Corp",
+            character_id=103201,
+            job_id=9900101,
+            installer_id=provider.id,
+            station_id=PUBLIC_STATION_ID,
+            location_name="Corp Factory",
+            activity_id=1,
+            blueprint_id=6009101,
+            blueprint_type_id=6009102,
+            runs=1,
+            status="active",
+            duration=3600,
+            start_date=start,
+            end_date=start + timedelta(hours=1),
+            activity_name="Manufacturing",
+            blueprint_type_name="Corporate Job Blueprint",
+            product_type_name="Corporate Job Product",
+            character_name="Corp Job Provider",
+        )
+
+        self.client.force_login(viewer)
+        response = self.client.get(
+            reverse("indy_hub:corporation_job_list"),
+            {"per_page": "999"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["jobs"].paginator.per_page, 200)
+
     def test_corporation_jobs_visible_to_shared_catalog_viewer(self) -> None:
         provider = User.objects.create_user(
             "corpjob_provider_shared", password="secret123"
@@ -5611,6 +5743,42 @@ class BlueprintCopyDeliveryChatTests(TestCase):
         chat.refresh_from_db()
         self.assertTrue(request_obj.delivered)
         self.assertFalse(chat.is_open)
+
+    def test_mark_delivered_requires_post(self) -> None:
+        request_obj = BlueprintCopyRequest.objects.create(
+            type_id=16,
+            material_efficiency=6,
+            time_efficiency=10,
+            requested_by=self.buyer,
+            runs_requested=1,
+            copies_requested=1,
+            fulfilled=True,
+            fulfilled_by=self.seller,
+        )
+        offer = BlueprintCopyOffer.objects.create(
+            request=request_obj,
+            owner=self.seller,
+            status="accepted",
+            accepted_by_buyer=True,
+            accepted_by_seller=True,
+        )
+        chat = BlueprintCopyChat.objects.create(
+            request=request_obj,
+            offer=offer,
+            buyer=self.buyer,
+            seller=self.seller,
+            is_open=True,
+        )
+
+        response = self.client.get(
+            reverse("indy_hub:bp_mark_copy_delivered", args=[request_obj.id])
+        )
+
+        self.assertEqual(response.status_code, 405)
+        request_obj.refresh_from_db()
+        chat.refresh_from_db()
+        self.assertFalse(request_obj.delivered)
+        self.assertTrue(chat.is_open)
 
 
 class OnboardingViewsTests(TestCase):

--- a/indy_hub/urls.py
+++ b/indy_hub/urls.py
@@ -22,6 +22,8 @@ from .views.api import (
 )
 from .views.hubs import (
     settings_admin_users,
+    settings_admin_users_global_usage_fragment,
+    settings_admin_users_usage_detail_fragment,
     settings_hub,
     test_darkly_theme,
 )
@@ -153,6 +155,16 @@ urlpatterns = [
     path("esi/", token_management, name="esi_hub"),
     path("settings/", settings_hub, name="settings_hub"),
     path("settings/admin-users/", settings_admin_users, name="settings_admin_users"),
+    path(
+        "settings/admin-users/global-usage-fragment/",
+        settings_admin_users_global_usage_fragment,
+        name="settings_admin_users_global_usage_fragment",
+    ),
+    path(
+        "settings/admin-users/usage-detail-fragment/<int:user_id>/",
+        settings_admin_users_usage_detail_fragment,
+        name="settings_admin_users_usage_detail_fragment",
+    ),
     path("personnal-bp/", personnal_bp_list, name="personnal_bp_list"),
     path(
         "corporation-bp/",

--- a/indy_hub/views/hubs.py
+++ b/indy_hub/views/hubs.py
@@ -195,7 +195,6 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
                 int(user_usage.activity_30d_count) if user_usage else 0
             ),
         )
-        usage_detail = build_indy_hub_usage_detail(user_usage)
         problems = detect_admin_user_reminder_problems(
             missing_scopes=missing_scopes,
             notifications_off=(notify_frequency == CharacterSettings.NOTIFY_DISABLED),
@@ -228,7 +227,7 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
                 "total_usage_count": (
                     int(user_usage.total_usage_count) if user_usage else 0
                 ),
-                "usage_detail": usage_detail,
+                "_usage_obj": user_usage,
                 "health": health,
                 "problem_counts": {
                     "blocking": len(
@@ -249,6 +248,11 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
 
     paginator = Paginator(rows, _ADMIN_USERS_PAGE_SIZE)
     page_obj = paginator.get_page(_parse_optional_int(params.get("page")) or 1)
+    page_rows = list(page_obj.object_list)
+    for row in page_rows:
+        row["usage_detail"] = build_indy_hub_usage_detail(row.get("_usage_obj"))
+        row.pop("_usage_obj", None)
+
     current_query = _build_admin_user_filters_query(
         {
             "selected_corporation_id": selected_corporation_id,
@@ -266,7 +270,7 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
 
     return {
         "all_rows": rows,
-        "rows": list(page_obj.object_list),
+        "rows": page_rows,
         "all_rows_count": len(rows),
         "global_usage_detail": global_usage_detail,
         "page_obj": page_obj,

--- a/indy_hub/views/hubs.py
+++ b/indy_hub/views/hubs.py
@@ -11,12 +11,14 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.db.models import Max
+from django.http import JsonResponse
 from django.shortcuts import redirect, render
+from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 # Alliance Auth
-from allianceauth.authentication.models import CharacterOwnership
+from allianceauth.authentication.models import UserProfile
 from allianceauth.services.hooks import get_extension_logger
 
 # Local
@@ -40,6 +42,7 @@ from ..services.user_health import build_user_health_score
 from ..services.user_usage import (
     build_indy_hub_global_usage_detail,
     build_indy_hub_usage_detail,
+    calculate_recent_activity_counts,
 )
 from ..utils.analytics import emit_view_analytics_event
 from .navigation import build_nav_context
@@ -59,24 +62,24 @@ def _build_user_corporation_data(
     visible_user_ids: list[int],
 ) -> tuple[dict[int, list[dict[str, object]]], dict[int, str]]:
     corp_rows = (
-        CharacterOwnership.objects.filter(user_id__in=visible_user_ids)
-        .exclude(character__corporation_id__isnull=True)
-        .values("user_id", "character__corporation_id")
-        .annotate(corporation_name=Max("character__corporation_name"))
-        .order_by("user_id", "character__corporation_id")
+        UserProfile.objects.filter(user_id__in=visible_user_ids)
+        .exclude(main_character__corporation_id__isnull=True)
+        .values("user_id", "main_character__corporation_id")
+        .annotate(corporation_name=Max("main_character__corporation_name"))
+        .order_by("user_id")
     )
 
     corp_by_user_id: dict[int, list[dict[str, object]]] = {}
     corp_name_by_id: dict[int, str] = {}
     for row in corp_rows:
-        corp_id = int(row["character__corporation_id"])
+        corp_id = int(row["main_character__corporation_id"])
         corp_name = (row.get("corporation_name") or str(corp_id)).strip() or str(
             corp_id
         )
         corp_name_by_id[corp_id] = corp_name
-        corp_by_user_id.setdefault(int(row["user_id"]), []).append(
+        corp_by_user_id[int(row["user_id"])] = [
             {"corporation_id": corp_id, "corporation_name": corp_name}
-        )
+        ]
 
     return corp_by_user_id, corp_name_by_id
 
@@ -89,12 +92,19 @@ def _parse_optional_int(value: str | None) -> int | None:
     return parsed
 
 
-def _build_settings_admin_users_state(user, params) -> dict[str, object]:
-    visible_users = list(
+def _build_settings_admin_users_state(
+    user,
+    params,
+    *,
+    include_page_usage_details: bool = True,
+    include_global_usage_detail: bool = True,
+) -> dict[str, object]:
+    visible_users_qs = (
         get_visible_indy_hub_users_for_admin_scope(user)
         .order_by("username", "id")
         .distinct()
     )
+    visible_users = list(visible_users_qs)
     visible_user_ids = [int(row.id) for row in visible_users]
 
     settings_by_user_id = {
@@ -104,9 +114,14 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
             character_id=0,
         )
     }
-    usage_by_user_id = {
+    usage_summary_by_user_id = {
         int(obj.user_id): obj
-        for obj in IndyHubUserUsage.objects.filter(user_id__in=visible_user_ids)
+        for obj in IndyHubUserUsage.objects.filter(user_id__in=visible_user_ids).only(
+            "user_id",
+            "last_used_at",
+            "total_usage_count",
+            "daily_usage",
+        )
     }
     corp_by_user_id, corp_name_by_id = _build_user_corporation_data(visible_user_ids)
     scope_status_by_user_id = collect_user_scope_status_map(visible_user_ids)
@@ -137,12 +152,14 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
         filter_max_health_score = max(0, min(100, filter_max_health_score))
     inactive_cutoff = timezone.now() - timedelta(days=_INACTIVITY_WINDOW_DAYS)
 
-    rows: list[dict[str, object]] = []
-    rows_usage_objects: list[IndyHubUserUsage] = []
+    filtered_user_ids: list[int] = []
+    filtered_usage_user_ids: list[int] = []
+    active_user_count_30d = 0
+
     for user_obj in visible_users:
         user_id = int(user_obj.id)
         user_settings = settings_by_user_id.get(user_id)
-        user_usage = usage_by_user_id.get(user_id)
+        user_usage = usage_summary_by_user_id.get(user_id)
         corp_entries = list(corp_by_user_id.get(user_id, []))
         if not user.is_superuser:
             allowed_corp_ids = set(managed_corp_ids_for_scope)
@@ -170,16 +187,22 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
             ):
                 notify_frequency = user_settings.jobs_notify_frequency
 
-        scope_status = scope_status_by_user_id.get(
-            user_id, collect_user_scope_status(user_obj)
-        )
+        scope_status = scope_status_by_user_id.get(user_id)
+        if scope_status is None:
+            scope_status = collect_user_scope_status(user_obj)
         scope_flags = dict(scope_status.get("flags") or {})
         scope_is_complete = bool(scope_status.get("is_complete"))
-        missing_scopes = list(scope_status.get("missing_labels") or [])
         is_inactive = bool(
             not user_usage
             or not user_usage.last_used_at
             or user_usage.last_used_at < inactive_cutoff
+        )
+        activity_30d_count = (
+            calculate_recent_activity_counts(
+                getattr(user_usage, "daily_usage", {}),
+            )[1]
+            if user_usage
+            else 0
         )
 
         if filter_incomplete and scope_is_complete:
@@ -187,13 +210,90 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
         if filter_inactive and not is_inactive:
             continue
 
+        if filter_health_level or filter_max_health_score is not None:
+            health = build_user_health_score(
+                scope_flags=scope_flags,
+                settings_obj=user_settings,
+                is_inactive=is_inactive,
+                activity_30d_count=activity_30d_count,
+            )
+            if filter_health_level and health.get("level") != filter_health_level:
+                continue
+            if (
+                filter_max_health_score is not None
+                and int(health.get("score", 0)) > filter_max_health_score
+            ):
+                continue
+
+        filtered_user_ids.append(user_id)
+        if user_usage:
+            filtered_usage_user_ids.append(user_id)
+        if activity_30d_count > 0:
+            active_user_count_30d += 1
+
+    filtered_users_qs = visible_users_qs.filter(id__in=filtered_user_ids)
+    paginator = Paginator(filtered_users_qs, _ADMIN_USERS_PAGE_SIZE)
+    page_obj = paginator.get_page(_parse_optional_int(params.get("page")) or 1)
+    page_users = list(page_obj.object_list)
+
+    usage_by_user_id: dict[int, IndyHubUserUsage] = {}
+    if include_page_usage_details and page_users:
+        page_user_ids = [int(page_user.id) for page_user in page_users]
+        usage_by_user_id = {
+            int(obj.user_id): obj
+            for obj in IndyHubUserUsage.objects.filter(user_id__in=page_user_ids)
+        }
+
+    page_rows: list[dict[str, object]] = []
+    for user_obj in page_users:
+        user_id = int(user_obj.id)
+        user_settings = settings_by_user_id.get(user_id)
+        user_usage = usage_by_user_id.get(user_id) or usage_summary_by_user_id.get(
+            user_id
+        )
+        corp_entries = list(corp_by_user_id.get(user_id, []))
+        if not user.is_superuser:
+            allowed_corp_ids = set(managed_corp_ids_for_scope)
+            corp_entries = [
+                entry
+                for entry in corp_entries
+                if int(entry["corporation_id"]) in allowed_corp_ids
+            ]
+
+        sharing_scope = CharacterSettings.SCOPE_NONE
+        notify_frequency = CharacterSettings.NOTIFY_DISABLED
+        if user_settings:
+            if user_settings.copy_sharing_scope in dict(
+                CharacterSettings.COPY_SHARING_SCOPE_CHOICES
+            ):
+                sharing_scope = user_settings.copy_sharing_scope
+            if user_settings.jobs_notify_frequency in dict(
+                CharacterSettings.JOB_NOTIFICATION_FREQUENCY_CHOICES
+            ):
+                notify_frequency = user_settings.jobs_notify_frequency
+
+        scope_status = scope_status_by_user_id.get(user_id)
+        if scope_status is None:
+            scope_status = collect_user_scope_status(user_obj)
+        scope_flags = dict(scope_status.get("flags") or {})
+        missing_scopes = list(scope_status.get("missing_labels") or [])
+        is_inactive = bool(
+            not user_usage
+            or not user_usage.last_used_at
+            or user_usage.last_used_at < inactive_cutoff
+        )
+        activity_30d_count = (
+            calculate_recent_activity_counts(
+                getattr(user_usage, "daily_usage", {}),
+            )[1]
+            if user_usage
+            else 0
+        )
         health = build_user_health_score(
             scope_flags=scope_flags,
             settings_obj=user_settings,
             is_inactive=is_inactive,
-            activity_30d_count=(
-                int(user_usage.activity_30d_count) if user_usage else 0
-            ),
+            activity_30d_count=activity_30d_count,
         )
         problems = detect_admin_user_reminder_problems(
             missing_scopes=missing_scopes,
@@ -202,28 +302,18 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
             health_level=str(health.get("level") or "critical"),
         )
 
-        if filter_health_level and health.get("level") != filter_health_level:
-            continue
-        if (
-            filter_max_health_score is not None
-            and int(health.get("score", 0)) > filter_max_health_score
-        ):
-            continue
-
-        rows.append(
+        page_rows.append(
             {
                 "user": user_obj,
                 "sharing_scope": sharing_scope,
                 "notify_frequency": notify_frequency,
-                "scope_is_complete": scope_is_complete,
+                "scope_is_complete": bool(scope_status.get("is_complete")),
                 "scope_flags": scope_flags,
                 "missing_scopes": missing_scopes,
                 "corporations": corp_entries,
                 "is_inactive": is_inactive,
                 "last_used_at": user_usage.last_used_at if user_usage else None,
-                "activity_30d_count": (
-                    int(user_usage.activity_30d_count) if user_usage else 0
-                ),
+                "activity_30d_count": activity_30d_count,
                 "total_usage_count": (
                     int(user_usage.total_usage_count) if user_usage else 0
                 ),
@@ -243,15 +333,14 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
                 },
             }
         )
-        if user_usage:
-            rows_usage_objects.append(user_usage)
 
-    paginator = Paginator(rows, _ADMIN_USERS_PAGE_SIZE)
-    page_obj = paginator.get_page(_parse_optional_int(params.get("page")) or 1)
-    page_rows = list(page_obj.object_list)
-    for row in page_rows:
-        row["usage_detail"] = build_indy_hub_usage_detail(row.get("_usage_obj"))
-        row.pop("_usage_obj", None)
+    if include_page_usage_details:
+        for row in page_rows:
+            row["usage_detail"] = build_indy_hub_usage_detail(row.get("_usage_obj"))
+            row.pop("_usage_obj", None)
+    else:
+        for row in page_rows:
+            row.pop("_usage_obj", None)
 
     current_query = _build_admin_user_filters_query(
         {
@@ -262,16 +351,27 @@ def _build_settings_admin_users_state(user, params) -> dict[str, object]:
             "filter_max_health_score": filter_max_health_score,
         }
     )
-    global_usage_detail = build_indy_hub_global_usage_detail(rows_usage_objects)
-    global_usage_detail["visible_user_count"] = len(rows)
-    global_usage_detail["active_user_count_30d"] = sum(
-        1 for row in rows if int(row.get("activity_30d_count") or 0) > 0
-    )
+    global_usage_detail: dict[str, object] | None = None
+    if include_global_usage_detail:
+        full_usage_by_user_id = {
+            int(obj.user_id): obj
+            for obj in IndyHubUserUsage.objects.filter(
+                user_id__in=filtered_usage_user_ids
+            )
+        }
+        rows_usage_objects = [
+            full_usage_by_user_id[user_id]
+            for user_id in filtered_user_ids
+            if user_id in full_usage_by_user_id
+        ]
+        global_usage_detail = build_indy_hub_global_usage_detail(rows_usage_objects)
+        global_usage_detail["visible_user_count"] = len(filtered_user_ids)
+        global_usage_detail["active_user_count_30d"] = active_user_count_30d
 
     return {
-        "all_rows": rows,
+        "all_rows": page_rows,
         "rows": page_rows,
-        "all_rows_count": len(rows),
+        "all_rows_count": len(filtered_user_ids),
         "global_usage_detail": global_usage_detail,
         "page_obj": page_obj,
         "is_paginated": page_obj.paginator.num_pages > 1,
@@ -306,6 +406,10 @@ def _build_admin_user_filters_query(state: dict[str, object]) -> str:
     if state.get("filter_max_health_score") is not None:
         query["max_health_score"] = str(state["filter_max_health_score"])
     return urlencode(query)
+
+
+def _settings_admin_users_scope_allowed(user) -> bool:
+    return bool(can_access_indy_hub_user_admin_scope(user))
 
 
 @indy_hub_permission_required("can_access_indy_hub")
@@ -363,7 +467,7 @@ def settings_hub(request):
 def settings_admin_users(request):
     emit_view_analytics_event(view_name="settings_admin_users", request=request)
 
-    if not can_access_indy_hub_user_admin_scope(request.user):
+    if not _settings_admin_users_scope_allowed(request.user):
         messages.error(
             request,
             _("You do not have permission to access Indy Hub user administration."),
@@ -375,7 +479,12 @@ def settings_admin_users(request):
     can_view_corporation_bp = can_view_corporation_blueprints(request.user)
     can_view_corporation_jobs_flag = can_view_corporation_jobs(request.user)
 
-    state = _build_settings_admin_users_state(request.user, request.GET)
+    state = _build_settings_admin_users_state(
+        request.user,
+        request.GET,
+        include_page_usage_details=False,
+        include_global_usage_detail=False,
+    )
 
     context = {
         **base_context,
@@ -395,6 +504,64 @@ def settings_admin_users(request):
     }
 
     return render(request, "indy_hub/settings/admin_users.html", context)
+
+
+@indy_hub_permission_required("can_access_indy_hub")
+@login_required
+def settings_admin_users_global_usage_fragment(request):
+    emit_view_analytics_event(
+        view_name="settings_admin_users_global_usage_fragment", request=request
+    )
+
+    if not _settings_admin_users_scope_allowed(request.user):
+        return JsonResponse({"error": "forbidden"}, status=403)
+
+    state = _build_settings_admin_users_state(
+        request.user,
+        request.GET,
+        include_page_usage_details=False,
+        include_global_usage_detail=True,
+    )
+    html = render_to_string(
+        "indy_hub/settings/partials/admin_users_global_usage_content.html",
+        {
+            "global_usage_detail": state["global_usage_detail"],
+        },
+        request=request,
+    )
+    return JsonResponse({"html": html})
+
+
+@indy_hub_permission_required("can_access_indy_hub")
+@login_required
+def settings_admin_users_usage_detail_fragment(request, user_id: int):
+    emit_view_analytics_event(
+        view_name="settings_admin_users_usage_detail_fragment", request=request
+    )
+
+    if not _settings_admin_users_scope_allowed(request.user):
+        return JsonResponse({"error": "forbidden"}, status=403)
+
+    visible_user = (
+        get_visible_indy_hub_users_for_admin_scope(request.user)
+        .filter(id=user_id)
+        .order_by("id")
+        .first()
+    )
+    if visible_user is None:
+        return JsonResponse({"error": "not_found"}, status=404)
+
+    usage_obj = IndyHubUserUsage.objects.filter(user_id=int(visible_user.id)).first()
+    usage_detail = build_indy_hub_usage_detail(usage_obj)
+    html = render_to_string(
+        "indy_hub/settings/partials/admin_user_usage_modal_body.html",
+        {
+            "usage_detail": usage_detail,
+            "usage_user": visible_user,
+        },
+        request=request,
+    )
+    return JsonResponse({"html": html})
 
 
 @indy_hub_permission_required("can_access_indy_hub")

--- a/indy_hub/views/industry.py
+++ b/indy_hub/views/industry.py
@@ -28,7 +28,7 @@ from django.utils import timezone
 from django.utils.html import escape, mark_safe
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
-from django.views.decorators.http import require_http_methods
+from django.views.decorators.http import require_http_methods, require_POST
 
 # Alliance Auth
 from allianceauth.authentication.models import CharacterOwnership
@@ -257,6 +257,9 @@ from .navigation import build_nav_context
 
 # ESI skills scope + industry slot calculations
 SKILL_CACHE_TTL = timedelta(hours=1)
+INDUSTRY_JOBS_PER_PAGE_DEFAULT = 50
+INDUSTRY_JOBS_PER_PAGE_MAX_CHARACTER = 100
+INDUSTRY_JOBS_PER_PAGE_MAX_CORPORATION = 200
 MANUFACTURING_ACTIVITY_IDS = {1}
 RESEARCH_ACTIVITY_IDS = {3, 4, 5, 8}
 REACTION_ACTIVITY_IDS = {9, 11}
@@ -416,6 +419,25 @@ def _has_required_scopes(user, scopes: list[str]) -> bool:
         )
     except Exception:
         return False
+
+
+def _parse_bounded_int(
+    raw_value,
+    *,
+    default: int,
+    minimum: int = 1,
+    maximum: int | None = None,
+) -> int:
+    try:
+        parsed_value = int(str(raw_value).strip())
+    except (TypeError, ValueError):
+        parsed_value = default
+
+    if parsed_value < minimum:
+        parsed_value = minimum
+    if maximum is not None and parsed_value > maximum:
+        parsed_value = maximum
+    return parsed_value
 
 
 def _resolve_user_identity(user: User | None) -> UserIdentity:
@@ -1582,32 +1604,23 @@ def personnal_job_list(request, scope="character"):
     activity_filter = request.GET.get("activity", "")
     sort_by = request.GET.get("sort", "start_date")
     sort_order = request.GET.get("order", "desc")
-    page = int(request.GET.get("page", 1))
-    per_page = request.GET.get("per_page")
+    page = _parse_bounded_int(request.GET.get("page", 1), default=1)
+    max_per_page = (
+        INDUSTRY_JOBS_PER_PAGE_MAX_CORPORATION
+        if is_corporation_scope
+        else INDUSTRY_JOBS_PER_PAGE_MAX_CHARACTER
+    )
+    per_page = _parse_bounded_int(
+        request.GET.get("per_page", INDUSTRY_JOBS_PER_PAGE_DEFAULT),
+        default=INDUSTRY_JOBS_PER_PAGE_DEFAULT,
+        maximum=max_per_page,
+    )
 
     owner_kind_filter = (
         Blueprint.OwnerKind.CORPORATION
         if is_corporation_scope
         else Blueprint.OwnerKind.CHARACTER
     )
-
-    if per_page:
-        per_page = int(per_page)
-        if per_page < 1:
-            per_page = 1
-    else:
-        if is_corporation_scope:
-            per_page = IndustryJob.objects.filter(
-                owner_kind=owner_kind_filter,
-                corporation_id__in=accessible_corporation_ids,
-            ).count()
-        else:
-            per_page = IndustryJob.objects.filter(
-                owner_user=request.user,
-                owner_kind=owner_kind_filter,
-            ).count()
-        if per_page < 1:
-            per_page = 1
 
     if is_corporation_scope:
         base_jobs_qs = IndustryJob.objects.filter(
@@ -1643,6 +1656,10 @@ def personnal_job_list(request, scope="character"):
                 continue
             display_name = get_character_name(cid) or str(cid)
             owner_options.append((cid, display_name))
+
+    per_page_options = [10, 25, 50, 100]
+    if is_corporation_scope:
+        per_page_options.append(200)
 
     jobs_qs = base_jobs_qs
     now = timezone.now()
@@ -1965,7 +1982,7 @@ def personnal_job_list(request, scope="character"):
                 "order": sort_order,
                 "per_page": per_page,
             },
-            "per_page_options": [10, 25, 50, 100, 200],
+            "per_page_options": per_page_options,
             "jobs_page": jobs_page,
             "job_groups": job_groups,
             "has_job_results": bool(job_groups),
@@ -4546,6 +4563,7 @@ def bp_discord_action(request):
 @indy_hub_access_required
 @indy_hub_permission_required("can_access_indy_hub")
 @login_required
+@require_POST
 def bp_buyer_accept_offer(request, offer_id):
     """Allow buyer to accept a conditional offer."""
     offer = get_object_or_404(BlueprintCopyOffer, id=offer_id, status="conditional")
@@ -4708,6 +4726,7 @@ def bp_reject_copy_request(request, request_id):
 @indy_hub_access_required
 @indy_hub_permission_required("can_access_indy_hub")
 @login_required
+@require_POST
 def bp_cancel_copy_request(request, request_id):
     """Allow user to cancel their own copy request before delivery."""
     req = get_object_or_404(
@@ -4753,6 +4772,7 @@ def bp_cancel_copy_request(request, request_id):
 @indy_hub_access_required
 @indy_hub_permission_required("can_access_indy_hub")
 @login_required
+@require_POST
 def bp_mark_copy_delivered(request, request_id):
     """Mark a fulfilled blueprint copy request as delivered (provider action)."""
     req = get_object_or_404(


### PR DESCRIPTION
## Description

This change hardens the Indy Hub settings and admin-user experience while keeping the existing AJAX loading model:
- paginated admin-user loading with deferred detail hydration
- rolling 7d/30d usage counts computed at read time
- safer POST-only handling for sensitive actions
- optional, allowlisted usage-tracking middleware
- bounded industry jobs pagination and stricter scope aggregation
- main-character corporation display only in the admin-user list

No external dependencies were added beyond the project’s existing Django/Alliance Auth stack.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
